### PR TITLE
feat: export raw pixel/bitmap data before PNG encoding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,9 @@ export {
   aztecPNGDataURI,
 } from "./_png";
 export type { BarcodePNGOptions, MatrixPNGOptions } from "./renderers/png/types";
-export { renderBarcodePNG, renderMatrixPNG } from "./renderers/png/rasterize";
+export { renderBarcodeRaster, renderMatrixRaster, renderBarcodePNG, renderMatrixPNG } from "./renderers/png/rasterize";
+export type { RasterData } from "./renderers/png/rasterize";
+export { encodePNG } from "./renderers/png/png-encoder";
 
 // --- Renderers ---
 export { renderBarcodeSVG } from "./renderers/svg/barcode";

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,12 @@ export {
   aztecPNGDataURI,
 } from "./_png";
 export type { BarcodePNGOptions, MatrixPNGOptions } from "./renderers/png/types";
-export { renderBarcodeRaster, renderMatrixRaster, renderBarcodePNG, renderMatrixPNG } from "./renderers/png/rasterize";
+export {
+  renderBarcodeRaster,
+  renderMatrixRaster,
+  renderBarcodePNG,
+  renderMatrixPNG,
+} from "./renderers/png/rasterize";
 export type { RasterData } from "./renderers/png/rasterize";
 export { encodePNG } from "./renderers/png/png-encoder";
 

--- a/src/png.ts
+++ b/src/png.ts
@@ -23,4 +23,6 @@ export {
 } from "./_png";
 export type { BarcodeEncodingOptions } from "./_types";
 export type { BarcodePNGOptions, MatrixPNGOptions } from "./renderers/png/types";
-export { renderBarcodePNG, renderMatrixPNG } from "./renderers/png/rasterize";
+export { renderBarcodeRaster, renderMatrixRaster, renderBarcodePNG, renderMatrixPNG } from "./renderers/png/rasterize";
+export type { RasterData } from "./renderers/png/rasterize";
+export { encodePNG } from "./renderers/png/png-encoder";

--- a/src/png.ts
+++ b/src/png.ts
@@ -23,6 +23,11 @@ export {
 } from "./_png";
 export type { BarcodeEncodingOptions } from "./_types";
 export type { BarcodePNGOptions, MatrixPNGOptions } from "./renderers/png/types";
-export { renderBarcodeRaster, renderMatrixRaster, renderBarcodePNG, renderMatrixPNG } from "./renderers/png/rasterize";
+export {
+  renderBarcodeRaster,
+  renderMatrixRaster,
+  renderBarcodePNG,
+  renderMatrixPNG,
+} from "./renderers/png/rasterize";
 export type { RasterData } from "./renderers/png/rasterize";
 export { encodePNG } from "./renderers/png/png-encoder";

--- a/src/renderers/png/rasterize.ts
+++ b/src/renderers/png/rasterize.ts
@@ -7,19 +7,29 @@ import { parseHexColor } from "./types";
 import type { BarcodePNGOptions, MatrixPNGOptions } from "./types";
 
 /**
- * Render a 1D barcode bar pattern as PNG
+ * Raster data result with raw pixel rows
  */
