### PR TITLE
fix: add missing exports to subpath entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ npx etiket wifi "MyNetwork" "secret123" -o wifi.svg
 Import only what you need:
 
 ```ts
-import { barcode } from "etiket/barcode"; // 1D barcodes only
-import { qrcode } from "etiket/qr"; // QR codes only
-import { datamatrix } from "etiket/datamatrix";
+import { barcode, barcodeDataURI, barcodeBase64 } from "etiket/barcode";
+import { qrcode, qrcodeDataURI, qrcodeBase64, qrcodeTerminal } from "etiket/qr";
+import { datamatrix, gs1datamatrix } from "etiket/datamatrix";
 import { pdf417 } from "etiket/pdf417";
 import { aztec } from "etiket/aztec";
 import { barcodePNG, qrcodePNG } from "etiket/png"; // PNG output

--- a/src/aztec.ts
+++ b/src/aztec.ts
@@ -6,3 +6,4 @@ export { aztec } from "./_2d";
 export { encodeAztec } from "./encoders/aztec/index";
 export type { AztecOptions } from "./encoders/aztec/index";
 export { renderMatrixSVG } from "./renderers/svg/matrix";
+export type { MatrixSVGOptions } from "./renderers/svg/matrix";

--- a/src/barcode.ts
+++ b/src/barcode.ts
@@ -7,11 +7,12 @@
  * ```
  */
 
-export { barcode } from "./_barcode";
-export type { BarcodeType, BarcodeOptions } from "./_types";
+export { barcode, barcodeDataURI, barcodeBase64, encodeBars } from "./_barcode";
+export type { BarcodeType, BarcodeOptions, BarcodeEncodingOptions } from "./_types";
 export type { BarcodeSVGOptions } from "./renderers/svg/types";
 
 export { encodeCode128 } from "./encoders/code128";
+export type { Code128Charset, Code128Options } from "./encoders/code128";
 export { encodeEAN13, encodeEAN8 } from "./encoders/ean";
 export { encodeCode39, encodeCode39Extended } from "./encoders/code39";
 export { encodeCode93, encodeCode93Extended } from "./encoders/code93";
@@ -24,4 +25,12 @@ export type { MSICheckDigitType } from "./encoders/msi";
 export { encodePharmacode } from "./encoders/pharmacode";
 export { encodeCode11 } from "./encoders/code11";
 export { encodeGS1128 } from "./encoders/gs1-128";
+export { encodeIdentcode, encodeLeitcode } from "./encoders/deutsche-post";
+export { encodePOSTNET, encodePLANET } from "./encoders/postnet";
+export { encodePlessey } from "./encoders/plessey";
+export {
+  encodeGS1DataBarOmni,
+  encodeGS1DataBarLimited,
+  encodeGS1DataBarExpanded,
+} from "./encoders/gs1-databar";
 export { renderBarcodeSVG } from "./renderers/svg/barcode";

--- a/src/datamatrix.ts
+++ b/src/datamatrix.ts
@@ -2,6 +2,7 @@
  * Data Matrix-only entry point for tree-shaking
  */
 
-export { datamatrix } from "./_2d";
-export { encodeDataMatrix } from "./encoders/datamatrix/index";
+export { datamatrix, gs1datamatrix } from "./_2d";
+export { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index";
 export { renderMatrixSVG } from "./renderers/svg/matrix";
+export type { MatrixSVGOptions } from "./renderers/svg/matrix";

--- a/src/pdf417.ts
+++ b/src/pdf417.ts
@@ -5,4 +5,7 @@
 export { pdf417 } from "./_2d";
 export { encodePDF417 } from "./encoders/pdf417/index";
 export type { PDF417Options } from "./encoders/pdf417/index";
+export { encodeMicroPDF417 } from "./encoders/micropdf417";
+export type { MicroPDF417Options } from "./encoders/micropdf417";
 export { renderMatrixSVG } from "./renderers/svg/matrix";
+export type { MatrixSVGOptions } from "./renderers/svg/matrix";

--- a/src/qr.ts
+++ b/src/qr.ts
@@ -13,5 +13,7 @@ export type { QRCodeOptions, ErrorCorrectionLevel, EncodingMode } from "./encode
 export type { DotType, GradientOptions, CornerOptions, LogoOptions } from "./renderers/svg/types";
 
 export { encodeQR } from "./encoders/qr/index";
+export { encodeMicroQR } from "./encoders/qr/micro";
+export type { MicroQROptions } from "./encoders/qr/micro";
 export { renderQRCodeSVG } from "./renderers/svg/qr";
 export { renderText } from "./renderers/text";


### PR DESCRIPTION
## Summary

Fixes #87 — `barcodeBase64` (and other functions) not importable from `etiket/barcode` subpath.

Audited **all 6 subpath entry points** and added every missing export:

| Subpath | Added |
|---|---|
| `etiket/barcode` | `barcodeDataURI`, `barcodeBase64`, `encodeBars`, `encodeIdentcode`, `encodeLeitcode`, `encodePOSTNET`, `encodePLANET`, `encodePlessey`, `encodeGS1DataBarOmni/Limited/Expanded`, `Code128Charset`, `Code128Options`, `BarcodeEncodingOptions` |
| `etiket/qr` | `encodeMicroQR`, `MicroQROptions` |
| `etiket/datamatrix` | `gs1datamatrix`, `encodeGS1DataMatrix`, `MatrixSVGOptions` |
| `etiket/pdf417` | `encodeMicroPDF417`, `MicroPDF417Options`, `MatrixSVGOptions` |
| `etiket/aztec` | `MatrixSVGOptions` |
| `etiket/png` | Already complete ✓ |

README tree-shaking section updated to reflect the full set of available subpath imports.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds — new exports visible in bundle output
- [x] `pnpm vitest run` — 905 tests pass
- [x] `pnpm lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)