-export function renderBarcodePNG(bars: number[], options: BarcodePNGOptions = {}): Uint8Array {
+export interface RasterData {
+  /** Image width in pixels */
+  width: number;
+  /** Image height in pixels */
+  height: number;
+  /** Pixel rows — each Uint8Array where 0 = background, 1 = foreground */
+  rows: Uint8Array[];
+}
+
+/**
+ * Rasterize a 1D barcode bar pattern to raw pixel rows
+ */
+export function renderBarcodeRaster(
+  bars: number[],
+  options: BarcodePNGOptions = {},
+): RasterData {
   const {
     scale = 2,
     height = 80,
     margin = 10,
-    color = "#000000",
-    background = "#ffffff",
   } = options;
-
-  const fg = parseHexColor(color);
-  const bg = parseHexColor(background);
 
   let totalBarWidth = 0;
   for (let i = 0; i < bars.length; i++) {
@@ -47,17 +57,28 @@ export function renderBarcodePNG(bars: number[], options: BarcodePNGOptions = {}
   for (let y = 0; y < height; y++) rows.push(barRow);
   for (let y = 0; y < margin; y++) rows.push(marginRow);
 
-  return encodePNG(width, totalHeight, rows, fg, bg, false);
+  return { width, height: totalHeight, rows };
 }
 
 /**
- * Render a 2D matrix (QR, DataMatrix, Aztec, PDF417) as PNG
+ * Render a 1D barcode bar pattern as PNG
  */
-export function renderMatrixPNG(matrix: boolean[][], options: MatrixPNGOptions = {}): Uint8Array {
-  const { moduleSize = 10, margin = 4, color = "#000000", background = "#ffffff" } = options;
-
+export function renderBarcodePNG(bars: number[], options: BarcodePNGOptions = {}): Uint8Array {
+  const { color = "#000000", background = "#ffffff" } = options;
   const fg = parseHexColor(color);
   const bg = parseHexColor(background);
+  const { width, height, rows } = renderBarcodeRaster(bars, options);
+  return encodePNG(width, height, rows, fg, bg, false);
+}
+
+/**
+ * Rasterize a 2D matrix (QR, DataMatrix, Aztec, PDF417) to raw pixel rows
+ */
+export function renderMatrixRaster(
+  matrix: boolean[][],
+  options: MatrixPNGOptions = {},
+): RasterData {
+  const { moduleSize = 10, margin = 4 } = options;
 
   const matRows = matrix.length;
   const matCols = matRows > 0 ? matrix[0]!.length : 0;
@@ -85,5 +106,16 @@ export function renderMatrixPNG(matrix: boolean[][], options: MatrixPNGOptions =
 
   for (let y = 0; y < marginPixels; y++) rows.push(marginRow);
 
+  return { width, height, rows };
+}
+
+/**
+ * Render a 2D matrix (QR, DataMatrix, Aztec, PDF417) as PNG
+ */
+export function renderMatrixPNG(matrix: boolean[][], options: MatrixPNGOptions = {}): Uint8Array {
+  const { color = "#000000", background = "#ffffff" } = options;
+  const fg = parseHexColor(color);
+  const bg = parseHexColor(background);
+  const { width, height, rows } = renderMatrixRaster(matrix, options);
   return encodePNG(width, height, rows, fg, bg, true);
 }

--- a/src/renderers/png/rasterize.ts
+++ b/src/renderers/png/rasterize.ts
@@ -21,15 +21,8 @@ export interface RasterData {
 /**
  * Rasterize a 1D barcode bar pattern to raw pixel rows
  */
-export function renderBarcodeRaster(
-  bars: number[],
-  options: BarcodePNGOptions = {},
-): RasterData {
-  const {
-    scale = 2,
-    height = 80,
-    margin = 10,
-  } = options;
+export function renderBarcodeRaster(bars: number[], options: BarcodePNGOptions = {}): RasterData {
+  const { scale = 2, height = 80, margin = 10 } = options;
 
   let totalBarWidth = 0;
   for (let i = 0; i < bars.length; i++) {

--- a/test/raster.test.ts
+++ b/test/raster.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  renderBarcodeRaster,
-  renderMatrixRaster,
-} from "../src/renderers/png/rasterize";
+import { renderBarcodeRaster, renderMatrixRaster } from "../src/renderers/png/rasterize";
 import type { RasterData } from "../src/renderers/png/rasterize";
 
 describe("renderBarcodeRaster", () => {

--- a/test/raster.test.ts
+++ b/test/raster.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderBarcodeRaster,
+  renderMatrixRaster,
+} from "../src/renderers/png/rasterize";
+import type { RasterData } from "../src/renderers/png/rasterize";
+
+describe("renderBarcodeRaster", () => {
+  it("returns raw pixel rows with correct dimensions", () => {
+    const bars = [2, 1, 3, 1, 2];
+    const result: RasterData = renderBarcodeRaster(bars, { scale: 1, height: 10, margin: 0 });
+    expect(result.width).toBe(9);
+    expect(result.height).toBe(10);
+    expect(result.rows).toHaveLength(10);
+    expect(result.rows[0]).toBeInstanceOf(Uint8Array);
+    expect(result.rows[0]!.length).toBe(9);
+  });
+
+  it("has foreground pixels (1) in bar positions", () => {
+    const bars = [2, 1, 2];
+    const result = renderBarcodeRaster(bars, { scale: 1, height: 5, margin: 0 });
+    const row = result.rows[0]!;
+    // bars[0]=2 (fg), bars[1]=1 (bg), bars[2]=2 (fg)
+    expect(row[0]).toBe(1);
+    expect(row[1]).toBe(1);
+    expect(row[2]).toBe(0);
+    expect(row[3]).toBe(1);
+    expect(row[4]).toBe(1);
+  });
+
+  it("applies margin", () => {
+    const bars = [1];
+    const result = renderBarcodeRaster(bars, { scale: 1, height: 1, margin: 5 });
+    expect(result.width).toBe(11); // 1 + 5*2
+    expect(result.height).toBe(11); // 1 + 5*2
+    expect(result.rows).toHaveLength(11);
+  });
+});
+
+describe("renderMatrixRaster", () => {
+  it("returns raw pixel rows with correct dimensions", () => {
+    const matrix = [
+      [true, false],
+      [false, true],
+    ];
+    const result: RasterData = renderMatrixRaster(matrix, { moduleSize: 1, margin: 0 });
+    expect(result.width).toBe(2);
+    expect(result.height).toBe(2);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0]![0]).toBe(1);
+    expect(result.rows[0]![1]).toBe(0);
+    expect(result.rows[1]![0]).toBe(0);
+    expect(result.rows[1]![1]).toBe(1);
+  });
+
+  it("scales with moduleSize", () => {
+    const matrix = [[true]];
+    const result = renderMatrixRaster(matrix, { moduleSize: 4, margin: 0 });
+    expect(result.width).toBe(4);
+    expect(result.height).toBe(4);
+    expect(result.rows).toHaveLength(4);
+    expect(result.rows[0]!.every((v) => v === 1)).toBe(true);
+  });
+
+  it("applies margin", () => {
+    const matrix = [[true]];
+    const result = renderMatrixRaster(matrix, { moduleSize: 2, margin: 1 });
+    expect(result.width).toBe(6); // (1 + 1*2) * 2
+    expect(result.height).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `renderBarcodeRaster()` and `renderMatrixRaster()` returning raw pixel data (`{ width, height, rows: Uint8Array[] }`) before PNG encoding
- Export `encodePNG()` for manual PNG assembly from raw raster data
- Export `RasterData` type interface
- All new APIs exported from both `etiket` and `etiket/png` entry points

Closes #89

## Test plan

- [x] Existing PNG tests pass (37 tests)
- [x] New `test/raster.test.ts` with 6 tests covering dimensions, pixel values, margins, and module scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)