### PR TITLE
chore: drop semicolons via oxfmt semi: false

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://unpkg.com/oxfmt/configuration_schema.json",
+  "semi": false,
   "ignorePatterns": ["CHANGELOG.md"]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ pnpm docs:dev       # npx mdzilla ./docs
 - **Pure ESM** — no CJS
 - **Zero runtime dependencies** — CLI deps (citty, consola) are bundled
 - **TypeScript strict** — TypeScript 7 (`tsc`) for typecheck
-- **Formatter:** oxfmt (double quotes, semicolons)
+- **Formatter:** oxfmt (double quotes, no semicolons — `semi: false` in `.oxfmtrc.json`)
 - **Linter:** oxlint (unicorn, typescript, oxc plugins)
 - **Tests:** vitest in `test/` directory, flat naming
 - **Internal files:** prefix with `_` where applicable

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ npm install etiket
 ```
 
 ```ts
-import { barcode, qrcode } from "etiket";
+import { barcode, qrcode } from "etiket"
 
-const svg = barcode("Hello World");
-const qr = qrcode("https://example.com", { dotType: "dots", ecLevel: "H" });
+const svg = barcode("Hello World")
+const qr = qrcode("https://example.com", { dotType: "dots", ecLevel: "H" })
 ```
 
 ## CLI
@@ -62,13 +62,13 @@ helpers. Add `--png` or use a `.png` output path for raster output.
 Import only what you need:
 
 ```ts
-import { barcode, barcodeDataURI, barcodeBase64 } from "etiket/barcode";
-import { postal, encodePostal } from "etiket/postal";
-import { qrcode, qrcodeDataURI, qrcodeBase64, qrcodeTerminal, microqr, rmqr } from "etiket/qr";
-import { datamatrix, gs1datamatrix } from "etiket/datamatrix";
-import { pdf417, micropdf417 } from "etiket/pdf417";
-import { aztec } from "etiket/aztec";
-import { barcodePNG, qrcodePNG, postalPNG } from "etiket/png"; // PNG output
+import { barcode, barcodeDataURI, barcodeBase64 } from "etiket/barcode"
+import { postal, encodePostal } from "etiket/postal"
+import { qrcode, qrcodeDataURI, qrcodeBase64, qrcodeTerminal, microqr, rmqr } from "etiket/qr"
+import { datamatrix, gs1datamatrix } from "etiket/datamatrix"
+import { pdf417, micropdf417 } from "etiket/pdf417"
+import { aztec } from "etiket/aztec"
+import { barcodePNG, qrcodePNG, postalPNG } from "etiket/png" // PNG output
 ```
 
 ## Supported Formats
@@ -142,17 +142,17 @@ extent, not its width — so they have their own encoder and renderer.
 | **USPS IMb**       | `imb`     | Intelligent Mail (US)         |
 
 ```ts
-import { postal, encodePostal, postalPNG } from "etiket";
+import { postal, encodePostal, postalPNG } from "etiket"
 
-postal("12345-6789", { type: "postnet" }); // SVG
-postal("SN34RD1A", { type: "rm4scc" });
-postal("12345678", { type: "auspost", fcc: "59" });
-postal("01234567094987654321", { type: "imb", routingCode: "01234567891" });
+postal("12345-6789", { type: "postnet" }) // SVG
+postal("SN34RD1A", { type: "rm4scc" })
+postal("12345678", { type: "auspost", fcc: "59" })
+postal("01234567094987654321", { type: "imb", routingCode: "01234567891" })
 
-postalPNG("12345", { type: "postnet" }); // Uint8Array
+postalPNG("12345", { type: "postnet" }) // Uint8Array
 
 // Raw bar states: 'T' | 'A' | 'D' | 'F' (4-state), or 1 / 0 (POSTNET, PLANET)
-const bars = encodePostal("SN34RD1A", { type: "rm4scc" });
+const bars = encodePostal("SN34RD1A", { type: "rm4scc" })
 ```
 
 `barcode()` accepts `postnet` and `planet` and routes them to the postal
@@ -165,13 +165,13 @@ renderer automatically. The per-format raw encoders (`encodeRM4SCC`,
 ### Barcodes
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
-barcode("Hello World"); // Code 128 (default)
-barcode("4006381333931", { type: "ean13", showText: true });
-barcode("00012345678905", { type: "itf14", bearerBars: true });
-barcode("(01)12345678901234(17)260101", { type: "gs1-128" });
-barcode("HELLO", { type: "code39", code39CheckDigit: true });
+barcode("Hello World") // Code 128 (default)
+barcode("4006381333931", { type: "ean13", showText: true })
+barcode("00012345678905", { type: "itf14", bearerBars: true })
+barcode("(01)12345678901234(17)260101", { type: "gs1-128" })
+barcode("HELLO", { type: "code39", code39CheckDigit: true })
 ```
 
 | Option         | Type                            | Default       | Description                 |
@@ -202,10 +202,10 @@ barcode("HELLO", { type: "code39", code39CheckDigit: true });
 ### QR Codes
 
 ```ts
-import { qrcode } from "etiket";
+import { qrcode } from "etiket"
 
-qrcode("https://example.com");
-qrcode("Hello", { size: 300, ecLevel: "H", dotType: "rounded" });
+qrcode("https://example.com")
+qrcode("Hello", { size: 300, ecLevel: "H", dotType: "rounded" })
 
 // With gradient
 qrcode("Test", {
@@ -217,7 +217,7 @@ qrcode("Test", {
       { offset: 1, color: "#0000ff" },
     ],
   },
-});
+})
 
 // With corner styling
 qrcode("Test", {
@@ -227,7 +227,7 @@ qrcode("Test", {
     topRight: { outerShape: "extra-rounded" },
     bottomLeft: { outerShape: "dots" },
   },
-});
+})
 ```
 
 | Option           | Type                                              | Default    | Description            |
@@ -273,26 +273,26 @@ import {
   codablockf,
   code16k,
   jabcode,
-} from "etiket";
+} from "etiket"
 
-datamatrix("Hello World");
-gs1datamatrix("(01)12345678901231");
-pdf417("Hello World", { ecLevel: 4, columns: 5 });
-micropdf417("Hello", { columns: 2 });
-aztec("Hello World", { ecPercent: 33 });
+datamatrix("Hello World")
+gs1datamatrix("(01)12345678901231")
+pdf417("Hello World", { ecLevel: 4, columns: 5 })
+micropdf417("Hello", { columns: 2 })
+aztec("Hello World", { ecPercent: 33 })
 
-microqr("12345", { version: 3 });
-rmqr("Hello", { ecLevel: "H" });
-maxicode("Hello", { mode: 2, postalCode: "123456789", countryCode: 840 });
-dotcode("Hello");
-hanxin("Hello", { ecLevel: 3 });
+microqr("12345", { version: 3 })
+rmqr("Hello", { ecLevel: "H" })
+maxicode("Hello", { mode: 2, postalCode: "123456789", countryCode: 840 })
+dotcode("Hello")
+hanxin("Hello", { ecLevel: 3 })
 
 // Stacked linear symbologies (rows taller than modules are wide)
-codablockf("Hello World", { columns: 8 });
-code16k("Hello World");
+codablockf("Hello World", { columns: 8 })
+code16k("Hello World")
 
 // Polychrome
-jabcode("Hello", { colors: 8 });
+jabcode("Hello", { colors: 8 })
 ```
 
 ## Output Formats
@@ -310,18 +310,18 @@ import {
   qrcodePNG,
   barcodePNGDataURI,
   qrcodePNGDataURI,
-} from "etiket";
+} from "etiket"
 
 // SVG
-const svg = qrcode("Hello"); // SVG string
-const uri = qrcodeDataURI("Hello"); // data:image/svg+xml,...
-const b64 = qrcodeBase64("Hello"); // data:image/svg+xml;base64,...
-const term = qrcodeTerminal("Hello"); // Terminal (UTF-8 blocks)
+const svg = qrcode("Hello") // SVG string
+const uri = qrcodeDataURI("Hello") // data:image/svg+xml,...
+const b64 = qrcodeBase64("Hello") // data:image/svg+xml;base64,...
+const term = qrcodeTerminal("Hello") // Terminal (UTF-8 blocks)
 
 // PNG (zero-dependency raster output — no canvas, no native deps)
-const png = qrcodePNG("Hello"); // Uint8Array
-const pngUri = qrcodePNGDataURI("Hello"); // data:image/png;base64,...
-const barPng = barcodePNG("12345", { type: "code128" }); // Uint8Array
+const png = qrcodePNG("Hello") // Uint8Array
+const pngUri = qrcodePNGDataURI("Hello") // data:image/png;base64,...
+const barPng = barcodePNG("12345", { type: "code128" }) // Uint8Array
 ```
 
 PNG output is available for every format except JAB Code, each with a matching
@@ -336,28 +336,28 @@ PNG output is available for every format except JAB Code, each with a matching
 `encode()` returns the underlying data for any symbology without rendering:
 
 ```ts
-import { encode } from "etiket";
+import { encode } from "etiket"
 
-const result = encode("Hello", { type: "qr", qr: { ecLevel: "H" } });
+const result = encode("Hello", { type: "qr", qr: { ecLevel: "H" } })
 
 if (result.type === "1d")
-  result.bars; // bar/space widths
+  result.bars // bar/space widths
 else if (result.type === "2d")
-  result.matrix; // boolean[][]
-else result.bars; // postal bar states
+  result.matrix // boolean[][]
+else result.bars // postal bar states
 ```
 
 ## Convenience Helpers
 
 ```ts
-import { wifi, email, sms, geo, url, phone, vcard, mecard, event } from "etiket";
+import { wifi, email, sms, geo, url, phone, vcard, mecard, event } from "etiket"
 
-wifi("MyNetwork", "password123"); // WiFi QR
-email("test@example.com"); // mailto: QR
-sms("+1234567890", "Hello!"); // SMS QR
-geo(37.7749, -122.4194); // Location QR
-url("https://example.com"); // URL QR
-phone("+1234567890"); // tel: QR
+wifi("MyNetwork", "password123") // WiFi QR
+email("test@example.com") // mailto: QR
+sms("+1234567890", "Hello!") // SMS QR
+geo(37.7749, -122.4194) // Location QR
+url("https://example.com") // URL QR
+phone("+1234567890") // tel: QR
 
 // vCard QR
 vcard({
@@ -366,10 +366,10 @@ vcard({
   phone: "+1234567890",
   email: "john@example.com",
   org: "Acme Inc",
-});
+})
 
 // MeCard QR (simpler, used by Android)
-mecard({ name: "John Doe", phone: "+1234567890", email: "john@example.com" });
+mecard({ name: "John Doe", phone: "+1234567890", email: "john@example.com" })
 
 // Calendar event QR
 event({
@@ -377,17 +377,17 @@ event({
   start: "2026-04-01T10:00:00",
   end: "2026-04-01T11:00:00",
   location: "Office",
-});
+})
 ```
 
 ## Validation
 
 ```ts
-import { validateBarcode, isValidInput, validateQRInput } from "etiket";
+import { validateBarcode, isValidInput, validateQRInput } from "etiket"
 
-validateBarcode("4006381333931", "ean13"); // { valid: true }
-validateBarcode("ABC", "ean13"); // { valid: false, error: '...' }
-isValidInput("HELLO", "code39"); // true
+validateBarcode("4006381333931", "ean13") // { valid: true }
+validateBarcode("ABC", "ean13") // { valid: false, error: '...' }
+isValidInput("HELLO", "code39") // true
 ```
 
 ## Swiss QR Code
@@ -395,7 +395,7 @@ isValidInput("HELLO", "code39"); // true
 Generate QR-bill payment codes (mandatory in Switzerland since 2022):
 
 ```ts
-import { swissQR } from "etiket";
+import { swissQR } from "etiket"
 
 swissQR({
   iban: "CH4431999123000889012",
@@ -404,7 +404,7 @@ swissQR({
   currency: "CHF",
   reference: "210000000003139471430009017",
   referenceType: "QRR",
-});
+})
 ```
 
 ## Raw Encoders
@@ -424,19 +424,19 @@ import {
   renderMatrixSVG,
   renderBarcodePNG,
   renderMatrixPNG,
-} from "etiket";
+} from "etiket"
 
-const bars = encodeCode128("data"); // number[] (bar/space widths)
-const matrix = encodeQR("data"); // boolean[][] (QR matrix)
-const dm = encodeDataMatrix("data"); // boolean[][] (Data Matrix)
+const bars = encodeCode128("data") // number[] (bar/space widths)
+const matrix = encodeQR("data") // boolean[][] (QR matrix)
+const dm = encodeDataMatrix("data") // boolean[][] (Data Matrix)
 
 // SVG rendering
-const svg = renderBarcodeSVG(bars, { height: 100 });
-const qrSvg = renderQRCodeSVG(matrix, { size: 400, dotType: "dots" });
+const svg = renderBarcodeSVG(bars, { height: 100 })
+const qrSvg = renderQRCodeSVG(matrix, { size: 400, dotType: "dots" })
 
 // PNG rendering
-const png = renderBarcodePNG(bars, { height: 100, scale: 2 });
-const qrPng = renderMatrixPNG(matrix, { moduleSize: 10, margin: 4 });
+const png = renderBarcodePNG(bars, { height: 100, scale: 2 })
+const qrPng = renderMatrixPNG(matrix, { moduleSize: 10, margin: 4 })
 ```
 
 ## Industry Standards
@@ -448,7 +448,7 @@ import {
   gs1DigitalLink,
   encodeHIBCPrimary,
   encodeHIBCSecondary,
-} from "etiket";
+} from "etiket"
 
 // Swiss QR-bill (mandatory in Switzerland since 2022)
 swissQR({
@@ -456,21 +456,21 @@ swissQR({
   creditor: { name: "Max Muster", postalCode: "8000", city: "Zürich", country: "CH" },
   amount: 1949.75,
   currency: "CHF",
-});
+})
 
 // GS1 DataMatrix (healthcare, supply chain)
-gs1datamatrix("(01)12345678901234(17)260101(10)BATCH01");
+gs1datamatrix("(01)12345678901234(17)260101(10)BATCH01")
 
 // GS1 Digital Link (2027 retail migration)
-gs1DigitalLink({ gtin: "09520123456788", batch: "ABC123", serial: "12345" });
+gs1DigitalLink({ gtin: "09520123456788", batch: "ABC123", serial: "12345" })
 
 // HIBC (medical device labeling, FDA UDI)
-const hibc = encodeHIBCPrimary("A123", "PROD456");
-barcode(hibc, { type: "code128" }); // Encode in any symbology
+const hibc = encodeHIBCPrimary("A123", "PROD456")
+barcode(hibc, { type: "code128" }) // Encode in any symbology
 
 // ISBT 128 (blood bank labeling, ISO 7064 Mod 37-2 check character)
-const din = encodeISBT128DIN("US", "12345", "26", "000001");
-barcode(din, { type: "code128" });
+const din = encodeISBT128DIN("US", "12345", "26", "000001")
+barcode(din, { type: "code128" })
 
 // MaxiCode (UPS shipping labels)
 const mc = encodeMaxiCode("Test shipment", {
@@ -478,7 +478,7 @@ const mc = encodeMaxiCode("Test shipment", {
   postalCode: "12345",
   countryCode: 840,
   serviceClass: 1,
-});
+})
 ```
 
 ## SVG Accessibility
@@ -491,15 +491,15 @@ barcode("123456789", {
   ariaLabel: "EAN-13 barcode for product 123456789",
   title: "Product Barcode",
   desc: "EAN-13 barcode encoding the GTIN 123456789",
-});
+})
 
 qrcode("https://example.com", {
   ariaLabel: "QR code linking to example.com",
   title: "Website QR Code",
-});
+})
 
 // CSS currentColor support for theme-aware barcodes
-barcode("HELLO", { color: "currentColor", background: "transparent" });
+barcode("HELLO", { color: "currentColor", background: "transparent" })
 ```
 
 ## Framework Integration
@@ -509,7 +509,7 @@ etiket generates plain SVG strings — no DOM required. Works with any framework
 ### React / Next.js
 
 ```tsx
-import { qrcode } from "etiket";
+import { qrcode } from "etiket"
 
 function QRCode({ url }: { url: string }) {
   const svg = qrcode(url, {
@@ -521,29 +521,29 @@ function QRCode({ url }: { url: string }) {
       topRight: { outerShape: "dots", innerShape: "dots" },
       bottomLeft: { outerShape: "dots", innerShape: "dots" },
     },
-  });
+  })
 
-  return <div dangerouslySetInnerHTML={{ __html: svg }} />;
+  return <div dangerouslySetInnerHTML={{ __html: svg }} />
 }
 ```
 
 Or use a data URI for `<img>`:
 
 ```tsx
-import { qrcodeDataURI } from "etiket";
+import { qrcodeDataURI } from "etiket"
 
 function QRImage({ url }: { url: string }) {
-  return <img src={qrcodeDataURI(url)} alt="QR Code" width={200} height={200} />;
+  return <img src={qrcodeDataURI(url)} alt="QR Code" width={200} height={200} />
 }
 ```
 
 PNG output (useful for downloads or `<canvas>`):
 
 ```tsx
-import { qrcodePNGDataURI } from "etiket/png";
+import { qrcodePNGDataURI } from "etiket/png"
 
 function QRCodePNG({ url }: { url: string }) {
-  return <img src={qrcodePNGDataURI(url, { size: 200 })} alt="QR Code" width={200} height={200} />;
+  return <img src={qrcodePNGDataURI(url, { size: 200 })} alt="QR Code" width={200} height={200} />
 }
 ```
 
@@ -553,10 +553,10 @@ function QRCodePNG({ url }: { url: string }) {
 
 ```vue
 <script setup lang="ts">
-import { qrcode } from "etiket";
+import { qrcode } from "etiket"
 
-const props = defineProps<{ url: string }>();
-const svg = computed(() => qrcode(props.url, { dotType: "dots", ecLevel: "H" }));
+const props = defineProps<{ url: string }>()
+const svg = computed(() => qrcode(props.url, { dotType: "dots", ecLevel: "H" }))
 </script>
 
 <template>
@@ -580,21 +580,21 @@ const svg = computed(() => qrcode(props.url, { dotType: "dots", ecLevel: "H" }))
 ### Angular
 
 ```typescript
-import { Component, Input } from "@angular/core";
-import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
-import { qrcode } from "etiket";
+import { Component, Input } from "@angular/core"
+import { DomSanitizer, SafeHtml } from "@angular/platform-browser"
+import { qrcode } from "etiket"
 
 @Component({
   selector: "app-qrcode",
   template: `<div [innerHTML]="svg"></div>`,
 })
 export class QRCodeComponent {
-  svg: SafeHtml = "";
+  svg: SafeHtml = ""
 
   @Input() set url(value: string) {
     this.svg = this.sanitizer.bypassSecurityTrustHtml(
       qrcode(value, { dotType: "dots", ecLevel: "H" }),
-    );
+    )
   }
 
   constructor(private sanitizer: DomSanitizer) {}

--- a/build.config.ts
+++ b/build.config.ts
@@ -1,4 +1,4 @@
-import { defineBuildConfig } from "obuild/config";
+import { defineBuildConfig } from "obuild/config"
 
 export default defineBuildConfig({
   entries: [
@@ -9,4 +9,4 @@ export default defineBuildConfig({
       dts: true,
     },
   ],
-});
+})

--- a/docs/2d-codes/index.md
+++ b/docs/2d-codes/index.md
@@ -25,14 +25,14 @@ encoder returning the module matrix, and — apart from JAB Code — PNG output.
 ECC 200 standard. 24 square sizes (10x10 to 144x144) plus 6 rectangular sizes.
 
 ```ts
-import { datamatrix, encodeDataMatrix } from "etiket";
+import { datamatrix, encodeDataMatrix } from "etiket"
 
 // Convenience function — returns SVG
-datamatrix("Hello World");
-datamatrix("Data", { size: 200, color: "#333" });
+datamatrix("Hello World")
+datamatrix("Data", { size: 200, color: "#333" })
 
 // Raw encoder — returns boolean[][]
-const matrix = encodeDataMatrix("Hello");
+const matrix = encodeDataMatrix("Hello")
 ```
 
 Used in: electronics, healthcare, aerospace (small items requiring dense data).
@@ -42,14 +42,14 @@ Used in: electronics, healthcare, aerospace (small items requiring dense data).
 Stacked 2D barcode with 929 possible codeword values and 9 error correction levels.
 
 ```ts
-import { pdf417, encodePDF417 } from "etiket";
+import { pdf417, encodePDF417 } from "etiket"
 
 // Convenience function — returns SVG
-pdf417("Hello World");
-pdf417("Data", { ecLevel: 4, columns: 5, compact: true });
+pdf417("Hello World")
+pdf417("Data", { ecLevel: 4, columns: 5, compact: true })
 
 // Raw encoder — returns { matrix, rows, cols }
-const result = encodePDF417("Hello", { ecLevel: 2 });
+const result = encodePDF417("Hello", { ecLevel: 2 })
 ```
 
 | Option    | Type      | Default | Description                         |
@@ -65,14 +65,14 @@ Used in: government IDs, transport tickets, shipping labels.
 Bullseye-centered barcode. No quiet zone required — ideal for space-constrained applications.
 
 ```ts
-import { aztec, encodeAztec } from "etiket";
+import { aztec, encodeAztec } from "etiket"
 
 // Convenience function — returns SVG
-aztec("Hello World");
-aztec("Data", { ecPercent: 33, size: 200 });
+aztec("Hello World")
+aztec("Data", { ecPercent: 33, size: 200 })
 
 // Raw encoder — returns boolean[][]
-const matrix = encodeAztec("Hello", { compact: true });
+const matrix = encodeAztec("Hello", { compact: true })
 ```
 
 | Option      | Type      | Default | Description                               |
@@ -89,12 +89,12 @@ Compact QR variant (ISO/IEC 18004) with a single finder pattern. Versions M1–M
 11×11 to 17×17 modules.
 
 ```ts
-import { microqr, encodeMicroQR } from "etiket";
+import { microqr, encodeMicroQR } from "etiket"
 
-microqr("12345");
-microqr("12345", { version: 3, ecLevel: "M", size: 200 });
+microqr("12345")
+microqr("12345", { version: 3, ecLevel: "M", size: 200 })
 
-const matrix = encodeMicroQR("12345");
+const matrix = encodeMicroQR("12345")
 ```
 
 | Option    | Type      | Default | Description                    |
@@ -110,10 +110,10 @@ Used in: small electronic components, where a full QR code will not fit.
 ISO/IEC 23941 rectangular QR variant for narrow spaces.
 
 ```ts
-import { rmqr, encodeRMQR } from "etiket";
+import { rmqr, encodeRMQR } from "etiket"
 
-rmqr("HELLO");
-rmqr("HELLO", { ecLevel: "H" });
+rmqr("HELLO")
+rmqr("HELLO", { ecLevel: "H" })
 ```
 
 | Option    | Type   | Default | Description               |
@@ -130,12 +130,12 @@ package sorting. Modules are hexagons on a staggered grid, so MaxiCode gets a
 dedicated renderer.
 
 ```ts
-import { maxicode, encodeMaxiCode, maxicodePNG } from "etiket";
+import { maxicode, encodeMaxiCode, maxicodePNG } from "etiket"
 
-maxicode("HELLO");
-maxicode("HELLO", { mode: 2, postalCode: "123456789", countryCode: 840, serviceClass: 1 });
+maxicode("HELLO")
+maxicode("HELLO", { mode: 2, postalCode: "123456789", countryCode: 840, serviceClass: 1 })
 
-maxicodePNG("HELLO", { moduleSize: 10 });
+maxicodePNG("HELLO", { moduleSize: 10 })
 ```
 
 | Option         | Type     | Default | Description                                           |
@@ -155,9 +155,9 @@ Used in: parcel carriers (notably UPS).
 High-speed dot matrix symbology for laser-marked and inkjet-printed items.
 
 ```ts
-import { dotcode, encodeDotCode } from "etiket";
+import { dotcode, encodeDotCode } from "etiket"
 
-dotcode("HELLO");
+dotcode("HELLO")
 ```
 
 Used in: tobacco packaging, high-speed production lines.
@@ -168,10 +168,10 @@ Chinese national 2D standard (ISO/IEC 20830), 84 versions from 23×23 to
 189×189 modules, with four finder patterns.
 
 ```ts
-import { hanxin, encodeHanXin } from "etiket";
+import { hanxin, encodeHanXin } from "etiket"
 
-hanxin("HELLO");
-hanxin("HELLO", { ecLevel: 3, version: 5 });
+hanxin("HELLO")
+hanxin("HELLO", { ecLevel: 3, version: 5 })
 ```
 
 | Option    | Type   | Default | Description                                 |
@@ -188,14 +188,14 @@ are taller than a module is wide; `rowHeight` controls that ratio and defaults
 to a spec-appropriate value per format.
 
 ```ts
-import { codablockf, code16k, micropdf417 } from "etiket";
+import { codablockf, code16k, micropdf417 } from "etiket"
 
-codablockf("CODABLOCK F DATA", { columns: 8 });
-code16k("CODE 16K DATA");
-micropdf417("MICRO", { columns: 2 });
+codablockf("CODABLOCK F DATA", { columns: 8 })
+code16k("CODE 16K DATA")
+micropdf417("MICRO", { columns: 2 })
 
 // Square modules instead of tall rows
-code16k("DATA", { rowHeight: 1 });
+code16k("DATA", { rowHeight: 1 })
 ```
 
 | Format      | Option    | Description                    |
@@ -213,16 +213,16 @@ returns a matrix of palette indices plus the palette itself, so it renders
 through the colour matrix renderer.
 
 ```ts
-import { jabcode, encodeJABCode, renderColorMatrixSVG } from "etiket";
+import { jabcode, encodeJABCode, renderColorMatrixSVG } from "etiket"
 
-jabcode("HELLO");
-jabcode("HELLO", { colors: 8, ecPercent: 30 });
+jabcode("HELLO")
+jabcode("HELLO", { colors: 8, ecPercent: 30 })
 
 // Custom palette
-const result = encodeJABCode("HELLO", { colors: 4 });
+const result = encodeJABCode("HELLO", { colors: 4 })
 renderColorMatrixSVG(result.matrix, result.palette, {
   palette: ["#000000", "#e63946", "#457b9d", "#f1faee"],
-});
+})
 ```
 
 | Option      | Type     | Default | Description                 |

--- a/docs/barcodes/codabar.md
+++ b/docs/barcodes/codabar.md
@@ -5,12 +5,12 @@ Self-checking barcode used in libraries, blood banks, and FedEx airbills.
 ## Usage
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
-barcode("12345", { type: "codabar" });
+barcode("12345", { type: "codabar" })
 
 // Custom start/stop characters (A, B, C, or D)
-barcode("12345", { type: "codabar", codabarStart: "A", codabarStop: "B" });
+barcode("12345", { type: "codabar", codabarStart: "A", codabarStop: "B" })
 ```
 
 Character set: `0-9`, `-`, `$`, `:`, `/`, `.`, `+`
@@ -20,7 +20,7 @@ Start/stop: `A`, `B`, `C`, `D` (auto-detected if present in input, defaults to `
 ## Raw Encoder
 
 ```ts
-import { encodeCodabar } from "etiket";
+import { encodeCodabar } from "etiket"
 
-const bars = encodeCodabar("12345", { start: "A", stop: "B" });
+const bars = encodeCodabar("12345", { start: "A", stop: "B" })
 ```

--- a/docs/barcodes/code11.md
+++ b/docs/barcodes/code11.md
@@ -5,9 +5,9 @@ Barcode used in telecommunications for labeling equipment.
 ## Usage
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
-barcode("123-456", { type: "code11" });
+barcode("123-456", { type: "code11" })
 ```
 
 Character set: `0-9`, `-`
@@ -20,7 +20,7 @@ Check digits are automatic:
 ## Raw Encoder
 
 ```ts
-import { encodeCode11 } from "etiket";
+import { encodeCode11 } from "etiket"
 
-const bars = encodeCode11("123-456");
+const bars = encodeCode11("123-456")
 ```

--- a/docs/barcodes/code128.md
+++ b/docs/barcodes/code128.md
@@ -5,10 +5,10 @@ The most versatile 1D barcode. Supports full ASCII with automatic charset optimi
 ## Usage
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
-barcode("Hello World");
-barcode("ABC-123", { type: "code128", showText: true });
+barcode("Hello World")
+barcode("ABC-123", { type: "code128", showText: true })
 ```
 
 ## How It Works
@@ -31,8 +31,8 @@ etiket automatically selects the optimal charset (Auto mode):
 ## Raw Encoder
 
 ```ts
-import { encodeCode128 } from "etiket";
+import { encodeCode128 } from "etiket"
 
-const bars = encodeCode128("Hello");
+const bars = encodeCode128("Hello")
 // Returns number[] of alternating bar/space widths
 ```

--- a/docs/barcodes/code39.md
+++ b/docs/barcodes/code39.md
@@ -5,16 +5,16 @@ Widely used in non-retail, logistics, and defense. Self-checking symbology.
 ## Usage
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
 // Standard Code 39 (0-9, A-Z, -.$/+% space)
-barcode("HELLO-123", { type: "code39" });
+barcode("HELLO-123", { type: "code39" })
 
 // With optional check digit
-barcode("HELLO", { type: "code39", code39CheckDigit: true });
+barcode("HELLO", { type: "code39", code39CheckDigit: true })
 
 // Extended Code 39 (full ASCII)
-barcode("hello world", { type: "code39ext" });
+barcode("hello world", { type: "code39ext" })
 ```
 
 ## Character Set
@@ -32,8 +32,8 @@ barcode("hello world", { type: "code39ext" });
 ## Raw Encoder
 
 ```ts
-import { encodeCode39, encodeCode39Extended } from "etiket";
+import { encodeCode39, encodeCode39Extended } from "etiket"
 
-const bars = encodeCode39("HELLO", { checkDigit: true });
-const extBars = encodeCode39Extended("hello");
+const bars = encodeCode39("HELLO", { checkDigit: true })
+const extBars = encodeCode39Extended("hello")
 ```

--- a/docs/barcodes/code93.md
+++ b/docs/barcodes/code93.md
@@ -5,20 +5,20 @@ Higher density alternative to Code 39. Two mandatory check digits (C and K).
 ## Usage
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
 // Standard Code 93
-barcode("TEST-123", { type: "code93" });
+barcode("TEST-123", { type: "code93" })
 
 // Extended Code 93 (full ASCII)
-barcode("hello world", { type: "code93ext" });
+barcode("hello world", { type: "code93ext" })
 ```
 
 ## Raw Encoders
 
 ```ts
-import { encodeCode93, encodeCode93Extended } from "etiket";
+import { encodeCode93, encodeCode93Extended } from "etiket"
 
-const bars = encodeCode93("TEST");
-const extBars = encodeCode93Extended("hello");
+const bars = encodeCode93("TEST")
+const extBars = encodeCode93Extended("hello")
 ```

--- a/docs/barcodes/ean.md
+++ b/docs/barcodes/ean.md
@@ -5,13 +5,13 @@ European Article Number — the global standard for retail products.
 ## EAN-13
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
 // 13 digits (with check digit)
-barcode("4006381333931", { type: "ean13" });
+barcode("4006381333931", { type: "ean13" })
 
 // 12 digits (check digit auto-calculated)
-barcode("400638133393", { type: "ean13", showText: true });
+barcode("400638133393", { type: "ean13", showText: true })
 ```
 
 ## EAN-8
@@ -20,10 +20,10 @@ Compact version for small packages.
 
 ```ts
 // 8 digits (with check digit)
-barcode("96385074", { type: "ean8" });
+barcode("96385074", { type: "ean8" })
 
 // 7 digits (check digit auto-calculated)
-barcode("9638507", { type: "ean8" });
+barcode("9638507", { type: "ean8" })
 ```
 
 ## EAN-5 (Addon)
@@ -32,7 +32,7 @@ barcode("9638507", { type: "ean8" });
 
 ```ts
 // Price $24.95
-barcode("52495", { type: "ean5" });
+barcode("52495", { type: "ean5" })
 ```
 
 ## EAN-2 (Addon)
@@ -40,16 +40,16 @@ barcode("52495", { type: "ean5" });
 2-digit supplemental barcode for periodical issue numbers.
 
 ```ts
-barcode("53", { type: "ean2" });
+barcode("53", { type: "ean2" })
 ```
 
 ## Raw Encoders
 
 ```ts
-import { encodeEAN13, encodeEAN8, encodeEAN5, encodeEAN2 } from "etiket";
+import { encodeEAN13, encodeEAN8, encodeEAN5, encodeEAN2 } from "etiket"
 
-const { bars, guards } = encodeEAN13("4006381333931");
-const { bars: bars8, guards: guards8 } = encodeEAN8("96385074");
-const addon5 = encodeEAN5("52495"); // number[]
-const addon2 = encodeEAN2("53"); // number[]
+const { bars, guards } = encodeEAN13("4006381333931")
+const { bars: bars8, guards: guards8 } = encodeEAN8("96385074")
+const addon5 = encodeEAN5("52495") // number[]
+const addon2 = encodeEAN2("53") // number[]
 ```

--- a/docs/barcodes/gs1-128.md
+++ b/docs/barcodes/gs1-128.md
@@ -5,13 +5,13 @@ GS1-128 extends Code 128 with Application Identifiers (AIs) for supply chain dat
 ## Usage
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
 // Parenthesized AI format (recommended)
-barcode("(01)12345678901234(17)260101(10)ABC123", { type: "gs1-128" });
+barcode("(01)12345678901234(17)260101(10)ABC123", { type: "gs1-128" })
 
 // GTIN only
-barcode("(01)12345678901234", { type: "gs1-128", showText: true });
+barcode("(01)12345678901234", { type: "gs1-128", showText: true })
 ```
 
 ## Application Identifiers
@@ -35,7 +35,7 @@ FNC1 separators are automatically inserted between variable-length fields.
 ## Raw Encoder
 
 ```ts
-import { encodeGS1128 } from "etiket";
+import { encodeGS1128 } from "etiket"
 
-const bars = encodeGS1128("(01)12345678901234(10)ABC");
+const bars = encodeGS1128("(01)12345678901234(10)ABC")
 ```

--- a/docs/barcodes/index.md
+++ b/docs/barcodes/index.md
@@ -3,9 +3,9 @@
 etiket supports 26 types of 1D barcodes. All are generated with the `barcode()` function.
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
-const svg = barcode("data", { type: "code128" });
+const svg = barcode("data", { type: "code128" })
 ```
 
 ## Supported Formats
@@ -64,5 +64,5 @@ barcode("data", {
   fontFamily: "monospace",
   margin: 10, // Margin around barcode
   textAlign: "center", // 'center' | 'left' | 'right'
-});
+})
 ```

--- a/docs/barcodes/itf.md
+++ b/docs/barcodes/itf.md
@@ -5,10 +5,10 @@ Interleaved 2 of 5 — high-density numeric barcode used in distribution and log
 ## ITF
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
 // Even number of digits required (odd count gets leading 0)
-barcode("1234567890", { type: "itf" });
+barcode("1234567890", { type: "itf" })
 ```
 
 ## ITF-14
@@ -17,24 +17,24 @@ barcode("1234567890", { type: "itf" });
 
 ```ts
 // 14 digits
-barcode("00012345678905", { type: "itf14" });
+barcode("00012345678905", { type: "itf14" })
 
 // 13 digits (check digit auto-calculated)
-barcode("0001234567890", { type: "itf14" });
+barcode("0001234567890", { type: "itf14" })
 
 // With bearer bars
 barcode("00012345678905", {
   type: "itf14",
   bearerBars: true,
   bearerBarWidth: 4,
-});
+})
 ```
 
 ## Raw Encoders
 
 ```ts
-import { encodeITF, encodeITF14 } from "etiket";
+import { encodeITF, encodeITF14 } from "etiket"
 
-const bars = encodeITF("1234567890");
-const bars14 = encodeITF14("00012345678905");
+const bars = encodeITF("1234567890")
+const bars14 = encodeITF14("00012345678905")
 ```

--- a/docs/barcodes/msi.md
+++ b/docs/barcodes/msi.md
@@ -5,17 +5,17 @@ Numeric barcode used in warehouse shelves and inventory management.
 ## Usage
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
 // Default: Mod 10 check digit
-barcode("12345", { type: "msi" });
+barcode("12345", { type: "msi" })
 
 // Different check digit algorithms
-barcode("12345", { type: "msi", msiCheckDigit: "mod10" });
-barcode("12345", { type: "msi", msiCheckDigit: "mod11" });
-barcode("12345", { type: "msi", msiCheckDigit: "mod1010" });
-barcode("12345", { type: "msi", msiCheckDigit: "mod1110" });
-barcode("12345", { type: "msi", msiCheckDigit: "none" });
+barcode("12345", { type: "msi", msiCheckDigit: "mod10" })
+barcode("12345", { type: "msi", msiCheckDigit: "mod11" })
+barcode("12345", { type: "msi", msiCheckDigit: "mod1010" })
+barcode("12345", { type: "msi", msiCheckDigit: "mod1110" })
+barcode("12345", { type: "msi", msiCheckDigit: "none" })
 ```
 
 ## Check Digit Types
@@ -31,7 +31,7 @@ barcode("12345", { type: "msi", msiCheckDigit: "none" });
 ## Raw Encoder
 
 ```ts
-import { encodeMSI } from "etiket";
+import { encodeMSI } from "etiket"
 
-const bars = encodeMSI("12345", { checkDigit: "mod1010" });
+const bars = encodeMSI("12345", { checkDigit: "mod1010" })
 ```

--- a/docs/barcodes/pharmacode.md
+++ b/docs/barcodes/pharmacode.md
@@ -5,17 +5,17 @@ Binary barcode used in pharmaceutical packaging. Readable in both directions.
 ## Usage
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
 // Value must be 3-131070
-barcode("1234", { type: "pharmacode" });
-barcode("50000", { type: "pharmacode" });
+barcode("1234", { type: "pharmacode" })
+barcode("50000", { type: "pharmacode" })
 ```
 
 ## Raw Encoder
 
 ```ts
-import { encodePharmacode } from "etiket";
+import { encodePharmacode } from "etiket"
 
-const bars = encodePharmacode(1234);
+const bars = encodePharmacode(1234)
 ```

--- a/docs/barcodes/upc.md
+++ b/docs/barcodes/upc.md
@@ -5,13 +5,13 @@ Universal Product Code — the standard for retail in North America.
 ## UPC-A
 
 ```ts
-import { barcode } from "etiket";
+import { barcode } from "etiket"
 
 // 12 digits (with check digit)
-barcode("012345678905", { type: "upca", showText: true });
+barcode("012345678905", { type: "upca", showText: true })
 
 // 11 digits (check digit auto-calculated)
-barcode("01234567890", { type: "upca" });
+barcode("01234567890", { type: "upca" })
 ```
 
 ## UPC-E
@@ -20,17 +20,17 @@ Compressed 8-digit version for small packages. Uses zero-suppression encoding.
 
 ```ts
 // 8 digits (number system + 6 digits + check)
-barcode("01234565", { type: "upce" });
+barcode("01234565", { type: "upce" })
 
 // 6 digits (number system 0 implied, check auto-calculated)
-barcode("123456", { type: "upce" });
+barcode("123456", { type: "upce" })
 ```
 
 ## Raw Encoders
 
 ```ts
-import { encodeUPCA, encodeUPCE } from "etiket";
+import { encodeUPCA, encodeUPCE } from "etiket"
 
-const { bars, guards } = encodeUPCA("012345678905");
-const { bars: barsE, guards: guardsE } = encodeUPCE("01234565");
+const { bars, guards } = encodeUPCA("012345678905")
+const { bars: barsE, guards: guardsE } = encodeUPCE("01234565")
 ```

--- a/docs/getting-started/frameworks.md
+++ b/docs/getting-started/frameworks.md
@@ -5,16 +5,16 @@ etiket returns SVG strings, making it easy to use in any framework.
 ## React
 
 ```tsx
-import { qrcode, barcode } from "etiket";
+import { qrcode, barcode } from "etiket"
 
 function QRCode({ text, ...options }) {
-  const svg = qrcode(text, options);
-  return <div dangerouslySetInnerHTML={{ __html: svg }} />;
+  const svg = qrcode(text, options)
+  return <div dangerouslySetInnerHTML={{ __html: svg }} />
 }
 
 function Barcode({ text, type = "code128", ...options }) {
-  const svg = barcode(text, { type, ...options });
-  return <div dangerouslySetInnerHTML={{ __html: svg }} />;
+  const svg = barcode(text, { type, ...options })
+  return <div dangerouslySetInnerHTML={{ __html: svg }} />
 }
 
 // Usage
@@ -24,7 +24,7 @@ export default function App() {
       <QRCode text="https://example.com" size={200} dotType="dots" />
       <Barcode text="Hello" showText />
     </>
-  );
+  )
 }
 ```
 
@@ -32,10 +32,10 @@ export default function App() {
 
 ```vue
 <script setup lang="ts">
-import { qrcode, barcode } from "etiket";
+import { qrcode, barcode } from "etiket"
 
-const qr = qrcode("https://example.com", { size: 200, dotType: "dots" });
-const bc = barcode("Hello", { showText: true });
+const qr = qrcode("https://example.com", { size: 200, dotType: "dots" })
+const bc = barcode("Hello", { showText: true })
 </script>
 
 <template>
@@ -62,27 +62,27 @@ const bc = barcode("Hello", { showText: true });
 ## Solid
 
 ```tsx
-import { qrcode, barcode } from "etiket";
+import { qrcode, barcode } from "etiket"
 
 function QRCode(props) {
-  const svg = () => qrcode(props.text, props);
-  return <div innerHTML={svg()} />;
+  const svg = () => qrcode(props.text, props)
+  return <div innerHTML={svg()} />
 }
 ```
 
 ## Angular
 
 ```typescript
-import { Component } from "@angular/core";
-import { DomSanitizer } from "@angular/platform-browser";
-import { qrcode } from "etiket";
+import { Component } from "@angular/core"
+import { DomSanitizer } from "@angular/platform-browser"
+import { qrcode } from "etiket"
 
 @Component({
   selector: "app-qr",
   template: `<div [innerHTML]="svg"></div>`,
 })
 export class QRComponent {
-  svg = this.sanitizer.bypassSecurityTrustHtml(qrcode("https://example.com"));
+  svg = this.sanitizer.bypassSecurityTrustHtml(qrcode("https://example.com"))
   constructor(private sanitizer: DomSanitizer) {}
 }
 ```
@@ -90,28 +90,28 @@ export class QRComponent {
 ## Server-Side (Node.js / Bun / Deno)
 
 ```ts
-import { writeFileSync } from "node:fs";
-import { qrcode, barcode } from "etiket";
+import { writeFileSync } from "node:fs"
+import { qrcode, barcode } from "etiket"
 
 // Write SVG files
-writeFileSync("qr.svg", qrcode("https://example.com"));
-writeFileSync("barcode.svg", barcode("Hello", { showText: true }));
+writeFileSync("qr.svg", qrcode("https://example.com"))
+writeFileSync("barcode.svg", barcode("Hello", { showText: true }))
 ```
 
 ## Cloudflare Workers
 
 ```ts
-import { qrcode } from "etiket";
+import { qrcode } from "etiket"
 
 export default {
   fetch(request: Request): Response {
-    const url = new URL(request.url);
-    const text = url.searchParams.get("text") || "Hello";
-    const svg = qrcode(text, { size: 300 });
+    const url = new URL(request.url)
+    const text = url.searchParams.get("text") || "Hello"
+    const svg = qrcode(text, { size: 300 })
 
     return new Response(svg, {
       headers: { "Content-Type": "image/svg+xml" },
-    });
+    })
   },
-};
+}
 ```

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -3,27 +3,27 @@
 ## Basic Usage
 
 ```ts
-import { barcode, qrcode } from "etiket";
+import { barcode, qrcode } from "etiket"
 
 // Generate a Code 128 barcode
-const barcodeSvg = barcode("Hello World");
+const barcodeSvg = barcode("Hello World")
 
 // Generate a QR code
-const qrSvg = qrcode("https://example.com");
+const qrSvg = qrcode("https://example.com")
 ```
 
 Both functions return an SVG string that you can use anywhere:
 
 ```ts
 // In the browser
-document.getElementById("barcode").innerHTML = barcodeSvg;
+document.getElementById("barcode").innerHTML = barcodeSvg
 
 // In Node.js — write to file
-import { writeFileSync } from "node:fs";
-writeFileSync("barcode.svg", barcodeSvg);
+import { writeFileSync } from "node:fs"
+writeFileSync("barcode.svg", barcodeSvg)
 
 // As an img src
-const dataUri = `data:image/svg+xml,${encodeURIComponent(barcodeSvg)}`;
+const dataUri = `data:image/svg+xml,${encodeURIComponent(barcodeSvg)}`
 ```
 
 ## Tree Shaking
@@ -31,11 +31,11 @@ const dataUri = `data:image/svg+xml,${encodeURIComponent(barcodeSvg)}`;
 Import only the format you need to minimize bundle size:
 
 ```ts
-import { barcode } from "etiket/barcode"; // 1D barcodes only
-import { qrcode } from "etiket/qr"; // QR codes only
-import { datamatrix } from "etiket/datamatrix";
-import { pdf417 } from "etiket/pdf417";
-import { aztec } from "etiket/aztec";
+import { barcode } from "etiket/barcode" // 1D barcodes only
+import { qrcode } from "etiket/qr" // QR codes only
+import { datamatrix } from "etiket/datamatrix"
+import { pdf417 } from "etiket/pdf417"
+import { aztec } from "etiket/aztec"
 ```
 
 ## Output Formats
@@ -51,20 +51,20 @@ import {
   barcodeBase64,
   qrcodeBase64,
   qrcodeTerminal,
-} from "etiket";
+} from "etiket"
 
 // SVG string (default)
-const svg = qrcode("Hello");
+const svg = qrcode("Hello")
 
 // Data URI — use in <img src="...">
-const uri = qrcodeDataURI("Hello");
+const uri = qrcodeDataURI("Hello")
 
 // Base64 encoded SVG
-const b64 = qrcodeBase64("Hello");
+const b64 = qrcodeBase64("Hello")
 
 // Terminal output with Unicode blocks
-const terminal = qrcodeTerminal("Hello");
-console.log(terminal);
+const terminal = qrcodeTerminal("Hello")
+console.log(terminal)
 ```
 
 ## Convenience Helpers
@@ -72,11 +72,11 @@ console.log(terminal);
 Generate QR codes for common use cases:
 
 ```ts
-import { wifi, email, sms, geo, url } from "etiket";
+import { wifi, email, sms, geo, url } from "etiket"
 
-wifi("MyNetwork", "password123");
-email("hello@example.com");
-sms("+1234567890", "Hello!");
-geo(37.7749, -122.4194);
-url("https://example.com");
+wifi("MyNetwork", "password123")
+email("hello@example.com")
+sms("+1234567890", "Hello!")
+geo(37.7749, -122.4194)
+url("https://example.com")
 ```

--- a/docs/getting-started/validation.md
+++ b/docs/getting-started/validation.md
@@ -5,44 +5,44 @@ etiket provides validation utilities to check inputs before encoding.
 ## Validate Barcode Input
 
 ```ts
-import { validateBarcode, isValidInput } from "etiket";
+import { validateBarcode, isValidInput } from "etiket"
 
 // Returns { valid: true } or { valid: false, error: "..." }
-validateBarcode("4006381333931", "ean13");
+validateBarcode("4006381333931", "ean13")
 // → { valid: true }
 
-validateBarcode("ABC", "ean13");
+validateBarcode("ABC", "ean13")
 // → { valid: false, error: "EAN-13 requires 12 or 13 digits" }
 
 // Boolean shorthand
-isValidInput("HELLO", "code39"); // true
-isValidInput("hello", "code39"); // false (lowercase not allowed)
+isValidInput("HELLO", "code39") // true
+isValidInput("hello", "code39") // false (lowercase not allowed)
 ```
 
 ## Validate QR Input
 
 ```ts
-import { validateQRInput } from "etiket";
+import { validateQRInput } from "etiket"
 
-validateQRInput("Hello World", "M");
+validateQRInput("Hello World", "M")
 // → { valid: true }
 
-validateQRInput("A".repeat(10000), "H");
+validateQRInput("A".repeat(10000), "H")
 // → { valid: false, error: "Data too long for QR code..." }
 ```
 
 ## Check Digits
 
 ```ts
-import { calculateEANCheckDigit, verifyEANCheckDigit } from "etiket";
+import { calculateEANCheckDigit, verifyEANCheckDigit } from "etiket"
 
 // Calculate check digit for EAN/UPC
-calculateEANCheckDigit([4, 0, 0, 6, 3, 8, 1, 3, 3, 3, 9, 3]);
+calculateEANCheckDigit([4, 0, 0, 6, 3, 8, 1, 3, 3, 3, 9, 3])
 // → 1
 
 // Verify an existing check digit
-verifyEANCheckDigit("4006381333931"); // true
-verifyEANCheckDigit("4006381333932"); // false
+verifyEANCheckDigit("4006381333931") // true
+verifyEANCheckDigit("4006381333932") // false
 ```
 
 ## Error Classes
@@ -50,13 +50,13 @@ verifyEANCheckDigit("4006381333932"); // false
 etiket throws specific error types:
 
 ```ts
-import { InvalidInputError, CapacityError, CheckDigitError } from "etiket";
+import { InvalidInputError, CapacityError, CheckDigitError } from "etiket"
 
 try {
-  barcode("abc", { type: "ean13" });
+  barcode("abc", { type: "ean13" })
 } catch (e) {
   if (e instanceof InvalidInputError) {
-    console.log(e.message); // "EAN-13 requires 12 or 13 digits"
+    console.log(e.message) // "EAN-13 requires 12 or 13 digits"
   }
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,10 @@ Zero-dependency barcode & QR code generator — SVG & PNG output. 40+ formats, s
 ## Quick Example
 
 ```ts
-import { barcode, qrcode, postal, qrcodePNG } from "etiket";
+import { barcode, qrcode, postal, qrcodePNG } from "etiket"
 
 // Code 128 barcode
-const svg = barcode("Hello World");
+const svg = barcode("Hello World")
 
 // Styled QR code
 const qr = qrcode("https://example.com", {
@@ -26,13 +26,13 @@ const qr = qrcode("https://example.com", {
   ecLevel: "H",
   dotType: "dots",
   color: "#1a1a2e",
-});
+})
 
 // Royal Mail 4-state postal barcode
-const rm = postal("SN34RD1A", { type: "rm4scc" });
+const rm = postal("SN34RD1A", { type: "rm4scc" })
 
 // PNG bytes, no canvas required
-const png = qrcodePNG("https://example.com", { moduleSize: 8 });
+const png = qrcodePNG("https://example.com", { moduleSize: 8 })
 ```
 
 ## Format Families

--- a/docs/postal/index.md
+++ b/docs/postal/index.md
@@ -5,21 +5,21 @@ vertical extent, not its width. They therefore have their own encoder and
 renderer, separate from the width-modulated 1D barcodes.
 
 ```ts
-import { postal, encodePostal } from "etiket";
+import { postal, encodePostal } from "etiket"
 
 // Convenience function — returns SVG
-postal("12345-6789", { type: "postnet" });
-postal("SN34RD1A", { type: "rm4scc" });
+postal("12345-6789", { type: "postnet" })
+postal("SN34RD1A", { type: "rm4scc" })
 
 // Raw encoder — returns bar states
-const bars = encodePostal("SN34RD1A", { type: "rm4scc" });
+const bars = encodePostal("SN34RD1A", { type: "rm4scc" })
 // ['A', 'T', 'A', ... , 'F']
 ```
 
 A dedicated sub-path export is available for tree-shaking:
 
 ```ts
-import { postal, encodePostal } from "etiket/postal";
+import { postal, encodePostal } from "etiket/postal"
 ```
 
 ## Supported Formats
@@ -58,13 +58,13 @@ Some formats take a second field, supplied through options:
 
 ```ts
 // Australia Post — Format Control Code (default "11")
-postal("12345678", { type: "auspost", fcc: "59" });
+postal("12345678", { type: "auspost", fcc: "59" })
 
 // USPS Intelligent Mail — routing code (0, 5, 9 or 11 digits)
-postal("01234567094987654321", { type: "imb", routingCode: "01234567891" });
+postal("01234567094987654321", { type: "imb", routingCode: "01234567891" })
 
 // Japan Post — address following the postal code
-postal("1234567", { type: "jppost", routingCode: "1-2-3" });
+postal("1234567", { type: "jppost", routingCode: "1-2-3" })
 ```
 
 ## Rendering Options
@@ -82,7 +82,7 @@ postal("12345", {
   shortRatio: 0.4, // Short bar height, POSTNET/PLANET only
   showText: true,
   text: "12345",
-});
+})
 ```
 
 | Option         | Type     | Default        | Description                                                   |
@@ -101,10 +101,10 @@ they are on the other renderers.
 ## PNG Output
 
 ```ts
-import { postalPNG, postalPNGDataURI } from "etiket";
+import { postalPNG, postalPNGDataURI } from "etiket"
 
-const png = postalPNG("12345", { type: "postnet", scale: 2, height: 40 });
-const uri = postalPNGDataURI("SN34RD1A", { type: "rm4scc" });
+const png = postalPNG("12345", { type: "postnet", scale: 2, height: 40 })
+const uri = postalPNGDataURI("SN34RD1A", { type: "rm4scc" })
 ```
 
 ## `barcode()` Compatibility
@@ -114,7 +114,7 @@ renderer automatically, so existing calls keep working and now produce correct
 height-modulated output:
 
 ```ts
-barcode("12345", { type: "postnet" }); // identical to postal("12345")
+barcode("12345", { type: "postnet" }) // identical to postal("12345")
 ```
 
 `encodeBars()` — which returns bar _widths_ — throws for these types, since a
@@ -134,24 +134,24 @@ import {
   encodeAustraliaPost,
   encodeJapanPost,
   encodeIMb,
-} from "etiket";
+} from "etiket"
 
-encodePOSTNET("12345"); // number[] — 1 = tall, 0 = short
-encodeRM4SCC("SN34RD1A"); // FourState[]
-encodeAustraliaPost("11", "12345678"); // (fcc, dpid)
-encodeJapanPost("1234567", "1-2-3"); // (zipcode, address?)
-encodeIMb("01234567094987654321", "01234567891"); // (tracking, routing?)
+encodePOSTNET("12345") // number[] — 1 = tall, 0 = short
+encodeRM4SCC("SN34RD1A") // FourState[]
+encodeAustraliaPost("11", "12345678") // (fcc, dpid)
+encodeJapanPost("1234567", "1-2-3") // (zipcode, address?)
+encodeIMb("01234567094987654321", "01234567891") // (tracking, routing?)
 ```
 
 ## Low-Level Rendering
 
 ```ts
-import { renderPostalSVG, renderPostalPNG, renderPostalRaster } from "etiket";
+import { renderPostalSVG, renderPostalPNG, renderPostalRaster } from "etiket"
 
-const bars = encodePostal("12345", { type: "postnet" });
-renderPostalSVG(bars, { height: 40 });
-renderPostalPNG(bars, { scale: 2 });
-renderPostalRaster(bars); // { width, height, rows }
+const bars = encodePostal("12345", { type: "postnet" })
+renderPostalSVG(bars, { height: 40 })
+renderPostalPNG(bars, { scale: 2 })
+renderPostalRaster(bars) // { width, height, rows }
 ```
 
 The renderer detects the family from the input, so 4-state letters and 2-state

--- a/docs/qr-code/index.md
+++ b/docs/qr-code/index.md
@@ -5,10 +5,10 @@ Full ISO/IEC 18004 implementation. Versions 1-40, all error correction levels, m
 ## Basic Usage
 
 ```ts
-import { qrcode } from "etiket";
+import { qrcode } from "etiket"
 
-qrcode("https://example.com");
-qrcode("Hello World", { size: 300 });
+qrcode("https://example.com")
+qrcode("Hello World", { size: 300 })
 ```
 
 ## Error Correction
@@ -21,7 +21,7 @@ qrcode("Hello World", { size: 300 });
 | `H`   | ~30%     | Required when using logos |
 
 ```ts
-qrcode("data", { ecLevel: "H" });
+qrcode("data", { ecLevel: "H" })
 ```
 
 ## Encoding Modes
@@ -35,10 +35,10 @@ etiket auto-detects the optimal mode, or you can force one:
 | `byte`         | Any (UTF-8)               | 1 byte/8 bits      |
 
 ```ts
-qrcode("12345", { mode: "numeric" });
-qrcode("HELLO", { mode: "alphanumeric" });
-qrcode("hello", { mode: "byte" });
-qrcode("auto detected"); // mode: "auto" (default)
+qrcode("12345", { mode: "numeric" })
+qrcode("HELLO", { mode: "alphanumeric" })
+qrcode("hello", { mode: "byte" })
+qrcode("auto detected") // mode: "auto" (default)
 ```
 
 ## Version Selection
@@ -47,10 +47,10 @@ Versions 1-40 control the QR code size (21x21 to 177x177 modules). Auto-selected
 
 ```ts
 // Auto (smallest version that fits)
-qrcode("data");
+qrcode("data")
 
 // Force specific version
-qrcode("data", { version: 10 }); // 57x57 modules
+qrcode("data", { version: 10 }) // 57x57 modules
 ```
 
 ## Mask Pattern
@@ -58,14 +58,14 @@ qrcode("data", { version: 10 }); // 57x57 modules
 8 mask patterns are evaluated and the best one is automatically selected. You can override:
 
 ```ts
-qrcode("data", { mask: 3 }); // Force mask pattern 3
+qrcode("data", { mask: 3 }) // Force mask pattern 3
 ```
 
 ## Raw Encoder
 
 ```ts
-import { encodeQR } from "etiket";
+import { encodeQR } from "etiket"
 
-const matrix = encodeQR("Hello", { ecLevel: "H" });
+const matrix = encodeQR("Hello", { ecLevel: "H" })
 // boolean[][] — true = dark module
 ```

--- a/docs/qr-code/styling.md
+++ b/docs/qr-code/styling.md
@@ -7,25 +7,25 @@ etiket supports extensive QR code customization with dot shapes, gradients, corn
 12 module shapes available:
 
 ```ts
-import { qrcode } from "etiket";
+import { qrcode } from "etiket"
 
-qrcode("Hello", { dotType: "square" }); // Default
-qrcode("Hello", { dotType: "rounded" }); // Rounded corners
-qrcode("Hello", { dotType: "dots" }); // Circular
-qrcode("Hello", { dotType: "diamond" }); // 45° rotated
-qrcode("Hello", { dotType: "classy" }); // One rounded corner
-qrcode("Hello", { dotType: "classy-rounded" });
-qrcode("Hello", { dotType: "extra-rounded" }); // Fully rounded
-qrcode("Hello", { dotType: "vertical-line" });
-qrcode("Hello", { dotType: "horizontal-line" });
-qrcode("Hello", { dotType: "small-square" }); // With gap
-qrcode("Hello", { dotType: "tiny-square" }); // Smaller with gap
+qrcode("Hello", { dotType: "square" }) // Default
+qrcode("Hello", { dotType: "rounded" }) // Rounded corners
+qrcode("Hello", { dotType: "dots" }) // Circular
+qrcode("Hello", { dotType: "diamond" }) // 45° rotated
+qrcode("Hello", { dotType: "classy" }) // One rounded corner
+qrcode("Hello", { dotType: "classy-rounded" })
+qrcode("Hello", { dotType: "extra-rounded" }) // Fully rounded
+qrcode("Hello", { dotType: "vertical-line" })
+qrcode("Hello", { dotType: "horizontal-line" })
+qrcode("Hello", { dotType: "small-square" }) // With gap
+qrcode("Hello", { dotType: "tiny-square" }) // Smaller with gap
 ```
 
 Module size (0.1 to 1):
 
 ```ts
-qrcode("Hello", { dotType: "dots", dotSize: 0.8 });
+qrcode("Hello", { dotType: "dots", dotSize: 0.8 })
 ```
 
 ## Gradients
@@ -43,7 +43,7 @@ qrcode("Hello", {
       { offset: 1, color: "#4ecdc4" },
     ],
   },
-});
+})
 
 // Radial gradient on background
 qrcode("Hello", {
@@ -54,7 +54,7 @@ qrcode("Hello", {
       { offset: 1, color: "#f0f0f0" },
     ],
   },
-});
+})
 ```
 
 ## Corner (Finder Pattern) Styling
@@ -84,7 +84,7 @@ qrcode("Hello", {
       outerShape: "dots",
     },
   },
-});
+})
 ```
 
 ## Logo Embedding
@@ -101,7 +101,7 @@ qrcode("Hello", {
     hideBackgroundDots: true, // Remove modules behind logo
     backgroundColor: "#ffffff", // Background behind logo
   },
-});
+})
 
 // Or use SVG path data
 qrcode("Hello", {
@@ -110,10 +110,10 @@ qrcode("Hello", {
     path: "M10 10 L90 10 L90 90 L10 90 Z", // SVG path
     size: 0.25,
   },
-});
+})
 
 // Or use an image (PNG, JPEG, SVG URL, or data URI)
-import { readFileSync } from "node:fs";
+import { readFileSync } from "node:fs"
 
 qrcode("Hello", {
   ecLevel: "H",
@@ -121,16 +121,16 @@ qrcode("Hello", {
     imageUrl: "https://example.com/logo.png",
     // imageWidth / imageHeight are optional (defaults to fill logo area)
   },
-});
+})
 
 // ICO/favicon files are auto-converted to PNG
-const favicon = readFileSync("favicon.ico");
+const favicon = readFileSync("favicon.ico")
 qrcode("Hello", {
   ecLevel: "H",
   logo: {
     imageUrl: `data:image/x-icon;base64,${favicon.toString("base64")}`,
   },
-});
+})
 ```
 
 **Supported image formats for `imageUrl`:**
@@ -141,7 +141,7 @@ qrcode("Hello", {
 ## Transparent Background
 
 ```ts
-qrcode("Hello", { background: "transparent" });
+qrcode("Hello", { background: "transparent" })
 ```
 
 ## XML Declaration
@@ -149,5 +149,5 @@ qrcode("Hello", { background: "transparent" });
 Add `<?xml version="1.0"?>` header for standalone SVG files:
 
 ```ts
-qrcode("Hello", { xmlDeclaration: true });
+qrcode("Hello", { xmlDeclaration: true })
 ```

--- a/docs/rendering/index.md
+++ b/docs/rendering/index.md
@@ -7,9 +7,9 @@ etiket provides multiple rendering options for different use cases.
 All high-level functions return SVG strings:
 
 ```ts
-import { barcode, qrcode, datamatrix, pdf417, aztec } from "etiket";
+import { barcode, qrcode, datamatrix, pdf417, aztec } from "etiket"
 
-const svg = barcode("Hello");
+const svg = barcode("Hello")
 // '<svg xmlns="http://www.w3.org/2000/svg" ...>...</svg>'
 ```
 
@@ -18,21 +18,21 @@ const svg = barcode("Hello");
 For embedding directly in `<img>` tags or CSS:
 
 ```ts
-import { barcodeDataURI, qrcodeDataURI } from "etiket";
+import { barcodeDataURI, qrcodeDataURI } from "etiket"
 
-const uri = qrcodeDataURI("Hello");
+const uri = qrcodeDataURI("Hello")
 // 'data:image/svg+xml,...'
 
 // Use in HTML
-`<img src="${uri}" alt="QR Code" />`;
+const html = `<img src="${uri}" alt="QR Code" />`
 ```
 
 ## Base64
 
 ```ts
-import { barcodeBase64, qrcodeBase64 } from "etiket";
+import { barcodeBase64, qrcodeBase64 } from "etiket"
 
-const b64 = qrcodeBase64("Hello");
+const b64 = qrcodeBase64("Hello")
 // 'data:image/svg+xml;base64,...'
 ```
 
@@ -41,9 +41,9 @@ const b64 = qrcodeBase64("Hello");
 Print QR codes in the terminal using Unicode half-block characters:
 
 ```ts
-import { qrcodeTerminal } from "etiket";
+import { qrcodeTerminal } from "etiket"
 
-console.log(qrcodeTerminal("Hello"));
+console.log(qrcodeTerminal("Hello"))
 ```
 
 Uses `▀`, `▄`, `█` and space characters for compact display (2 rows per line).
@@ -97,19 +97,19 @@ etiket writes PNG files directly — no canvas, no native dependency. The encode
 uses stored DEFLATE blocks wrapped in zlib, so output is valid but uncompressed.
 
 ```ts
-import { qrcodePNG, barcodePNG, qrcodePNGDataURI } from "etiket";
+import { qrcodePNG, barcodePNG, qrcodePNGDataURI } from "etiket"
 
-const png = qrcodePNG("Hello", { moduleSize: 10, margin: 4 });
+const png = qrcodePNG("Hello", { moduleSize: 10, margin: 4 })
 // Uint8Array — write with fs.writeFileSync('qr.png', png)
 
-const uri = qrcodePNGDataURI("Hello");
+const uri = qrcodePNGDataURI("Hello")
 // 'data:image/png;base64,...'
 ```
 
 A dedicated sub-path keeps PNG out of SVG-only bundles:
 
 ```ts
-import { qrcodePNG } from "etiket/png";
+import { qrcodePNG } from "etiket/png"
 ```
 
 ### Available PNG Functions
@@ -131,9 +131,9 @@ modules); 1D barcodes take `scale` (pixels per module), `height` and a pixel
 `margin`. All accept `color` and `background` as hex strings.
 
 ```ts
-barcodePNG("12345", { scale: 3, height: 100, margin: 20, color: "#003049" });
-qrcodePNG("Hello", { moduleSize: 8, margin: 2, background: "#f1faee" });
-postalPNG("12345", { type: "postnet", scale: 2, pitch: 4, height: 40 });
+barcodePNG("12345", { scale: 3, height: 100, margin: 20, color: "#003049" })
+qrcodePNG("Hello", { moduleSize: 8, margin: 2, background: "#f1faee" })
+postalPNG("12345", { type: "postnet", scale: 2, pitch: 4, height: 40 })
 ```
 
 ### Low-Level Rasterizers
@@ -149,13 +149,13 @@ import {
   renderPostalRaster,
   renderMaxiCodeRaster,
   encodePNG,
-} from "etiket";
+} from "etiket"
 
 // Raw pixel rows: { width, height, rows } where each row is 0 = bg, 1 = fg
-const raster = renderMatrixRaster(matrix, { moduleSize: 4 });
+const raster = renderMatrixRaster(matrix, { moduleSize: 4 })
 
 // Assemble a PNG yourself
-const png = encodePNG(raster.width, raster.height, raster.rows, [0, 0, 0], [255, 255, 255], true);
+const png = encodePNG(raster.width, raster.height, raster.rows, [0, 0, 0], [255, 255, 255], true)
 ```
 
 ## Raw Encoding with `encode()`
@@ -164,31 +164,31 @@ const png = encodePNG(raster.width, raster.height, raster.rows, [0, 0, 0], [255,
 which is useful when feeding a custom renderer or another imaging library.
 
 ```ts
-import { encode } from "etiket";
+import { encode } from "etiket"
 
-const result = encode("Hello", { type: "qr" });
+const result = encode("Hello", { type: "qr" })
 
 switch (result.type) {
   case "1d":
-    result.bars; // number[] — alternating bar/space widths in modules
-    break;
+    result.bars // number[] — alternating bar/space widths in modules
+    break
   case "2d":
-    result.matrix; // boolean[][] — module grid
-    break;
+    result.matrix // boolean[][] — module grid
+    break
   case "postal":
-    result.bars; // 4-state letters, or 1 (tall) / 0 (short)
-    break;
+    result.bars // 4-state letters, or 1 (tall) / 0 (short)
+    break
 }
 ```
 
 Encoder options are passed per format:
 
 ```ts
-encode("Hello", { type: "qr", qr: { ecLevel: "H" } });
-encode("Hello", { type: "pdf417", pdf417: { columns: 4 } });
-encode("Hello", { type: "aztec", aztec: { ecPercent: 33 } });
-encode("HELLO", { type: "code39", code39CheckDigit: true });
-encode("12345678", { type: "auspost", fcc: "59" });
+encode("Hello", { type: "qr", qr: { ecLevel: "H" } })
+encode("Hello", { type: "pdf417", pdf417: { columns: 4 } })
+encode("Hello", { type: "aztec", aztec: { ecPercent: 33 } })
+encode("HELLO", { type: "code39", code39CheckDigit: true })
+encode("12345678", { type: "auspost", fcc: "59" })
 ```
 
 `encode()` shares its 1D dispatch with `barcode()`, so the two can never
@@ -199,7 +199,7 @@ disagree about how a given input is encoded.
 Barcode and postal SVGs accept a `unit` so output can be sized for print:
 
 ```ts
-barcode("12345", { unit: "mm", barWidth: 0.33, height: 25 });
+barcode("12345", { unit: "mm", barWidth: 0.33, height: 25 })
 // <svg width="..mm" height="..mm" viewBox="0 0 .. ..">
 ```
 
@@ -216,7 +216,7 @@ qrcode("https://example.com", {
   role: "img",
   title: "Website QR code",
   desc: "Scan to open example.com",
-});
+})
 ```
 
 `title` and `desc` become child elements of the `<svg>`; `role` defaults to

--- a/src/_2d.ts
+++ b/src/_2d.ts
@@ -3,42 +3,42 @@
  * polychrome and compact 2D symbologies)
  */
 
-import { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index";
-import { encodePDF417 } from "./encoders/pdf417/index";
-import { encodeMicroPDF417 } from "./encoders/micropdf417";
-import { encodeAztec } from "./encoders/aztec/index";
-import { encodeMicroQR } from "./encoders/qr/micro";
-import { encodeRMQR } from "./encoders/rmqr";
-import { encodeMaxiCode } from "./encoders/maxicode";
-import { encodeDotCode } from "./encoders/dotcode";
-import { encodeHanXin } from "./encoders/hanxin";
-import { encodeCodablockF } from "./encoders/codablock-f";
-import { encodeCode16K } from "./encoders/code16k";
-import { encodeJABCode } from "./encoders/jabcode";
-import { renderMatrixSVG, renderMaxiCodeSVG } from "./renderers/svg/matrix";
-import { renderColorMatrixSVG } from "./renderers/svg/color-matrix";
-import type { MatrixSVGOptions } from "./renderers/svg/matrix";
-import type { ColorMatrixSVGOptions } from "./renderers/svg/color-matrix";
-import type { MicroQROptions } from "./encoders/qr/micro";
-import type { RMQROptions } from "./encoders/rmqr";
-import type { MaxiCodeOptions } from "./encoders/maxicode";
-import type { HanXinOptions } from "./encoders/hanxin";
-import type { MicroPDF417Options } from "./encoders/micropdf417";
+import { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index"
+import { encodePDF417 } from "./encoders/pdf417/index"
+import { encodeMicroPDF417 } from "./encoders/micropdf417"
+import { encodeAztec } from "./encoders/aztec/index"
+import { encodeMicroQR } from "./encoders/qr/micro"
+import { encodeRMQR } from "./encoders/rmqr"
+import { encodeMaxiCode } from "./encoders/maxicode"
+import { encodeDotCode } from "./encoders/dotcode"
+import { encodeHanXin } from "./encoders/hanxin"
+import { encodeCodablockF } from "./encoders/codablock-f"
+import { encodeCode16K } from "./encoders/code16k"
+import { encodeJABCode } from "./encoders/jabcode"
+import { renderMatrixSVG, renderMaxiCodeSVG } from "./renderers/svg/matrix"
+import { renderColorMatrixSVG } from "./renderers/svg/color-matrix"
+import type { MatrixSVGOptions } from "./renderers/svg/matrix"
+import type { ColorMatrixSVGOptions } from "./renderers/svg/color-matrix"
+import type { MicroQROptions } from "./encoders/qr/micro"
+import type { RMQROptions } from "./encoders/rmqr"
+import type { MaxiCodeOptions } from "./encoders/maxicode"
+import type { HanXinOptions } from "./encoders/hanxin"
+import type { MicroPDF417Options } from "./encoders/micropdf417"
 
 /**
  * Generate a Data Matrix as SVG string
  */
 export function datamatrix(text: string, options?: MatrixSVGOptions): string {
-  const matrix = encodeDataMatrix(text);
-  return renderMatrixSVG(matrix, options);
+  const matrix = encodeDataMatrix(text)
+  return renderMatrixSVG(matrix, options)
 }
 
 /**
  * Generate a GS1 DataMatrix as SVG string
  */
 export function gs1datamatrix(text: string, options?: MatrixSVGOptions): string {
-  const matrix = encodeGS1DataMatrix(text);
-  return renderMatrixSVG(matrix, options);
+  const matrix = encodeGS1DataMatrix(text)
+  return renderMatrixSVG(matrix, options)
 }
 
 /**
@@ -47,16 +47,16 @@ export function gs1datamatrix(text: string, options?: MatrixSVGOptions): string 
 export function pdf417(
   text: string,
   options?: {
-    ecLevel?: number;
-    columns?: number;
-    compact?: boolean;
-    width?: number;
-    height?: number;
+    ecLevel?: number
+    columns?: number
+    compact?: boolean
+    width?: number
+    height?: number
   } & MatrixSVGOptions,
 ): string {
-  const { ecLevel, columns, compact, ...svgOpts } = options ?? {};
-  const result = encodePDF417(text, { ecLevel, columns, compact });
-  return renderMatrixSVG(result.matrix, { size: svgOpts.width ?? 400, ...svgOpts });
+  const { ecLevel, columns, compact, ...svgOpts } = options ?? {}
+  const result = encodePDF417(text, { ecLevel, columns, compact })
+  return renderMatrixSVG(result.matrix, { size: svgOpts.width ?? 400, ...svgOpts })
 }
 
 /**
@@ -65,32 +65,32 @@ export function pdf417(
 export function aztec(
   text: string,
   options?: {
-    ecPercent?: number;
-    layers?: number;
-    compact?: boolean;
+    ecPercent?: number
+    layers?: number
+    compact?: boolean
   } & MatrixSVGOptions,
 ): string {
-  const { ecPercent, layers, compact, ...svgOpts } = options ?? {};
-  const matrix = encodeAztec(text, { ecPercent, layers, compact });
-  return renderMatrixSVG(matrix, { margin: 0, ...svgOpts });
+  const { ecPercent, layers, compact, ...svgOpts } = options ?? {}
+  const matrix = encodeAztec(text, { ecPercent, layers, compact })
+  return renderMatrixSVG(matrix, { margin: 0, ...svgOpts })
 }
 
 /**
  * Generate a Micro QR Code (M1–M4) as SVG string
  */
 export function microqr(text: string, options: MicroQROptions & MatrixSVGOptions = {}): string {
-  const { version, ecLevel, mask, ...svgOpts } = options;
-  const matrix = encodeMicroQR(text, { version, ecLevel, mask });
-  return renderMatrixSVG(matrix, svgOpts);
+  const { version, ecLevel, mask, ...svgOpts } = options
+  const matrix = encodeMicroQR(text, { version, ecLevel, mask })
+  return renderMatrixSVG(matrix, svgOpts)
 }
 
 /**
  * Generate a Rectangular Micro QR Code (rMQR) as SVG string
  */
 export function rmqr(text: string, options: RMQROptions & MatrixSVGOptions = {}): string {
-  const { version, ecLevel, ...svgOpts } = options;
-  const matrix = encodeRMQR(text, { version, ecLevel });
-  return renderMatrixSVG(matrix, svgOpts);
+  const { version, ecLevel, ...svgOpts } = options
+  const matrix = encodeRMQR(text, { version, ecLevel })
+  return renderMatrixSVG(matrix, svgOpts)
 }
 
 /**
@@ -100,25 +100,25 @@ export function rmqr(text: string, options: RMQROptions & MatrixSVGOptions = {})
  * with the dedicated hexagonal renderer rather than the square matrix one.
  */
 export function maxicode(text: string, options: MaxiCodeOptions & MatrixSVGOptions = {}): string {
-  const { mode, postalCode, countryCode, serviceClass, ...svgOpts } = options;
-  const matrix = encodeMaxiCode(text, { mode, postalCode, countryCode, serviceClass });
-  return renderMaxiCodeSVG(matrix, svgOpts);
+  const { mode, postalCode, countryCode, serviceClass, ...svgOpts } = options
+  const matrix = encodeMaxiCode(text, { mode, postalCode, countryCode, serviceClass })
+  return renderMaxiCodeSVG(matrix, svgOpts)
 }
 
 /**
  * Generate a DotCode symbol as SVG string
  */
 export function dotcode(text: string, options: MatrixSVGOptions = {}): string {
-  return renderMatrixSVG(encodeDotCode(text), options);
+  return renderMatrixSVG(encodeDotCode(text), options)
 }
 
 /**
  * Generate a Han Xin Code as SVG string
  */
 export function hanxin(text: string, options: HanXinOptions & MatrixSVGOptions = {}): string {
-  const { version, ecLevel, ...svgOpts } = options;
-  const matrix = encodeHanXin(text, { version, ecLevel });
-  return renderMatrixSVG(matrix, svgOpts);
+  const { version, ecLevel, ...svgOpts } = options
+  const matrix = encodeHanXin(text, { version, ecLevel })
+  return renderMatrixSVG(matrix, svgOpts)
 }
 
 /**
@@ -131,9 +131,9 @@ export function micropdf417(
   text: string,
   options: MicroPDF417Options & MatrixSVGOptions = {},
 ): string {
-  const { columns, ...svgOpts } = options;
-  const result = encodeMicroPDF417(text, { columns });
-  return renderMatrixSVG(result.matrix, { rowHeight: 2, ...svgOpts });
+  const { columns, ...svgOpts } = options
+  const result = encodeMicroPDF417(text, { columns })
+  return renderMatrixSVG(result.matrix, { rowHeight: 2, ...svgOpts })
 }
 
 /**
@@ -143,17 +143,17 @@ export function codablockf(
   text: string,
   options: { columns?: number } & MatrixSVGOptions = {},
 ): string {
-  const { columns, ...svgOpts } = options;
-  const result = encodeCodablockF(text, { columns });
-  return renderMatrixSVG(result.matrix, { rowHeight: 8, ...svgOpts });
+  const { columns, ...svgOpts } = options
+  const result = encodeCodablockF(text, { columns })
+  return renderMatrixSVG(result.matrix, { rowHeight: 8, ...svgOpts })
 }
 
 /**
  * Generate a Code 16K stacked barcode as SVG string
  */
 export function code16k(text: string, options: MatrixSVGOptions = {}): string {
-  const result = encodeCode16K(text);
-  return renderMatrixSVG(result.matrix, { rowHeight: 8, ...options });
+  const result = encodeCode16K(text)
+  return renderMatrixSVG(result.matrix, { rowHeight: 8, ...options })
 }
 
 /**
@@ -163,7 +163,7 @@ export function jabcode(
   text: string,
   options: { colors?: 4 | 8; ecPercent?: number } & ColorMatrixSVGOptions = {},
 ): string {
-  const { colors, ecPercent, ...svgOpts } = options;
-  const result = encodeJABCode(text, { colors, ecPercent });
-  return renderColorMatrixSVG(result.matrix, result.palette, svgOpts);
+  const { colors, ecPercent, ...svgOpts } = options
+  const result = encodeJABCode(text, { colors, ecPercent })
+  return renderColorMatrixSVG(result.matrix, result.palette, svgOpts)
 }

--- a/src/_barcode.ts
+++ b/src/_barcode.ts
@@ -2,34 +2,34 @@
  * 1D barcode generation
  */
 
-import { encodeCode128 } from "./encoders/code128";
+import { encodeCode128 } from "./encoders/code128"
 import {
   encodeGS1DataBarOmni,
   encodeGS1DataBarLimited,
   encodeGS1DataBarExpanded,
-} from "./encoders/gs1-databar";
-import { encodeEAN13, encodeEAN8 } from "./encoders/ean";
-import { encodeCode39, encodeCode39Extended } from "./encoders/code39";
-import { encodeCode93, encodeCode93Extended } from "./encoders/code93";
-import { encodeITF, encodeITF14 } from "./encoders/itf";
-import { encodeUPCA, encodeUPCE } from "./encoders/upc";
-import { encodeEAN2, encodeEAN5 } from "./encoders/ean-addon";
-import { encodeCodabar } from "./encoders/codabar";
-import { encodeMSI } from "./encoders/msi";
-import { encodePharmacode } from "./encoders/pharmacode";
-import { encodeCode11 } from "./encoders/code11";
-import { encodeGS1128 } from "./encoders/gs1-128";
-import { encodeIdentcode, encodeLeitcode } from "./encoders/deutsche-post";
-import { encodePlessey } from "./encoders/plessey";
-import { renderBarcodeSVG } from "./renderers/svg/barcode";
-import { renderPostalSVG } from "./renderers/svg/postal";
-import { svgToDataURI, svgToBase64 } from "./renderers/data-uri";
-import { encodePostal } from "./_postal";
-import { InvalidInputError } from "./errors";
-import type { BarcodeEncodingOptions, BarcodeOptions } from "./_types";
+} from "./encoders/gs1-databar"
+import { encodeEAN13, encodeEAN8 } from "./encoders/ean"
+import { encodeCode39, encodeCode39Extended } from "./encoders/code39"
+import { encodeCode93, encodeCode93Extended } from "./encoders/code93"
+import { encodeITF, encodeITF14 } from "./encoders/itf"
+import { encodeUPCA, encodeUPCE } from "./encoders/upc"
+import { encodeEAN2, encodeEAN5 } from "./encoders/ean-addon"
+import { encodeCodabar } from "./encoders/codabar"
+import { encodeMSI } from "./encoders/msi"
+import { encodePharmacode } from "./encoders/pharmacode"
+import { encodeCode11 } from "./encoders/code11"
+import { encodeGS1128 } from "./encoders/gs1-128"
+import { encodeIdentcode, encodeLeitcode } from "./encoders/deutsche-post"
+import { encodePlessey } from "./encoders/plessey"
+import { renderBarcodeSVG } from "./renderers/svg/barcode"
+import { renderPostalSVG } from "./renderers/svg/postal"
+import { svgToDataURI, svgToBase64 } from "./renderers/data-uri"
+import { encodePostal } from "./_postal"
+import { InvalidInputError } from "./errors"
+import type { BarcodeEncodingOptions, BarcodeOptions } from "./_types"
 
 /** Types whose data lives in bar height rather than bar width. */
-const POSTAL_TYPES = new Set<string>(["postnet", "planet"]);
+const POSTAL_TYPES = new Set<string>(["postnet", "planet"])
 
 /**
  * Encode barcode text to bar width pattern
@@ -42,66 +42,66 @@ export function encodeBars(text: string, options: BarcodeEncodingOptions = {}): 
     codabarStart,
     codabarStop,
     code128Charset,
-  } = options;
+  } = options
 
   switch (type) {
     case "code128":
-      return encodeCode128(text, code128Charset ? { charset: code128Charset } : undefined);
+      return encodeCode128(text, code128Charset ? { charset: code128Charset } : undefined)
     case "ean13":
-      return encodeEAN13(text).bars;
+      return encodeEAN13(text).bars
     case "ean8":
-      return encodeEAN8(text).bars;
+      return encodeEAN8(text).bars
     case "code39":
-      return encodeCode39(text, { checkDigit: code39CheckDigit });
+      return encodeCode39(text, { checkDigit: code39CheckDigit })
     case "code39ext":
-      return encodeCode39Extended(text, { checkDigit: code39CheckDigit });
+      return encodeCode39Extended(text, { checkDigit: code39CheckDigit })
     case "code93":
-      return encodeCode93(text);
+      return encodeCode93(text)
     case "code93ext":
-      return encodeCode93Extended(text);
+      return encodeCode93Extended(text)
     case "itf":
-      return encodeITF(text);
+      return encodeITF(text)
     case "itf14":
-      return encodeITF14(text);
+      return encodeITF14(text)
     case "upca":
-      return encodeUPCA(text).bars;
+      return encodeUPCA(text).bars
     case "upce":
-      return encodeUPCE(text).bars;
+      return encodeUPCE(text).bars
     case "ean2":
-      return encodeEAN2(text);
+      return encodeEAN2(text)
     case "ean5":
-      return encodeEAN5(text);
+      return encodeEAN5(text)
     case "codabar":
-      return encodeCodabar(text, { start: codabarStart, stop: codabarStop });
+      return encodeCodabar(text, { start: codabarStart, stop: codabarStop })
     case "msi":
-      return encodeMSI(text, { checkDigit: msiCheckDigit });
+      return encodeMSI(text, { checkDigit: msiCheckDigit })
     case "pharmacode":
-      return encodePharmacode(Number(text));
+      return encodePharmacode(Number(text))
     case "code11":
-      return encodeCode11(text);
+      return encodeCode11(text)
     case "gs1-128":
-      return encodeGS1128(text);
+      return encodeGS1128(text)
     case "identcode":
-      return encodeIdentcode(text);
+      return encodeIdentcode(text)
     case "leitcode":
-      return encodeLeitcode(text);
+      return encodeLeitcode(text)
     case "postnet":
     case "planet":
       // POSTNET/PLANET encode data in bar *height*, not bar width, so they have
       // no meaningful bar-width pattern. Use encodePostal()/postal() instead.
       throw new InvalidInputError(
         `${type} is a height-modulated postal symbology — use encodePostal()/postal() instead of encodeBars()`,
-      );
+      )
     case "plessey":
-      return encodePlessey(text);
+      return encodePlessey(text)
     case "gs1-databar":
-      return encodeGS1DataBarOmni(text);
+      return encodeGS1DataBarOmni(text)
     case "gs1-databar-limited":
-      return encodeGS1DataBarLimited(text);
+      return encodeGS1DataBarLimited(text)
     case "gs1-databar-expanded":
-      return encodeGS1DataBarExpanded(text);
+      return encodeGS1DataBarExpanded(text)
     default:
-      throw new Error(`Unsupported barcode type: ${type}`);
+      throw new Error(`Unsupported barcode type: ${type}`)
   }
 }
 
@@ -117,38 +117,38 @@ export function barcode(text: string, options: BarcodeOptions = {}): string {
     codabarStop: _cbStop,
     code128Charset: _c128,
     ...svgOptions
-  } = options;
+  } = options
 
   // POSTNET/PLANET are height-modulated: render them with the postal renderer
   // so the tall/short distinction that carries the data is preserved.
   if (options.type && POSTAL_TYPES.has(options.type)) {
-    const postalBars = encodePostal(text, { type: options.type as "postnet" | "planet" });
+    const postalBars = encodePostal(text, { type: options.type as "postnet" | "planet" })
     return renderPostalSVG(postalBars, {
       ...svgOptions,
       text: svgOptions.showText !== false ? (svgOptions.text ?? text) : undefined,
       showText: svgOptions.showText ?? false,
-    });
+    })
   }
 
-  const bars = encodeBars(text, options);
+  const bars = encodeBars(text, options)
 
   return renderBarcodeSVG(bars, {
     ...svgOptions,
     text: svgOptions.showText !== false ? (svgOptions.text ?? text) : undefined,
     showText: svgOptions.showText ?? false,
-  });
+  })
 }
 
 /**
  * Generate a barcode as data URI
  */
 export function barcodeDataURI(text: string, options?: BarcodeOptions): string {
-  return svgToDataURI(barcode(text, options));
+  return svgToDataURI(barcode(text, options))
 }
 
 /**
  * Generate a barcode as base64 string
  */
 export function barcodeBase64(text: string, options?: BarcodeOptions): string {
-  return svgToBase64(barcode(text, options));
+  return svgToBase64(barcode(text, options))
 }

--- a/src/_cli.ts
+++ b/src/_cli.ts
@@ -5,12 +5,12 @@
  * in tests without the module running `runMain` on import.
  */
 
-import { defineCommand } from "citty";
-import { consola } from "consola";
-import { writeFileSync } from "node:fs";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { defineCommand } from "citty"
+import { consola } from "consola"
+import { writeFileSync } from "node:fs"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
 import {
   barcode,
   postal,
@@ -51,11 +51,11 @@ import {
   codablockfPNG,
   code16kPNG,
   maxicodePNG,
-} from "./index";
-import type { BarcodeType } from "./index";
-import type { PostalType } from "./_postal";
-import type { DotType } from "./renderers/svg/types";
-import type { ErrorCorrectionLevel } from "./encoders/qr/types";
+} from "./index"
+import type { BarcodeType } from "./index"
+import type { PostalType } from "./_postal"
+import type { DotType } from "./renderers/svg/types"
+import type { ErrorCorrectionLevel } from "./encoders/qr/types"
 
 /** Symbologies reachable through `etiket barcode`. */
 const BARCODE_TYPES: BarcodeType[] = [
@@ -85,7 +85,7 @@ const BARCODE_TYPES: BarcodeType[] = [
   "gs1-databar",
   "gs1-databar-limited",
   "gs1-databar-expanded",
-];
+]
 
 /** Symbologies reachable through `etiket postal`. */
 const POSTAL_TYPES: PostalType[] = [
@@ -96,17 +96,17 @@ const POSTAL_TYPES: PostalType[] = [
   "auspost",
   "jppost",
   "imb",
-];
+]
 
 function readVersion(): string {
   // dist/cli.mjs → ../package.json
   try {
-    const here = dirname(fileURLToPath(import.meta.url));
+    const here = dirname(fileURLToPath(import.meta.url))
     for (const candidate of [join(here, "..", "package.json"), join(here, "package.json")]) {
       try {
-        const pkg: unknown = JSON.parse(readFileSync(candidate, "utf-8"));
+        const pkg: unknown = JSON.parse(readFileSync(candidate, "utf-8"))
         if (pkg && typeof pkg === "object" && "version" in pkg) {
-          return String((pkg as { version: unknown }).version);
+          return String((pkg as { version: unknown }).version)
         }
       } catch {
         // try the next candidate
@@ -115,22 +115,22 @@ function readVersion(): string {
   } catch {
     // fall through
   }
-  return "unknown";
+  return "unknown"
 }
 
 /** Write SVG text or PNG bytes to a file, or stream to stdout. */
 function output(data: string | Uint8Array, file?: string): void {
   if (file) {
-    writeFileSync(file, data);
-    consola.success(`Written to ${file}`);
-    return;
+    writeFileSync(file, data)
+    consola.success(`Written to ${file}`)
+    return
   }
-  process.stdout.write(data);
+  process.stdout.write(data)
 }
 
 /** True when PNG output was requested explicitly or implied by the file name. */
 function wantsPNG(args: { png?: boolean; output?: string }): boolean {
-  return Boolean(args.png) || Boolean(args.output?.toLowerCase().endsWith(".png"));
+  return Boolean(args.png) || Boolean(args.output?.toLowerCase().endsWith(".png"))
 }
 
 const commonArgs = {
@@ -138,23 +138,23 @@ const commonArgs = {
   png: { type: "boolean", description: "Emit PNG instead of SVG" },
   color: { type: "string", description: "Foreground color", default: "#000000" },
   background: { type: "string", description: "Background color", default: "#ffffff" },
-} as const;
+} as const
 
 const matrixArgs = {
   ...commonArgs,
   size: { type: "string", description: "SVG size in pixels", default: "200" },
   "module-size": { type: "string", description: "PNG pixels per module", default: "10" },
   margin: { type: "string", description: "Quiet zone in modules" },
-} as const;
+} as const
 
 interface MatrixArgValues {
-  output?: string;
-  png?: boolean;
-  color: string;
-  background: string;
-  size: string;
-  "module-size": string;
-  margin?: string;
+  output?: string
+  png?: boolean
+  color: string
+  background: string
+  size: string
+  "module-size": string
+  margin?: string
 }
 
 function svgMatrixOptions(args: MatrixArgValues) {
@@ -163,7 +163,7 @@ function svgMatrixOptions(args: MatrixArgValues) {
     color: args.color,
     background: args.background,
     margin: args.margin ? Number(args.margin) : undefined,
-  };
+  }
 }
 
 function pngMatrixOptions(args: MatrixArgValues) {
@@ -172,7 +172,7 @@ function pngMatrixOptions(args: MatrixArgValues) {
     color: args.color,
     background: args.background,
     margin: args.margin ? Number(args.margin) : undefined,
-  };
+  }
 }
 
 /**
@@ -180,10 +180,10 @@ function pngMatrixOptions(args: MatrixArgValues) {
  * argument plus matrix options.
  */
 function defineMatrixCommand(config: {
-  name: string;
-  description: string;
-  svg: (text: string, options: ReturnType<typeof svgMatrixOptions>) => string;
-  png?: (text: string, options: ReturnType<typeof pngMatrixOptions>) => Uint8Array;
+  name: string
+  description: string
+  svg: (text: string, options: ReturnType<typeof svgMatrixOptions>) => string
+  png?: (text: string, options: ReturnType<typeof pngMatrixOptions>) => Uint8Array
 }) {
   return defineCommand({
     meta: { name: config.name, description: config.description },
@@ -192,19 +192,19 @@ function defineMatrixCommand(config: {
       ...matrixArgs,
     },
     run({ args }) {
-      const values = args as unknown as MatrixArgValues & { text: string };
+      const values = args as unknown as MatrixArgValues & { text: string }
       if (wantsPNG(values)) {
         if (!config.png) {
-          consola.error(`${config.name} does not support PNG output`);
-          process.exitCode = 1;
-          return;
+          consola.error(`${config.name} does not support PNG output`)
+          process.exitCode = 1
+          return
         }
-        output(config.png(values.text, pngMatrixOptions(values)), values.output);
-        return;
+        output(config.png(values.text, pngMatrixOptions(values)), values.output)
+        return
       }
-      output(config.svg(values.text, svgMatrixOptions(values)), values.output);
+      output(config.svg(values.text, svgMatrixOptions(values)), values.output)
     },
-  });
+  })
 }
 
 const qrCommand = defineCommand({
@@ -222,10 +222,10 @@ const qrCommand = defineCommand({
   },
   run({ args }) {
     if (args.terminal) {
-      consola.log(qrcodeTerminal(args.text, { ecLevel: args.ec as ErrorCorrectionLevel }));
-      return;
+      consola.log(qrcodeTerminal(args.text, { ecLevel: args.ec as ErrorCorrectionLevel }))
+      return
     }
-    const values = args as unknown as MatrixArgValues & { text: string };
+    const values = args as unknown as MatrixArgValues & { text: string }
     if (wantsPNG(values)) {
       output(
         qrcodePNG(args.text, {
@@ -233,8 +233,8 @@ const qrCommand = defineCommand({
           ...pngMatrixOptions(values),
         }),
         values.output,
-      );
-      return;
+      )
+      return
     }
     output(
       qrcode(args.text, {
@@ -244,9 +244,9 @@ const qrCommand = defineCommand({
         ...svgMatrixOptions(values),
       }),
       values.output,
-    );
+    )
   },
-});
+})
 
 const barcodeCommand = defineCommand({
   meta: { name: "barcode", description: "Generate a 1D barcode" },
@@ -277,7 +277,7 @@ const barcodeCommand = defineCommand({
       msiCheckDigit: args["msi-check-digit"] as "mod10" | undefined,
       code39CheckDigit: args["code39-check-digit"] || undefined,
       code128Charset: args["code128-charset"] as "auto" | undefined,
-    };
+    }
     if (wantsPNG(args)) {
       output(
         barcodePNG(args.text, {
@@ -289,8 +289,8 @@ const barcodeCommand = defineCommand({
           margin: args.margin ? Number(args.margin) : undefined,
         }),
         args.output,
-      );
-      return;
+      )
+      return
     }
     output(
       barcode(args.text, {
@@ -304,9 +304,9 @@ const barcodeCommand = defineCommand({
         margin: args.margin ? Number(args.margin) : undefined,
       }),
       args.output,
-    );
+    )
   },
-});
+})
 
 const postalCommand = defineCommand({
   meta: {
@@ -333,7 +333,7 @@ const postalCommand = defineCommand({
       type: args.type as PostalType,
       fcc: args.fcc,
       routingCode: args["routing-code"],
-    };
+    }
     if (wantsPNG(args)) {
       output(
         postalPNG(args.text, {
@@ -346,8 +346,8 @@ const postalCommand = defineCommand({
           margin: args.margin ? Number(args.margin) : undefined,
         }),
         args.output,
-      );
-      return;
+      )
+      return
     }
     output(
       postal(args.text, {
@@ -360,9 +360,9 @@ const postalCommand = defineCommand({
         margin: args.margin ? Number(args.margin) : undefined,
       }),
       args.output,
-    );
+    )
   },
-});
+})
 
 const datamatrixCommand = defineCommand({
   meta: { name: "datamatrix", description: "Generate a Data Matrix code" },
@@ -372,16 +372,16 @@ const datamatrixCommand = defineCommand({
     gs1: { type: "boolean", description: "Encode as GS1 DataMatrix" },
   },
   run({ args }) {
-    const values = args as unknown as MatrixArgValues & { text: string };
+    const values = args as unknown as MatrixArgValues & { text: string }
     if (wantsPNG(values)) {
-      const png = args.gs1 ? gs1datamatrixPNG : datamatrixPNG;
-      output(png(args.text, pngMatrixOptions(values)), values.output);
-      return;
+      const png = args.gs1 ? gs1datamatrixPNG : datamatrixPNG
+      output(png(args.text, pngMatrixOptions(values)), values.output)
+      return
     }
-    const svg = args.gs1 ? gs1datamatrix : datamatrix;
-    output(svg(args.text, svgMatrixOptions(values)), values.output);
+    const svg = args.gs1 ? gs1datamatrix : datamatrix
+    output(svg(args.text, svgMatrixOptions(values)), values.output)
   },
-});
+})
 
 const pdf417Command = defineCommand({
   meta: { name: "pdf417", description: "Generate a PDF417 barcode" },
@@ -393,19 +393,19 @@ const pdf417Command = defineCommand({
     compact: { type: "boolean", description: "Use compact mode" },
   },
   run({ args }) {
-    const values = args as unknown as MatrixArgValues & { text: string };
+    const values = args as unknown as MatrixArgValues & { text: string }
     const encoding = {
       ecLevel: args["ec-level"] ? Number(args["ec-level"]) : undefined,
       columns: args.columns ? Number(args.columns) : undefined,
       compact: args.compact || undefined,
-    };
-    if (wantsPNG(values)) {
-      output(pdf417PNG(args.text, { ...encoding, ...pngMatrixOptions(values) }), values.output);
-      return;
     }
-    output(pdf417(args.text, { ...encoding, ...svgMatrixOptions(values) }), values.output);
+    if (wantsPNG(values)) {
+      output(pdf417PNG(args.text, { ...encoding, ...pngMatrixOptions(values) }), values.output)
+      return
+    }
+    output(pdf417(args.text, { ...encoding, ...svgMatrixOptions(values) }), values.output)
   },
-});
+})
 
 const aztecCommand = defineCommand({
   meta: { name: "aztec", description: "Generate an Aztec code" },
@@ -417,19 +417,19 @@ const aztecCommand = defineCommand({
     compact: { type: "boolean", description: "Use compact mode" },
   },
   run({ args }) {
-    const values = args as unknown as MatrixArgValues & { text: string };
+    const values = args as unknown as MatrixArgValues & { text: string }
     const encoding = {
       ecPercent: args["ec-percent"] ? Number(args["ec-percent"]) : undefined,
       layers: args.layers ? Number(args.layers) : undefined,
       compact: args.compact || undefined,
-    };
-    if (wantsPNG(values)) {
-      output(aztecPNG(args.text, { ...encoding, ...pngMatrixOptions(values) }), values.output);
-      return;
     }
-    output(aztec(args.text, { ...encoding, ...svgMatrixOptions(values) }), values.output);
+    if (wantsPNG(values)) {
+      output(aztecPNG(args.text, { ...encoding, ...pngMatrixOptions(values) }), values.output)
+      return
+    }
+    output(aztec(args.text, { ...encoding, ...svgMatrixOptions(values) }), values.output)
   },
-});
+})
 
 const wifiCommand = defineCommand({
   meta: { name: "wifi", description: "Generate a WiFi QR code" },
@@ -443,7 +443,7 @@ const wifiCommand = defineCommand({
     hidden: { type: "boolean", description: "Mark the network as hidden" },
   },
   run({ args }) {
-    const values = args as unknown as MatrixArgValues;
+    const values = args as unknown as MatrixArgValues
     output(
       wifi(args.ssid, args.password, {
         encryption: args.encryption as "WPA",
@@ -453,9 +453,9 @@ const wifiCommand = defineCommand({
         ...svgMatrixOptions(values),
       }),
       values.output,
-    );
+    )
   },
-});
+})
 
 const contactCommand = defineCommand({
   meta: { name: "contact", description: "Generate a vCard QR code" },
@@ -469,9 +469,9 @@ const contactCommand = defineCommand({
     website: { type: "string", description: "Website URL" },
   },
   run({ args }) {
-    const values = args as unknown as MatrixArgValues;
+    const values = args as unknown as MatrixArgValues
     // vcard() takes structured name parts; split on the first space.
-    const [firstName = args.name, ...rest] = args.name.split(" ");
+    const [firstName = args.name, ...rest] = args.name.split(" ")
     output(
       vcard(
         {
@@ -486,9 +486,9 @@ const contactCommand = defineCommand({
         svgMatrixOptions(values),
       ),
       values.output,
-    );
+    )
   },
-});
+})
 
 const linkCommand = defineCommand({
   meta: {
@@ -506,51 +506,51 @@ const linkCommand = defineCommand({
     body: { type: "string", description: "Message body (sms)" },
   },
   run({ args }) {
-    const values = args as unknown as MatrixArgValues;
-    const opts = svgMatrixOptions(values);
-    let svg: string;
+    const values = args as unknown as MatrixArgValues
+    const opts = svgMatrixOptions(values)
+    let svg: string
     switch (args.kind) {
       case "email":
-        svg = email(args.value, opts);
-        break;
+        svg = email(args.value, opts)
+        break
       case "phone":
-        svg = phone(args.value, opts);
-        break;
+        svg = phone(args.value, opts)
+        break
       case "sms":
-        svg = sms(args.value, args.body, opts);
-        break;
+        svg = sms(args.value, args.body, opts)
+        break
       case "geo": {
-        const [lat, lng] = args.value.split(",").map(Number);
+        const [lat, lng] = args.value.split(",").map(Number)
         if (lat === undefined || lng === undefined || Number.isNaN(lat) || Number.isNaN(lng)) {
-          consola.error("geo expects 'lat,lng' — e.g. 41.0082,28.9784");
-          process.exitCode = 1;
-          return;
+          consola.error("geo expects 'lat,lng' — e.g. 41.0082,28.9784")
+          process.exitCode = 1
+          return
         }
-        svg = geo(lat, lng, opts);
-        break;
+        svg = geo(lat, lng, opts)
+        break
       }
       default:
-        svg = url(args.value, opts);
+        svg = url(args.value, opts)
     }
-    output(svg, values.output);
+    output(svg, values.output)
   },
-});
+})
 
 const listCommand = defineCommand({
   meta: { name: "list", description: "List every supported symbology" },
   run() {
-    consola.log("1D barcodes (etiket barcode --type <type>):");
-    consola.log("  " + BARCODE_TYPES.join(", "));
-    consola.log("\nPostal (etiket postal --type <type>):");
-    consola.log("  " + POSTAL_TYPES.join(", "));
-    consola.log("\n2D symbologies (own subcommand):");
+    consola.log("1D barcodes (etiket barcode --type <type>):")
+    consola.log("  " + BARCODE_TYPES.join(", "))
+    consola.log("\nPostal (etiket postal --type <type>):")
+    consola.log("  " + POSTAL_TYPES.join(", "))
+    consola.log("\n2D symbologies (own subcommand):")
     consola.log(
       "  qr, microqr, rmqr, datamatrix (--gs1), pdf417, micropdf417, aztec,\n" +
         "  maxicode, dotcode, hanxin, codablockf, code16k, jabcode",
-    );
-    consola.log("\nHelpers: wifi, contact, link");
+    )
+    consola.log("\nHelpers: wifi, contact, link")
   },
-});
+})
 
 export const main = defineCommand({
   meta: {
@@ -623,4 +623,4 @@ export const main = defineCommand({
     link: linkCommand,
     list: listCommand,
   },
-});
+})

--- a/src/_encode.ts
+++ b/src/_encode.ts
@@ -2,22 +2,22 @@
  * Unified encode() function — raw encoding without SVG rendering
  */
 
-import { encodeBars } from "./_barcode";
-import { encodePostal } from "./_postal";
-import { encodeQR } from "./encoders/qr/index";
-import { encodeMicroQR } from "./encoders/qr/micro";
-import { encodeRMQR } from "./encoders/rmqr";
-import { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index";
-import { encodePDF417 } from "./encoders/pdf417/index";
-import { encodeMicroPDF417 } from "./encoders/micropdf417";
-import { encodeAztec } from "./encoders/aztec/index";
-import { encodeMaxiCode } from "./encoders/maxicode";
-import { encodeDotCode } from "./encoders/dotcode";
-import { encodeHanXin } from "./encoders/hanxin";
-import { encodeCodablockF } from "./encoders/codablock-f";
-import { encodeCode16K } from "./encoders/code16k";
-import type { BarcodeType, EncodeOptions, EncodeResult, EncodeType } from "./_types";
-import type { PostalType } from "./_postal";
+import { encodeBars } from "./_barcode"
+import { encodePostal } from "./_postal"
+import { encodeQR } from "./encoders/qr/index"
+import { encodeMicroQR } from "./encoders/qr/micro"
+import { encodeRMQR } from "./encoders/rmqr"
+import { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index"
+import { encodePDF417 } from "./encoders/pdf417/index"
+import { encodeMicroPDF417 } from "./encoders/micropdf417"
+import { encodeAztec } from "./encoders/aztec/index"
+import { encodeMaxiCode } from "./encoders/maxicode"
+import { encodeDotCode } from "./encoders/dotcode"
+import { encodeHanXin } from "./encoders/hanxin"
+import { encodeCodablockF } from "./encoders/codablock-f"
+import { encodeCode16K } from "./encoders/code16k"
+import type { BarcodeType, EncodeOptions, EncodeResult, EncodeType } from "./_types"
+import type { PostalType } from "./_postal"
 
 const POSTAL_TYPES = new Set<EncodeType>([
   "postnet",
@@ -27,7 +27,7 @@ const POSTAL_TYPES = new Set<EncodeType>([
   "auspost",
   "jppost",
   "imb",
-]);
+])
 
 /**
  * Encode data without rendering — returns raw bars, a matrix, or postal bar
@@ -39,36 +39,36 @@ const POSTAL_TYPES = new Set<EncodeType>([
  * - `"postal"` — `bars` holds 4-state letters or POSTNET/PLANET height flags
  */
 export function encode(text: string, options: EncodeOptions = {}): EncodeResult {
-  const { type = "code128" } = options;
+  const { type = "code128" } = options
 
   // 2D codes
   switch (type) {
     case "qr":
-      return { type: "2d", matrix: encodeQR(text, options.qr) };
+      return { type: "2d", matrix: encodeQR(text, options.qr) }
     case "microqr":
-      return { type: "2d", matrix: encodeMicroQR(text, options.microqr) };
+      return { type: "2d", matrix: encodeMicroQR(text, options.microqr) }
     case "rmqr":
-      return { type: "2d", matrix: encodeRMQR(text, options.rmqr) };
+      return { type: "2d", matrix: encodeRMQR(text, options.rmqr) }
     case "datamatrix":
-      return { type: "2d", matrix: encodeDataMatrix(text) };
+      return { type: "2d", matrix: encodeDataMatrix(text) }
     case "gs1-datamatrix":
-      return { type: "2d", matrix: encodeGS1DataMatrix(text) };
+      return { type: "2d", matrix: encodeGS1DataMatrix(text) }
     case "pdf417":
-      return { type: "2d", matrix: encodePDF417(text, options.pdf417).matrix };
+      return { type: "2d", matrix: encodePDF417(text, options.pdf417).matrix }
     case "micropdf417":
-      return { type: "2d", matrix: encodeMicroPDF417(text, options.micropdf417).matrix };
+      return { type: "2d", matrix: encodeMicroPDF417(text, options.micropdf417).matrix }
     case "aztec":
-      return { type: "2d", matrix: encodeAztec(text, options.aztec) };
+      return { type: "2d", matrix: encodeAztec(text, options.aztec) }
     case "maxicode":
-      return { type: "2d", matrix: encodeMaxiCode(text, options.maxicode) };
+      return { type: "2d", matrix: encodeMaxiCode(text, options.maxicode) }
     case "dotcode":
-      return { type: "2d", matrix: encodeDotCode(text) };
+      return { type: "2d", matrix: encodeDotCode(text) }
     case "hanxin":
-      return { type: "2d", matrix: encodeHanXin(text, options.hanxin) };
+      return { type: "2d", matrix: encodeHanXin(text, options.hanxin) }
     case "codablock-f":
-      return { type: "2d", matrix: encodeCodablockF(text, options.codablockf).matrix };
+      return { type: "2d", matrix: encodeCodablockF(text, options.codablockf).matrix }
     case "code16k":
-      return { type: "2d", matrix: encodeCode16K(text).matrix };
+      return { type: "2d", matrix: encodeCode16K(text).matrix }
   }
 
   // Height-modulated postal codes
@@ -80,11 +80,11 @@ export function encode(text: string, options: EncodeOptions = {}): EncodeResult 
         fcc: options.fcc,
         routingCode: options.routingCode,
       }),
-    };
+    }
   }
 
   // 1D codes — share the dispatch used by barcode() so the two cannot diverge.
   // Every 2D and postal type has been handled above, so what remains is a
   // BarcodeType (or an unknown value, which encodeBars() rejects).
-  return { type: "1d", bars: encodeBars(text, { ...options, type: type as BarcodeType }) };
+  return { type: "1d", bars: encodeBars(text, { ...options, type: type as BarcodeType }) }
 }

--- a/src/_helpers.ts
+++ b/src/_helpers.ts
@@ -2,14 +2,14 @@
  * Convenience helpers for common QR code use cases
  */
 
-import { qrcode } from "./_qrcode";
-import type { QRCodeSVGOptions } from "./renderers/svg/types";
-import type { QRCodeOptions } from "./encoders/qr/types";
+import { qrcode } from "./_qrcode"
+import type { QRCodeSVGOptions } from "./renderers/svg/types"
+import type { QRCodeOptions } from "./encoders/qr/types"
 
-type QROpts = QRCodeSVGOptions & QRCodeOptions;
+type QROpts = QRCodeSVGOptions & QRCodeOptions
 
 function escapeWifi(str: string): string {
-  return str.replace(/([\\;,:"'])/g, "\\$1");
+  return str.replace(/([\\;,:"'])/g, "\\$1")
 }
 
 /** Generate a WiFi QR code */
@@ -18,50 +18,50 @@ export function wifi(
   password: string,
   options?: QROpts & { encryption?: "WPA" | "WEP" | "nopass"; hidden?: boolean },
 ): string {
-  const { encryption = "WPA", hidden, ...qrOpts } = options ?? {};
-  let text = `WIFI:T:${encryption};S:${escapeWifi(ssid)};P:${escapeWifi(password)};`;
-  if (hidden) text += "H:true;";
-  text += ";";
-  return qrcode(text, qrOpts);
+  const { encryption = "WPA", hidden, ...qrOpts } = options ?? {}
+  let text = `WIFI:T:${encryption};S:${escapeWifi(ssid)};P:${escapeWifi(password)};`
+  if (hidden) text += "H:true;"
+  text += ";"
+  return qrcode(text, qrOpts)
 }
 
 /** Generate a URL QR code */
 export function url(urlString: string, options?: QROpts): string {
-  return qrcode(urlString, options);
+  return qrcode(urlString, options)
 }
 
 /** Generate an email QR code */
 export function email(address: string, options?: QROpts): string {
-  return qrcode(`mailto:${address}`, options);
+  return qrcode(`mailto:${address}`, options)
 }
 
 /** Generate an SMS QR code */
 export function sms(number: string, body?: string, options?: QROpts): string {
-  const text = body ? `sms:${number}?body=${encodeURIComponent(body)}` : `sms:${number}`;
-  return qrcode(text, options);
+  const text = body ? `sms:${number}?body=${encodeURIComponent(body)}` : `sms:${number}`
+  return qrcode(text, options)
 }
 
 /** Generate a geo location QR code */
 export function geo(lat: number, lng: number, options?: QROpts): string {
-  return qrcode(`geo:${lat},${lng}`, options);
+  return qrcode(`geo:${lat},${lng}`, options)
 }
 
 /** Generate a phone call QR code */
 export function phone(number: string, options?: QROpts): string {
-  return qrcode(`tel:${number}`, options);
+  return qrcode(`tel:${number}`, options)
 }
 
 /** Generate a vCard QR code */
 export function vcard(
   contact: {
-    firstName: string;
-    lastName?: string;
-    phone?: string;
-    email?: string;
-    org?: string;
-    title?: string;
-    url?: string;
-    address?: string;
+    firstName: string
+    lastName?: string
+    phone?: string
+    email?: string
+    org?: string
+    title?: string
+    url?: string
+    address?: string
   },
   options?: QROpts,
 ): string {
@@ -70,15 +70,15 @@ export function vcard(
     "VERSION:3.0",
     `N:${contact.lastName ?? ""};${contact.firstName};;;`,
     `FN:${contact.firstName}${contact.lastName ? ` ${contact.lastName}` : ""}`,
-  ];
-  if (contact.phone) lines.push(`TEL:${contact.phone}`);
-  if (contact.email) lines.push(`EMAIL:${contact.email}`);
-  if (contact.org) lines.push(`ORG:${contact.org}`);
-  if (contact.title) lines.push(`TITLE:${contact.title}`);
-  if (contact.url) lines.push(`URL:${contact.url}`);
-  if (contact.address) lines.push(`ADR:;;${contact.address};;;;`);
-  lines.push("END:VCARD");
-  return qrcode(lines.join("\n"), options);
+  ]
+  if (contact.phone) lines.push(`TEL:${contact.phone}`)
+  if (contact.email) lines.push(`EMAIL:${contact.email}`)
+  if (contact.org) lines.push(`ORG:${contact.org}`)
+  if (contact.title) lines.push(`TITLE:${contact.title}`)
+  if (contact.url) lines.push(`URL:${contact.url}`)
+  if (contact.address) lines.push(`ADR:;;${contact.address};;;;`)
+  lines.push("END:VCARD")
+  return qrcode(lines.join("\n"), options)
 }
 
 /** Generate a MeCard QR code */
@@ -86,66 +86,66 @@ export function mecard(
   contact: { name: string; phone?: string; email?: string; url?: string; address?: string },
   options?: QROpts,
 ): string {
-  let text = `MECARD:N:${contact.name};`;
-  if (contact.phone) text += `TEL:${contact.phone};`;
-  if (contact.email) text += `EMAIL:${contact.email};`;
-  if (contact.url) text += `URL:${contact.url};`;
-  if (contact.address) text += `ADR:${contact.address};`;
-  text += ";";
-  return qrcode(text, options);
+  let text = `MECARD:N:${contact.name};`
+  if (contact.phone) text += `TEL:${contact.phone};`
+  if (contact.email) text += `EMAIL:${contact.email};`
+  if (contact.url) text += `URL:${contact.url};`
+  if (contact.address) text += `ADR:${contact.address};`
+  text += ";"
+  return qrcode(text, options)
 }
 
 /** Generate a calendar event QR code */
 export function event(
   ev: {
-    title: string;
-    start: Date | string;
-    end?: Date | string;
-    location?: string;
-    description?: string;
+    title: string
+    start: Date | string
+    end?: Date | string
+    location?: string
+    description?: string
   },
   options?: QROpts,
 ): string {
   const fmt = (d: Date | string) => {
-    const date = typeof d === "string" ? new Date(d) : d;
+    const date = typeof d === "string" ? new Date(d) : d
     return date
       .toISOString()
       .replace(/[-:]/g, "")
-      .replace(/\.\d{3}/, "");
-  };
-  const lines = ["BEGIN:VEVENT", `SUMMARY:${ev.title}`, `DTSTART:${fmt(ev.start)}`];
-  if (ev.end) lines.push(`DTEND:${fmt(ev.end)}`);
-  if (ev.location) lines.push(`LOCATION:${ev.location}`);
-  if (ev.description) lines.push(`DESCRIPTION:${ev.description}`);
-  lines.push("END:VEVENT");
-  return qrcode(lines.join("\n"), options);
+      .replace(/\.\d{3}/, "")
+  }
+  const lines = ["BEGIN:VEVENT", `SUMMARY:${ev.title}`, `DTSTART:${fmt(ev.start)}`]
+  if (ev.end) lines.push(`DTEND:${fmt(ev.end)}`)
+  if (ev.location) lines.push(`LOCATION:${ev.location}`)
+  if (ev.description) lines.push(`DESCRIPTION:${ev.description}`)
+  lines.push("END:VEVENT")
+  return qrcode(lines.join("\n"), options)
 }
 
 /** Generate a Swiss QR Code for QR-bill payments */
 export function swissQR(
   data: {
-    iban: string;
+    iban: string
     creditor: {
-      name: string;
-      street?: string;
-      houseNumber?: string;
-      postalCode: string;
-      city: string;
-      country: string;
-    };
-    amount?: number;
-    currency?: "CHF" | "EUR";
+      name: string
+      street?: string
+      houseNumber?: string
+      postalCode: string
+      city: string
+      country: string
+    }
+    amount?: number
+    currency?: "CHF" | "EUR"
     debtor?: {
-      name: string;
-      street?: string;
-      houseNumber?: string;
-      postalCode: string;
-      city: string;
-      country: string;
-    };
-    reference?: string;
-    referenceType?: "QRR" | "SCOR" | "NON";
-    additionalInfo?: string;
+      name: string
+      street?: string
+      houseNumber?: string
+      postalCode: string
+      city: string
+      country: string
+    }
+    reference?: string
+    referenceType?: "QRR" | "SCOR" | "NON"
+    additionalInfo?: string
   },
   options?: QROpts,
 ): string {
@@ -181,32 +181,32 @@ export function swissQR(
     data.reference ?? "",
     data.additionalInfo ?? "",
     "EPD",
-  ];
-  return qrcode(lines.join("\n"), { ecLevel: "M", ...options });
+  ]
+  return qrcode(lines.join("\n"), { ecLevel: "M", ...options })
 }
 
 /** Generate a GS1 Digital Link QR code */
 export function gs1DigitalLink(
   data: {
-    gtin: string;
-    batch?: string;
-    serial?: string;
-    expiry?: string;
-    weight?: string;
-    lot?: string;
-    [key: string]: string | undefined;
+    gtin: string
+    batch?: string
+    serial?: string
+    expiry?: string
+    weight?: string
+    lot?: string
+    [key: string]: string | undefined
   },
   options?: QROpts & { domain?: string },
 ): string {
-  const { domain = "https://id.gs1.org", ...qrOpts } = options ?? {};
-  let path = `/01/${data.gtin}`;
-  if (data.batch ?? data.lot) path += `/10/${data.batch ?? data.lot}`;
-  if (data.serial) path += `/21/${data.serial}`;
-  if (data.expiry) path += `/17/${data.expiry}`;
-  if (data.weight) path += `/3103/${data.weight}`;
-  const knownKeys = new Set(["gtin", "batch", "serial", "expiry", "weight", "lot"]);
+  const { domain = "https://id.gs1.org", ...qrOpts } = options ?? {}
+  let path = `/01/${data.gtin}`
+  if (data.batch ?? data.lot) path += `/10/${data.batch ?? data.lot}`
+  if (data.serial) path += `/21/${data.serial}`
+  if (data.expiry) path += `/17/${data.expiry}`
+  if (data.weight) path += `/3103/${data.weight}`
+  const knownKeys = new Set(["gtin", "batch", "serial", "expiry", "weight", "lot"])
   for (const [key, value] of Object.entries(data)) {
-    if (!knownKeys.has(key) && value) path += `/${key}/${value}`;
+    if (!knownKeys.has(key) && value) path += `/${key}/${value}`
   }
-  return qrcode(`${domain}${path}`, qrOpts);
+  return qrcode(`${domain}${path}`, qrOpts)
 }

--- a/src/_png.ts
+++ b/src/_png.ts
@@ -2,46 +2,46 @@
  * PNG output for barcodes and 2D codes
  */
 
-import { encodeBars } from "./_barcode";
-import { encodeQR } from "./encoders/qr/index";
-import { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index";
-import { encodePDF417 } from "./encoders/pdf417/index";
-import { encodeAztec } from "./encoders/aztec/index";
-import { encodeMicroQR } from "./encoders/qr/micro";
-import { encodeRMQR } from "./encoders/rmqr";
-import { encodeHanXin } from "./encoders/hanxin";
-import { encodeDotCode } from "./encoders/dotcode";
-import { encodeMicroPDF417 } from "./encoders/micropdf417";
-import { encodeCodablockF } from "./encoders/codablock-f";
-import { encodeCode16K } from "./encoders/code16k";
-import { encodeMaxiCode } from "./encoders/maxicode";
+import { encodeBars } from "./_barcode"
+import { encodeQR } from "./encoders/qr/index"
+import { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index"
+import { encodePDF417 } from "./encoders/pdf417/index"
+import { encodeAztec } from "./encoders/aztec/index"
+import { encodeMicroQR } from "./encoders/qr/micro"
+import { encodeRMQR } from "./encoders/rmqr"
+import { encodeHanXin } from "./encoders/hanxin"
+import { encodeDotCode } from "./encoders/dotcode"
+import { encodeMicroPDF417 } from "./encoders/micropdf417"
+import { encodeCodablockF } from "./encoders/codablock-f"
+import { encodeCode16K } from "./encoders/code16k"
+import { encodeMaxiCode } from "./encoders/maxicode"
 import {
   renderBarcodePNG,
   renderMatrixPNG,
   renderPostalPNG,
   renderMaxiCodePNG,
-} from "./renderers/png/rasterize";
-import { encodePostal } from "./_postal";
-import type { PostalEncodingOptions } from "./_postal";
-import type { BarcodeEncodingOptions } from "./_types";
-import type { QRCodeOptions } from "./encoders/qr/types";
-import type { MicroQROptions } from "./encoders/qr/micro";
-import type { RMQROptions } from "./encoders/rmqr";
-import type { HanXinOptions } from "./encoders/hanxin";
-import type { MicroPDF417Options } from "./encoders/micropdf417";
-import type { MaxiCodeOptions } from "./encoders/maxicode";
-import type { BarcodePNGOptions, MatrixPNGOptions, PostalPNGOptions } from "./renderers/png/types";
+} from "./renderers/png/rasterize"
+import { encodePostal } from "./_postal"
+import type { PostalEncodingOptions } from "./_postal"
+import type { BarcodeEncodingOptions } from "./_types"
+import type { QRCodeOptions } from "./encoders/qr/types"
+import type { MicroQROptions } from "./encoders/qr/micro"
+import type { RMQROptions } from "./encoders/rmqr"
+import type { HanXinOptions } from "./encoders/hanxin"
+import type { MicroPDF417Options } from "./encoders/micropdf417"
+import type { MaxiCodeOptions } from "./encoders/maxicode"
+import type { BarcodePNGOptions, MatrixPNGOptions, PostalPNGOptions } from "./renderers/png/types"
 
 function uint8ToBase64(data: Uint8Array): string {
-  let binary = "";
+  let binary = ""
   for (let i = 0; i < data.length; i++) {
-    binary += String.fromCharCode(data[i]!);
+    binary += String.fromCharCode(data[i]!)
   }
-  return btoa(binary);
+  return btoa(binary)
 }
 
 function toPNGDataURI(data: Uint8Array): string {
-  return `data:image/png;base64,${uint8ToBase64(data)}`;
+  return `data:image/png;base64,${uint8ToBase64(data)}`
 }
 
 /**
@@ -51,8 +51,8 @@ export function barcodePNG(
   text: string,
   options?: BarcodeEncodingOptions & BarcodePNGOptions,
 ): Uint8Array {
-  const bars = encodeBars(text, options);
-  return renderBarcodePNG(bars, options);
+  const bars = encodeBars(text, options)
+  return renderBarcodePNG(bars, options)
 }
 
 /**
@@ -62,7 +62,7 @@ export function barcodePNGDataURI(
   text: string,
   options?: BarcodeEncodingOptions & BarcodePNGOptions,
 ): string {
-  return toPNGDataURI(barcodePNG(text, options));
+  return toPNGDataURI(barcodePNG(text, options))
 }
 
 /**
@@ -72,8 +72,8 @@ export function postalPNG(
   text: string,
   options?: PostalEncodingOptions & PostalPNGOptions,
 ): Uint8Array {
-  const bars = encodePostal(text, options);
-  return renderPostalPNG(bars, options);
+  const bars = encodePostal(text, options)
+  return renderPostalPNG(bars, options)
 }
 
 /**
@@ -83,52 +83,52 @@ export function postalPNGDataURI(
   text: string,
   options?: PostalEncodingOptions & PostalPNGOptions,
 ): string {
-  return toPNGDataURI(postalPNG(text, options));
+  return toPNGDataURI(postalPNG(text, options))
 }
 
 /**
  * Generate a QR code as PNG
  */
 export function qrcodePNG(text: string, options?: QRCodeOptions & MatrixPNGOptions): Uint8Array {
-  const matrix = encodeQR(text, options);
-  return renderMatrixPNG(matrix, options);
+  const matrix = encodeQR(text, options)
+  return renderMatrixPNG(matrix, options)
 }
 
 /**
  * Generate a QR code as PNG data URI
  */
 export function qrcodePNGDataURI(text: string, options?: QRCodeOptions & MatrixPNGOptions): string {
-  return toPNGDataURI(qrcodePNG(text, options));
+  return toPNGDataURI(qrcodePNG(text, options))
 }
 
 /**
  * Generate a Data Matrix as PNG
  */
 export function datamatrixPNG(text: string, options?: MatrixPNGOptions): Uint8Array {
-  const matrix = encodeDataMatrix(text);
-  return renderMatrixPNG(matrix, options);
+  const matrix = encodeDataMatrix(text)
+  return renderMatrixPNG(matrix, options)
 }
 
 /**
  * Generate a Data Matrix as PNG data URI
  */
 export function datamatrixPNGDataURI(text: string, options?: MatrixPNGOptions): string {
-  return toPNGDataURI(datamatrixPNG(text, options));
+  return toPNGDataURI(datamatrixPNG(text, options))
 }
 
 /**
  * Generate a GS1 Data Matrix as PNG
  */
 export function gs1datamatrixPNG(text: string, options?: MatrixPNGOptions): Uint8Array {
-  const matrix = encodeGS1DataMatrix(text);
-  return renderMatrixPNG(matrix, options);
+  const matrix = encodeGS1DataMatrix(text)
+  return renderMatrixPNG(matrix, options)
 }
 
 /**
  * Generate a GS1 Data Matrix as PNG data URI
  */
 export function gs1datamatrixPNGDataURI(text: string, options?: MatrixPNGOptions): string {
-  return toPNGDataURI(gs1datamatrixPNG(text, options));
+  return toPNGDataURI(gs1datamatrixPNG(text, options))
 }
 
 /**
@@ -138,9 +138,9 @@ export function pdf417PNG(
   text: string,
   options?: { ecLevel?: number; columns?: number; compact?: boolean } & MatrixPNGOptions,
 ): Uint8Array {
-  const { ecLevel, columns, compact, ...pngOpts } = options ?? {};
-  const result = encodePDF417(text, { ecLevel, columns, compact });
-  return renderMatrixPNG(result.matrix, pngOpts);
+  const { ecLevel, columns, compact, ...pngOpts } = options ?? {}
+  const result = encodePDF417(text, { ecLevel, columns, compact })
+  return renderMatrixPNG(result.matrix, pngOpts)
 }
 
 /**
@@ -150,7 +150,7 @@ export function pdf417PNGDataURI(
   text: string,
   options?: { ecLevel?: number; columns?: number; compact?: boolean } & MatrixPNGOptions,
 ): string {
-  return toPNGDataURI(pdf417PNG(text, options));
+  return toPNGDataURI(pdf417PNG(text, options))
 }
 
 /**
@@ -160,9 +160,9 @@ export function aztecPNG(
   text: string,
   options?: { ecPercent?: number; layers?: number; compact?: boolean } & MatrixPNGOptions,
 ): Uint8Array {
-  const { ecPercent, layers, compact, ...pngOpts } = options ?? {};
-  const matrix = encodeAztec(text, { ecPercent, layers, compact });
-  return renderMatrixPNG(matrix, { margin: 0, ...pngOpts });
+  const { ecPercent, layers, compact, ...pngOpts } = options ?? {}
+  const matrix = encodeAztec(text, { ecPercent, layers, compact })
+  return renderMatrixPNG(matrix, { margin: 0, ...pngOpts })
 }
 
 /**
@@ -172,15 +172,15 @@ export function aztecPNGDataURI(
   text: string,
   options?: { ecPercent?: number; layers?: number; compact?: boolean } & MatrixPNGOptions,
 ): string {
-  return toPNGDataURI(aztecPNG(text, options));
+  return toPNGDataURI(aztecPNG(text, options))
 }
 
 /**
  * Generate a Micro QR Code as PNG
  */
 export function microqrPNG(text: string, options?: MicroQROptions & MatrixPNGOptions): Uint8Array {
-  const { version, ecLevel, mask, ...pngOpts } = options ?? {};
-  return renderMatrixPNG(encodeMicroQR(text, { version, ecLevel, mask }), pngOpts);
+  const { version, ecLevel, mask, ...pngOpts } = options ?? {}
+  return renderMatrixPNG(encodeMicroQR(text, { version, ecLevel, mask }), pngOpts)
 }
 
 /**
@@ -190,51 +190,51 @@ export function microqrPNGDataURI(
   text: string,
   options?: MicroQROptions & MatrixPNGOptions,
 ): string {
-  return toPNGDataURI(microqrPNG(text, options));
+  return toPNGDataURI(microqrPNG(text, options))
 }
 
 /**
  * Generate a Rectangular Micro QR Code (rMQR) as PNG
  */
 export function rmqrPNG(text: string, options?: RMQROptions & MatrixPNGOptions): Uint8Array {
-  const { version, ecLevel, ...pngOpts } = options ?? {};
-  return renderMatrixPNG(encodeRMQR(text, { version, ecLevel }), pngOpts);
+  const { version, ecLevel, ...pngOpts } = options ?? {}
+  return renderMatrixPNG(encodeRMQR(text, { version, ecLevel }), pngOpts)
 }
 
 /**
  * Generate a Rectangular Micro QR Code (rMQR) as PNG data URI
  */
 export function rmqrPNGDataURI(text: string, options?: RMQROptions & MatrixPNGOptions): string {
-  return toPNGDataURI(rmqrPNG(text, options));
+  return toPNGDataURI(rmqrPNG(text, options))
 }
 
 /**
  * Generate a Han Xin Code as PNG
  */
 export function hanxinPNG(text: string, options?: HanXinOptions & MatrixPNGOptions): Uint8Array {
-  const { version, ecLevel, ...pngOpts } = options ?? {};
-  return renderMatrixPNG(encodeHanXin(text, { version, ecLevel }), pngOpts);
+  const { version, ecLevel, ...pngOpts } = options ?? {}
+  return renderMatrixPNG(encodeHanXin(text, { version, ecLevel }), pngOpts)
 }
 
 /**
  * Generate a Han Xin Code as PNG data URI
  */
 export function hanxinPNGDataURI(text: string, options?: HanXinOptions & MatrixPNGOptions): string {
-  return toPNGDataURI(hanxinPNG(text, options));
+  return toPNGDataURI(hanxinPNG(text, options))
 }
 
 /**
  * Generate a DotCode symbol as PNG
  */
 export function dotcodePNG(text: string, options?: MatrixPNGOptions): Uint8Array {
-  return renderMatrixPNG(encodeDotCode(text), options);
+  return renderMatrixPNG(encodeDotCode(text), options)
 }
 
 /**
  * Generate a DotCode symbol as PNG data URI
  */
 export function dotcodePNGDataURI(text: string, options?: MatrixPNGOptions): string {
-  return toPNGDataURI(dotcodePNG(text, options));
+  return toPNGDataURI(dotcodePNG(text, options))
 }
 
 /**
@@ -244,8 +244,8 @@ export function micropdf417PNG(
   text: string,
   options?: MicroPDF417Options & MatrixPNGOptions,
 ): Uint8Array {
-  const { columns, ...pngOpts } = options ?? {};
-  return renderMatrixPNG(encodeMicroPDF417(text, { columns }).matrix, pngOpts);
+  const { columns, ...pngOpts } = options ?? {}
+  return renderMatrixPNG(encodeMicroPDF417(text, { columns }).matrix, pngOpts)
 }
 
 /**
@@ -255,7 +255,7 @@ export function micropdf417PNGDataURI(
   text: string,
   options?: MicroPDF417Options & MatrixPNGOptions,
 ): string {
-  return toPNGDataURI(micropdf417PNG(text, options));
+  return toPNGDataURI(micropdf417PNG(text, options))
 }
 
 /**
@@ -265,8 +265,8 @@ export function codablockfPNG(
   text: string,
   options?: { columns?: number } & MatrixPNGOptions,
 ): Uint8Array {
-  const { columns, ...pngOpts } = options ?? {};
-  return renderMatrixPNG(encodeCodablockF(text, { columns }).matrix, pngOpts);
+  const { columns, ...pngOpts } = options ?? {}
+  return renderMatrixPNG(encodeCodablockF(text, { columns }).matrix, pngOpts)
 }
 
 /**
@@ -276,21 +276,21 @@ export function codablockfPNGDataURI(
   text: string,
   options?: { columns?: number } & MatrixPNGOptions,
 ): string {
-  return toPNGDataURI(codablockfPNG(text, options));
+  return toPNGDataURI(codablockfPNG(text, options))
 }
 
 /**
  * Generate a Code 16K stacked barcode as PNG
  */
 export function code16kPNG(text: string, options?: MatrixPNGOptions): Uint8Array {
-  return renderMatrixPNG(encodeCode16K(text).matrix, options);
+  return renderMatrixPNG(encodeCode16K(text).matrix, options)
 }
 
 /**
  * Generate a Code 16K stacked barcode as PNG data URI
  */
 export function code16kPNGDataURI(text: string, options?: MatrixPNGOptions): string {
-  return toPNGDataURI(code16kPNG(text, options));
+  return toPNGDataURI(code16kPNG(text, options))
 }
 
 /**
@@ -300,9 +300,9 @@ export function maxicodePNG(
   text: string,
   options?: MaxiCodeOptions & MatrixPNGOptions,
 ): Uint8Array {
-  const { mode, postalCode, countryCode, serviceClass, ...pngOpts } = options ?? {};
-  const matrix = encodeMaxiCode(text, { mode, postalCode, countryCode, serviceClass });
-  return renderMaxiCodePNG(matrix, pngOpts);
+  const { mode, postalCode, countryCode, serviceClass, ...pngOpts } = options ?? {}
+  const matrix = encodeMaxiCode(text, { mode, postalCode, countryCode, serviceClass })
+  return renderMaxiCodePNG(matrix, pngOpts)
 }
 
 /**
@@ -312,5 +312,5 @@ export function maxicodePNGDataURI(
   text: string,
   options?: MaxiCodeOptions & MatrixPNGOptions,
 ): string {
-  return toPNGDataURI(maxicodePNG(text, options));
+  return toPNGDataURI(maxicodePNG(text, options))
 }

--- a/src/_postal.ts
+++ b/src/_postal.ts
@@ -6,33 +6,28 @@
  * Intelligent Mail (4-state).
  */
 
-import { encodePOSTNET, encodePLANET } from "./encoders/postnet";
-import {
-  encodeRM4SCC,
-  encodeKIX,
-  encodeAustraliaPost,
-  encodeJapanPost,
-} from "./encoders/fourstate";
-import { encodeIMb } from "./encoders/imb";
-import { renderPostalSVG } from "./renderers/svg/postal";
-import { svgToDataURI, svgToBase64 } from "./renderers/data-uri";
-import type { PostalBar, PostalSVGOptions } from "./renderers/svg/postal";
-import { InvalidInputError } from "./errors";
+import { encodePOSTNET, encodePLANET } from "./encoders/postnet"
+import { encodeRM4SCC, encodeKIX, encodeAustraliaPost, encodeJapanPost } from "./encoders/fourstate"
+import { encodeIMb } from "./encoders/imb"
+import { renderPostalSVG } from "./renderers/svg/postal"
+import { svgToDataURI, svgToBase64 } from "./renderers/data-uri"
+import type { PostalBar, PostalSVGOptions } from "./renderers/svg/postal"
+import { InvalidInputError } from "./errors"
 
 /** Height-modulated postal symbologies. */
-export type PostalType = "postnet" | "planet" | "rm4scc" | "kix" | "auspost" | "jppost" | "imb";
+export type PostalType = "postnet" | "planet" | "rm4scc" | "kix" | "auspost" | "jppost" | "imb"
 
 export interface PostalEncodingOptions {
   /** Postal symbology. Default "postnet". */
-  type?: PostalType;
+  type?: PostalType
   /** Australia Post Format Control Code ("11", "59" or "62"). Default "11". */
-  fcc?: string;
+  fcc?: string
   /**
    * Second data field, where the symbology has one:
    * - `imb` — the routing code (0, 5, 9 or 11 digits)
    * - `jppost` — the address portion following the postal code
    */
-  routingCode?: string;
+  routingCode?: string
 }
 
 export interface PostalOptions extends PostalEncodingOptions, PostalSVGOptions {}
@@ -44,25 +39,25 @@ export interface PostalOptions extends PostalEncodingOptions, PostalSVGOptions {
  * heights (`1` tall / `0` short) for POSTNET and PLANET.
  */
 export function encodePostal(text: string, options: PostalEncodingOptions = {}): PostalBar[] {
-  const { type = "postnet", fcc = "11", routingCode = "" } = options;
+  const { type = "postnet", fcc = "11", routingCode = "" } = options
 
   switch (type) {
     case "postnet":
-      return encodePOSTNET(text);
+      return encodePOSTNET(text)
     case "planet":
-      return encodePLANET(text);
+      return encodePLANET(text)
     case "rm4scc":
-      return encodeRM4SCC(text);
+      return encodeRM4SCC(text)
     case "kix":
-      return encodeKIX(text);
+      return encodeKIX(text)
     case "auspost":
-      return encodeAustraliaPost(fcc, text);
+      return encodeAustraliaPost(fcc, text)
     case "jppost":
-      return encodeJapanPost(text, routingCode || undefined);
+      return encodeJapanPost(text, routingCode || undefined)
     case "imb":
-      return encodeIMb(text, routingCode);
+      return encodeIMb(text, routingCode)
     default:
-      throw new InvalidInputError(`Unsupported postal type: ${String(type)}`);
+      throw new InvalidInputError(`Unsupported postal type: ${String(type)}`)
   }
 }
 
@@ -77,17 +72,17 @@ export function encodePostal(text: string, options: PostalEncodingOptions = {}):
  * ```
  */
 export function postal(text: string, options: PostalOptions = {}): string {
-  const { type: _type, fcc: _fcc, routingCode: _routing, ...svgOptions } = options;
-  const bars = encodePostal(text, options);
-  return renderPostalSVG(bars, svgOptions);
+  const { type: _type, fcc: _fcc, routingCode: _routing, ...svgOptions } = options
+  const bars = encodePostal(text, options)
+  return renderPostalSVG(bars, svgOptions)
 }
 
 /** Generate a postal barcode as a data URI */
 export function postalDataURI(text: string, options?: PostalOptions): string {
-  return svgToDataURI(postal(text, options));
+  return svgToDataURI(postal(text, options))
 }
 
 /** Generate a postal barcode as a base64 string */
 export function postalBase64(text: string, options?: PostalOptions): string {
-  return svgToBase64(postal(text, options));
+  return svgToBase64(postal(text, options))
 }

--- a/src/_qrcode.ts
+++ b/src/_qrcode.ts
@@ -2,12 +2,12 @@
  * QR code generation and output functions
  */
 
-import { encodeQR } from "./encoders/qr/index";
-import { renderQRCodeSVG } from "./renderers/svg/qr";
-import { renderText } from "./renderers/text";
-import { svgToDataURI, svgToBase64 } from "./renderers/data-uri";
-import type { QRCodeSVGOptions } from "./renderers/svg/types";
-import type { QRCodeOptions } from "./encoders/qr/types";
+import { encodeQR } from "./encoders/qr/index"
+import { renderQRCodeSVG } from "./renderers/svg/qr"
+import { renderText } from "./renderers/text"
+import { svgToDataURI, svgToBase64 } from "./renderers/data-uri"
+import type { QRCodeSVGOptions } from "./renderers/svg/types"
+import type { QRCodeOptions } from "./encoders/qr/types"
 
 /**
  * Generate a QR code as SVG string
@@ -29,12 +29,12 @@ export function qrcode(text: string, options: QRCodeSVGOptions & QRCodeOptions =
     title,
     desc,
     ...qrOptions
-  } = options;
+  } = options
   // Auto-upgrade EC level when logo is present (logo obscures modules)
   if (logo && !qrOptions.ecLevel) {
-    qrOptions.ecLevel = "H";
+    qrOptions.ecLevel = "H"
   }
-  const matrix = encodeQR(text, qrOptions);
+  const matrix = encodeQR(text, qrOptions)
   return renderQRCodeSVG(matrix, {
     size,
     margin,
@@ -50,27 +50,27 @@ export function qrcode(text: string, options: QRCodeSVGOptions & QRCodeOptions =
     role,
     title,
     desc,
-  });
+  })
 }
 
 /**
  * Generate a QR code as terminal-printable string
  */
 export function qrcodeTerminal(text: string, options?: QRCodeOptions): string {
-  const matrix = encodeQR(text, options);
-  return renderText(matrix);
+  const matrix = encodeQR(text, options)
+  return renderText(matrix)
 }
 
 /**
  * Generate a QR code as data URI
  */
 export function qrcodeDataURI(text: string, options?: QRCodeSVGOptions & QRCodeOptions): string {
-  return svgToDataURI(qrcode(text, options));
+  return svgToDataURI(qrcode(text, options))
 }
 
 /**
  * Generate a QR code as base64 string
  */
 export function qrcodeBase64(text: string, options?: QRCodeSVGOptions & QRCodeOptions): string {
-  return svgToBase64(qrcode(text, options));
+  return svgToBase64(qrcode(text, options))
 }

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2,16 +2,16 @@
  * Shared types for etiket
  */
 
-import type { BarcodeSVGOptions } from "./renderers/svg/types";
-import type { PostalBar } from "./renderers/svg/postal";
-import type { QRCodeOptions } from "./encoders/qr/types";
-import type { MicroQROptions } from "./encoders/qr/micro";
-import type { RMQROptions } from "./encoders/rmqr";
-import type { PDF417Options } from "./encoders/pdf417/index";
-import type { MicroPDF417Options } from "./encoders/micropdf417";
-import type { AztecOptions } from "./encoders/aztec/index";
-import type { MaxiCodeOptions } from "./encoders/maxicode";
-import type { HanXinOptions } from "./encoders/hanxin";
+import type { BarcodeSVGOptions } from "./renderers/svg/types"
+import type { PostalBar } from "./renderers/svg/postal"
+import type { QRCodeOptions } from "./encoders/qr/types"
+import type { MicroQROptions } from "./encoders/qr/micro"
+import type { RMQROptions } from "./encoders/rmqr"
+import type { PDF417Options } from "./encoders/pdf417/index"
+import type { MicroPDF417Options } from "./encoders/micropdf417"
+import type { AztecOptions } from "./encoders/aztec/index"
+import type { MaxiCodeOptions } from "./encoders/maxicode"
+import type { HanXinOptions } from "./encoders/hanxin"
 
 /** Width-modulated linear symbologies rendered by `barcode()`. */
 export type BarcodeType =
@@ -40,15 +40,15 @@ export type BarcodeType =
   | "plessey"
   | "gs1-databar"
   | "gs1-databar-limited"
-  | "gs1-databar-expanded";
+  | "gs1-databar-expanded"
 
 export interface BarcodeEncodingOptions {
-  type?: BarcodeType;
-  msiCheckDigit?: "mod10" | "mod11" | "mod1010" | "mod1110" | "none";
-  code39CheckDigit?: boolean;
-  codabarStart?: string;
-  codabarStop?: string;
-  code128Charset?: "auto" | "A" | "B" | "C";
+  type?: BarcodeType
+  msiCheckDigit?: "mod10" | "mod11" | "mod1010" | "mod1110" | "none"
+  code39CheckDigit?: boolean
+  codabarStart?: string
+  codabarStop?: string
+  code128Charset?: "auto" | "A" | "B" | "C"
 }
 
 export interface BarcodeOptions extends BarcodeEncodingOptions, BarcodeSVGOptions {}
@@ -75,43 +75,43 @@ export type EncodeType =
   | "dotcode"
   | "hanxin"
   | "codablock-f"
-  | "code16k";
+  | "code16k"
 
 export interface EncodeOptions extends Omit<BarcodeEncodingOptions, "type"> {
-  type?: EncodeType;
+  type?: EncodeType
 
   /** Australia Post Format Control Code ("11", "59" or "62"). */
-  fcc?: string;
+  fcc?: string
   /** Second data field for IMb (routing code) and Japan Post (address). */
-  routingCode?: string;
+  routingCode?: string
 
   /** Per-symbology encoder options. */
-  qr?: QRCodeOptions;
-  microqr?: MicroQROptions;
-  rmqr?: RMQROptions;
-  pdf417?: PDF417Options;
-  micropdf417?: MicroPDF417Options;
-  aztec?: AztecOptions;
-  maxicode?: MaxiCodeOptions;
-  hanxin?: HanXinOptions;
-  codablockf?: { columns?: number };
+  qr?: QRCodeOptions
+  microqr?: MicroQROptions
+  rmqr?: RMQROptions
+  pdf417?: PDF417Options
+  micropdf417?: MicroPDF417Options
+  aztec?: AztecOptions
+  maxicode?: MaxiCodeOptions
+  hanxin?: HanXinOptions
+  codablockf?: { columns?: number }
 }
 
 export interface Encode1DResult {
-  type: "1d";
+  type: "1d"
   /** Alternating bar/space widths in modules, starting with a bar. */
-  bars: number[];
+  bars: number[]
 }
 
 export interface Encode2DResult {
-  type: "2d";
-  matrix: boolean[][];
+  type: "2d"
+  matrix: boolean[][]
 }
 
 export interface EncodePostalResult {
-  type: "postal";
+  type: "postal"
   /** 4-state letters, or 1 (tall) / 0 (short) for POSTNET and PLANET. */
-  bars: PostalBar[];
+  bars: PostalBar[]
 }
 
-export type EncodeResult = Encode1DResult | Encode2DResult | EncodePostalResult;
+export type EncodeResult = Encode1DResult | Encode2DResult | EncodePostalResult

--- a/src/aztec.ts
+++ b/src/aztec.ts
@@ -2,8 +2,8 @@
  * Aztec Code-only entry point for tree-shaking
  */
 
-export { aztec } from "./_2d";
-export { encodeAztec } from "./encoders/aztec/index";
-export type { AztecOptions } from "./encoders/aztec/index";
-export { renderMatrixSVG } from "./renderers/svg/matrix";
-export type { MatrixSVGOptions } from "./renderers/svg/matrix";
+export { aztec } from "./_2d"
+export { encodeAztec } from "./encoders/aztec/index"
+export type { AztecOptions } from "./encoders/aztec/index"
+export { renderMatrixSVG } from "./renderers/svg/matrix"
+export type { MatrixSVGOptions } from "./renderers/svg/matrix"

--- a/src/barcode.ts
+++ b/src/barcode.ts
@@ -7,30 +7,30 @@
  * ```
  */
 
-export { barcode, barcodeDataURI, barcodeBase64, encodeBars } from "./_barcode";
-export type { BarcodeType, BarcodeOptions, BarcodeEncodingOptions } from "./_types";
-export type { BarcodeSVGOptions } from "./renderers/svg/types";
+export { barcode, barcodeDataURI, barcodeBase64, encodeBars } from "./_barcode"
+export type { BarcodeType, BarcodeOptions, BarcodeEncodingOptions } from "./_types"
+export type { BarcodeSVGOptions } from "./renderers/svg/types"
 
-export { encodeCode128 } from "./encoders/code128";
-export type { Code128Charset, Code128Options } from "./encoders/code128";
-export { encodeEAN13, encodeEAN8 } from "./encoders/ean";
-export { encodeCode39, encodeCode39Extended } from "./encoders/code39";
-export { encodeCode93, encodeCode93Extended } from "./encoders/code93";
-export { encodeITF, encodeITF14 } from "./encoders/itf";
-export { encodeUPCA, encodeUPCE } from "./encoders/upc";
-export { encodeEAN2, encodeEAN5 } from "./encoders/ean-addon";
-export { encodeCodabar } from "./encoders/codabar";
-export { encodeMSI } from "./encoders/msi";
-export type { MSICheckDigitType } from "./encoders/msi";
-export { encodePharmacode } from "./encoders/pharmacode";
-export { encodeCode11 } from "./encoders/code11";
-export { encodeGS1128 } from "./encoders/gs1-128";
-export { encodeIdentcode, encodeLeitcode } from "./encoders/deutsche-post";
-export { encodePOSTNET, encodePLANET } from "./encoders/postnet";
-export { encodePlessey } from "./encoders/plessey";
+export { encodeCode128 } from "./encoders/code128"
+export type { Code128Charset, Code128Options } from "./encoders/code128"
+export { encodeEAN13, encodeEAN8 } from "./encoders/ean"
+export { encodeCode39, encodeCode39Extended } from "./encoders/code39"
+export { encodeCode93, encodeCode93Extended } from "./encoders/code93"
+export { encodeITF, encodeITF14 } from "./encoders/itf"
+export { encodeUPCA, encodeUPCE } from "./encoders/upc"
+export { encodeEAN2, encodeEAN5 } from "./encoders/ean-addon"
+export { encodeCodabar } from "./encoders/codabar"
+export { encodeMSI } from "./encoders/msi"
+export type { MSICheckDigitType } from "./encoders/msi"
+export { encodePharmacode } from "./encoders/pharmacode"
+export { encodeCode11 } from "./encoders/code11"
+export { encodeGS1128 } from "./encoders/gs1-128"
+export { encodeIdentcode, encodeLeitcode } from "./encoders/deutsche-post"
+export { encodePOSTNET, encodePLANET } from "./encoders/postnet"
+export { encodePlessey } from "./encoders/plessey"
 export {
   encodeGS1DataBarOmni,
   encodeGS1DataBarLimited,
   encodeGS1DataBarExpanded,
-} from "./encoders/gs1-databar";
-export { renderBarcodeSVG } from "./renderers/svg/barcode";
+} from "./encoders/gs1-databar"
+export { renderBarcodeSVG } from "./renderers/svg/barcode"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@
  * `etiket` bin entry — see ./_cli for the command definitions.
  */
 
-import { runMain } from "citty";
-import { main } from "./_cli";
+import { runMain } from "citty"
+import { main } from "./_cli"
 
-runMain(main);
+runMain(main)

--- a/src/datamatrix.ts
+++ b/src/datamatrix.ts
@@ -2,7 +2,7 @@
  * Data Matrix-only entry point for tree-shaking
  */
 
-export { datamatrix, gs1datamatrix } from "./_2d";
-export { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index";
-export { renderMatrixSVG } from "./renderers/svg/matrix";
-export type { MatrixSVGOptions } from "./renderers/svg/matrix";
+export { datamatrix, gs1datamatrix } from "./_2d"
+export { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index"
+export { renderMatrixSVG } from "./renderers/svg/matrix"
+export type { MatrixSVGOptions } from "./renderers/svg/matrix"

--- a/src/encoders/aztec/encoder.ts
+++ b/src/encoders/aztec/encoder.ts
@@ -8,7 +8,7 @@
  * latch (permanent) and shift (single character) transitions as needed.
  */
 
-import { InvalidInputError } from "../../errors";
+import { InvalidInputError } from "../../errors"
 import {
   Mode,
   MODE_BITS,
@@ -17,7 +17,7 @@ import {
   getLatchSequence,
   SHIFT_TO_PUNCT,
   BINARY_SHIFT,
-} from "./tables";
+} from "./tables"
 
 // ---------------------------------------------------------------------------
 // Bit manipulation helpers
@@ -26,7 +26,7 @@ import {
 /** Append a value as `count` bits (MSB first) to a bit array */
 function pushBits(bits: number[], value: number, count: number): void {
   for (let i = count - 1; i >= 0; i--) {
-    bits.push((value >> i) & 1);
+    bits.push((value >> i) & 1)
   }
 }
 
@@ -39,15 +39,15 @@ function pushBits(bits: number[], value: number, count: number): void {
  * Returns an array of { mode, value } options.
  */
 function charModes(char: string): Array<{ mode: Mode; value: number }> {
-  const result: Array<{ mode: Mode; value: number }> = [];
+  const result: Array<{ mode: Mode; value: number }> = []
   for (let m = 0; m <= 4; m++) {
-    const table = CHAR_TABLE[m]!;
-    const val = table[char];
+    const table = CHAR_TABLE[m]!
+    const val = table[char]
     if (val !== undefined) {
-      result.push({ mode: m as Mode, value: val });
+      result.push({ mode: m as Mode, value: val })
     }
   }
-  return result;
+  return result
 }
 
 // ---------------------------------------------------------------------------
@@ -68,120 +68,120 @@ function charModes(char: string): Array<{ mode: Mode; value: number }> {
  */
 export function encodeHighLevel(text: string): number[] {
   if (text.length === 0) {
-    return [];
+    return []
   }
 
-  const bits: number[] = [];
-  let currentMode = Mode.Upper;
-  let i = 0;
+  const bits: number[] = []
+  let currentMode = Mode.Upper
+  let i = 0
 
   while (i < text.length) {
-    const char = text[i]!;
-    const charCode = text.charCodeAt(i);
+    const char = text[i]!
+    const charCode = text.charCodeAt(i)
 
     // --- Check for two-character punctuation pairs ---
     if (i + 1 < text.length) {
-      const pair = text[i]! + text[i + 1]!;
-      const punctPairVal = PUNCT_PAIRS.get(pair);
+      const pair = text[i]! + text[i + 1]!
+      const punctPairVal = PUNCT_PAIRS.get(pair)
       if (punctPairVal !== undefined) {
         if (currentMode === Mode.Punct) {
-          pushBits(bits, punctPairVal, MODE_BITS[Mode.Punct]);
+          pushBits(bits, punctPairVal, MODE_BITS[Mode.Punct])
         } else {
           // Shift to Punct for the pair
-          const shiftCode = SHIFT_TO_PUNCT[currentMode];
+          const shiftCode = SHIFT_TO_PUNCT[currentMode]
           if (shiftCode !== undefined) {
-            pushBits(bits, shiftCode, MODE_BITS[currentMode]);
-            pushBits(bits, punctPairVal, MODE_BITS[Mode.Punct]);
+            pushBits(bits, shiftCode, MODE_BITS[currentMode])
+            pushBits(bits, punctPairVal, MODE_BITS[Mode.Punct])
           } else {
             // Must latch to a mode that supports shift-to-punct, then shift
-            const latch = getLatchSequence(currentMode, Mode.Upper);
-            emitLatch(bits, latch);
-            currentMode = Mode.Upper;
-            pushBits(bits, SHIFT_TO_PUNCT[Mode.Upper]!, MODE_BITS[Mode.Upper]);
-            pushBits(bits, punctPairVal, MODE_BITS[Mode.Punct]);
+            const latch = getLatchSequence(currentMode, Mode.Upper)
+            emitLatch(bits, latch)
+            currentMode = Mode.Upper
+            pushBits(bits, SHIFT_TO_PUNCT[Mode.Upper]!, MODE_BITS[Mode.Upper])
+            pushBits(bits, punctPairVal, MODE_BITS[Mode.Punct])
           }
         }
-        i += 2;
-        continue;
+        i += 2
+        continue
       }
     }
 
     // --- Try encoding in the current mode ---
-    const currentTable = CHAR_TABLE[currentMode]!;
-    const directVal = currentTable[char];
+    const currentTable = CHAR_TABLE[currentMode]!
+    const directVal = currentTable[char]
     if (directVal !== undefined) {
-      pushBits(bits, directVal, MODE_BITS[currentMode]);
-      i++;
-      continue;
+      pushBits(bits, directVal, MODE_BITS[currentMode])
+      i++
+      continue
     }
 
     // --- Character not in current mode — find best alternative ---
-    const options = charModes(char);
+    const options = charModes(char)
 
     if (options.length > 0) {
       // Determine: should we shift or latch?
-      const bestOption = selectBestTransition(currentMode, options, text, i);
+      const bestOption = selectBestTransition(currentMode, options, text, i)
 
       if (bestOption.shift) {
         // Emit shift code, then character in the shifted mode
         if (bestOption.mode === Mode.Punct) {
-          const shiftCode = SHIFT_TO_PUNCT[currentMode];
+          const shiftCode = SHIFT_TO_PUNCT[currentMode]
           if (shiftCode !== undefined) {
-            pushBits(bits, shiftCode, MODE_BITS[currentMode]);
-            pushBits(bits, bestOption.value, MODE_BITS[Mode.Punct]);
-            i++;
-            continue;
+            pushBits(bits, shiftCode, MODE_BITS[currentMode])
+            pushBits(bits, bestOption.value, MODE_BITS[Mode.Punct])
+            i++
+            continue
           }
         }
         // Shift from Lower to Upper
         if (currentMode === Mode.Lower && bestOption.mode === Mode.Upper) {
-          pushBits(bits, 28, MODE_BITS[Mode.Lower]); // shift to upper
-          pushBits(bits, bestOption.value, MODE_BITS[Mode.Upper]);
-          i++;
-          continue;
+          pushBits(bits, 28, MODE_BITS[Mode.Lower]) // shift to upper
+          pushBits(bits, bestOption.value, MODE_BITS[Mode.Upper])
+          i++
+          continue
         }
         // No direct shift available — fall through to latch
       }
 
       // Latch to the target mode
-      const latch = getLatchSequence(currentMode, bestOption.mode);
-      emitLatch(bits, latch);
-      currentMode = bestOption.mode;
-      pushBits(bits, bestOption.value, MODE_BITS[currentMode]);
-      i++;
-      continue;
+      const latch = getLatchSequence(currentMode, bestOption.mode)
+      emitLatch(bits, latch)
+      currentMode = bestOption.mode
+      pushBits(bits, bestOption.value, MODE_BITS[currentMode])
+      i++
+      continue
     }
 
     // --- Character not in any text mode — use binary shift ---
     if (charCode > 255) {
       throw new InvalidInputError(
         `Aztec Code does not support character: "${char}" (U+${charCode.toString(16).padStart(4, "0")})`,
-      );
+      )
     }
 
     // Collect consecutive bytes that require binary encoding
-    const binaryStart = i;
+    const binaryStart = i
     while (i < text.length) {
-      const c = text[i]!;
+      const c = text[i]!
       if (charModes(c).length > 0) {
         // Check if it's only in a mode far from current — might be cheaper to stay binary
         // For simplicity, break out and let the text encoder handle it
-        break;
+        break
       }
       if (text.charCodeAt(i) > 255) {
         throw new InvalidInputError(
           `Aztec Code does not support character: "${text[i]}" (U+${text.charCodeAt(i).toString(16).padStart(4, "0")})`,
-        );
+        )
       }
-      i++;
+      i++
     }
 
-    const binaryLen = i - binaryStart;
-    emitBinaryShift(bits, text, binaryStart, binaryLen, currentMode);
-    continue;
+    const binaryLen = i - binaryStart
+    emitBinaryShift(bits, text, binaryStart, binaryLen, currentMode)
+    continue
   }
 
-  return bits;
+  return bits
 }
 
 // ---------------------------------------------------------------------------
@@ -189,9 +189,9 @@ export function encodeHighLevel(text: string): number[] {
 // ---------------------------------------------------------------------------
 
 interface TransitionChoice {
-  mode: Mode;
-  value: number;
-  shift: boolean;
+  mode: Mode
+  value: number
+  shift: boolean
 }
 
 /**
@@ -206,42 +206,42 @@ function selectBestTransition(
   pos: number,
 ): TransitionChoice {
   // Check if shift to Punct makes sense (single punctuation character)
-  const punctOption = options.find((o) => o.mode === Mode.Punct);
+  const punctOption = options.find((o) => o.mode === Mode.Punct)
   if (punctOption && SHIFT_TO_PUNCT[currentMode] !== undefined) {
     // Look ahead: if next char is NOT in Punct mode, shift is better than latch
-    const nextChar = pos + 1 < text.length ? text[pos + 1]! : undefined;
-    const nextInPunct = nextChar !== undefined && CHAR_TABLE[Mode.Punct]![nextChar] !== undefined;
+    const nextChar = pos + 1 < text.length ? text[pos + 1]! : undefined
+    const nextInPunct = nextChar !== undefined && CHAR_TABLE[Mode.Punct]![nextChar] !== undefined
     if (!nextInPunct) {
-      return { mode: Mode.Punct, value: punctOption.value, shift: true };
+      return { mode: Mode.Punct, value: punctOption.value, shift: true }
     }
   }
 
   // Check if shift from Lower to Upper makes sense
   if (currentMode === Mode.Lower) {
-    const upperOption = options.find((o) => o.mode === Mode.Upper);
+    const upperOption = options.find((o) => o.mode === Mode.Upper)
     if (upperOption) {
-      const nextChar = pos + 1 < text.length ? text[pos + 1]! : undefined;
-      const nextInUpper = nextChar !== undefined && CHAR_TABLE[Mode.Upper]![nextChar] !== undefined;
-      const nextInLower = nextChar !== undefined && CHAR_TABLE[Mode.Lower]![nextChar] !== undefined;
+      const nextChar = pos + 1 < text.length ? text[pos + 1]! : undefined
+      const nextInUpper = nextChar !== undefined && CHAR_TABLE[Mode.Upper]![nextChar] !== undefined
+      const nextInLower = nextChar !== undefined && CHAR_TABLE[Mode.Lower]![nextChar] !== undefined
       if (!nextInUpper || nextInLower) {
-        return { mode: Mode.Upper, value: upperOption.value, shift: true };
+        return { mode: Mode.Upper, value: upperOption.value, shift: true }
       }
     }
   }
 
   // Find the option with the cheapest latch
-  let bestCost = Infinity;
-  let best: TransitionChoice = { mode: options[0]!.mode, value: options[0]!.value, shift: false };
+  let bestCost = Infinity
+  let best: TransitionChoice = { mode: options[0]!.mode, value: options[0]!.value, shift: false }
 
   for (const opt of options) {
-    const latch = getLatchSequence(currentMode, opt.mode);
+    const latch = getLatchSequence(currentMode, opt.mode)
     if (latch.totalBits < bestCost) {
-      bestCost = latch.totalBits;
-      best = { mode: opt.mode, value: opt.value, shift: false };
+      bestCost = latch.totalBits
+      best = { mode: opt.mode, value: opt.value, shift: false }
     }
   }
 
-  return best;
+  return best
 }
 
 /** Emit latch codes into the bit stream */
@@ -250,9 +250,9 @@ function emitLatch(
   latch: { codes: number[]; modes: Mode[]; totalBits: number },
 ): void {
   for (let j = 0; j < latch.codes.length; j++) {
-    const code = latch.codes[j]!;
-    const mode = latch.modes[j]!;
-    pushBits(bits, code, MODE_BITS[mode]);
+    const code = latch.codes[j]!
+    const mode = latch.modes[j]!
+    pushBits(bits, code, MODE_BITS[mode])
   }
 }
 
@@ -276,40 +276,40 @@ function emitBinaryShift(
   length: number,
   currentMode: Mode,
 ): void {
-  let remaining = length;
-  let pos = start;
+  let remaining = length
+  let pos = start
 
   while (remaining > 0) {
     // A binary shift run carries at most 2078 bytes: 31 encodable in the
     // 5-bit length field, or 31 + 2047 via the extended 11-bit field.
-    const chunk = Math.min(remaining, 2078);
+    const chunk = Math.min(remaining, 2078)
 
     // Emit binary shift intro code
-    const bs = BINARY_SHIFT[currentMode];
+    const bs = BINARY_SHIFT[currentMode]
     if (bs) {
-      pushBits(bits, bs.code, bs.bits);
+      pushBits(bits, bs.code, bs.bits)
     } else {
       // Digit mode: need to latch to Upper first (shouldn't happen in practice
       // since we handle Digit's BS code in the table)
-      pushBits(bits, 15, 4);
+      pushBits(bits, 15, 4)
     }
 
     // Emit length: 1-31 fits the 5-bit field directly; longer runs signal 0
     // there and carry (length - 31) in a further 11 bits (ISO/IEC 24778).
     if (chunk <= 31) {
-      pushBits(bits, chunk, 5);
+      pushBits(bits, chunk, 5)
     } else {
-      pushBits(bits, 0, 5);
-      pushBits(bits, chunk - 31, 11);
+      pushBits(bits, 0, 5)
+      pushBits(bits, chunk - 31, 11)
     }
 
     // Emit raw bytes
     for (let j = 0; j < chunk; j++) {
-      pushBits(bits, text.charCodeAt(pos + j), 8);
+      pushBits(bits, text.charCodeAt(pos + j), 8)
     }
 
-    pos += chunk;
-    remaining -= chunk;
+    pos += chunk
+    remaining -= chunk
   }
 }
 
@@ -319,19 +319,19 @@ function emitBinaryShift(
  * padding bits should be 1 to avoid all-zero codewords).
  */
 export function bitsToCodewords(bits: number[], wordSize: number): number[] {
-  const codewords: number[] = [];
-  let i = 0;
+  const codewords: number[] = []
+  let i = 0
 
   while (i < bits.length) {
-    let value = 0;
+    let value = 0
     for (let b = 0; b < wordSize; b++) {
-      value = (value << 1) | (i < bits.length ? bits[i]! : 1);
-      i++;
+      value = (value << 1) | (i < bits.length ? bits[i]! : 1)
+      i++
     }
-    codewords.push(value);
+    codewords.push(value)
   }
 
-  return codewords;
+  return codewords
 }
 
 /**
@@ -347,38 +347,38 @@ export function bitsToCodewords(bits: number[], wordSize: number): number[] {
  * Matches the ZXing reference implementation exactly.
  */
 export function stuffBits(bits: number[], wordSize: number): number[] {
-  const result: number[] = [];
-  const n = bits.length;
-  const mask = (1 << wordSize) - 2; // e.g., for ws=6: 0b111110
+  const result: number[] = []
+  const n = bits.length
+  const mask = (1 << wordSize) - 2 // e.g., for ws=6: 0b111110
 
   for (let i = 0; i < n; i += wordSize) {
-    let word = 0;
+    let word = 0
     for (let j = 0; j < wordSize; j++) {
       if (i + j >= n || bits[i + j]!) {
-        word |= 1 << (wordSize - 1 - j);
+        word |= 1 << (wordSize - 1 - j)
       }
     }
 
     if ((word & mask) === mask) {
       // Top (wordSize-1) bits are all 1: output word with last bit forced to 0
-      pushBitsFromValue(result, word & mask, wordSize);
-      i--; // re-process the dropped last bit
+      pushBitsFromValue(result, word & mask, wordSize)
+      i-- // re-process the dropped last bit
     } else if ((word & mask) === 0) {
       // Top (wordSize-1) bits are all 0: output word with last bit forced to 1
-      pushBitsFromValue(result, word | 1, wordSize);
-      i--; // re-process the dropped last bit
+      pushBitsFromValue(result, word | 1, wordSize)
+      i-- // re-process the dropped last bit
     } else {
-      pushBitsFromValue(result, word, wordSize);
+      pushBitsFromValue(result, word, wordSize)
     }
   }
 
-  return result;
+  return result
 }
 
 /** Push a value as wordSize bits (MSB first) into a result array */
 function pushBitsFromValue(result: number[], value: number, wordSize: number): void {
   for (let b = wordSize - 1; b >= 0; b--) {
-    result.push((value >> b) & 1);
+    result.push((value >> b) & 1)
   }
 }
 
@@ -395,14 +395,14 @@ function pushBitsFromValue(result: number[], value: number, wordSize: number): v
  * @returns Array of totalWords codewords, with data in first positions
  */
 export function bitsToWords(stuffedBits: number[], wordSize: number, totalWords: number): number[] {
-  const message = Array.from<number>({ length: totalWords }).fill(0);
-  const n = Math.floor(stuffedBits.length / wordSize);
+  const message = Array.from<number>({ length: totalWords }).fill(0)
+  const n = Math.floor(stuffedBits.length / wordSize)
   for (let i = 0; i < n; i++) {
-    let value = 0;
+    let value = 0
     for (let j = 0; j < wordSize; j++) {
-      value |= (stuffedBits[i * wordSize + j]! ? 1 : 0) << (wordSize - j - 1);
+      value |= (stuffedBits[i * wordSize + j]! ? 1 : 0) << (wordSize - j - 1)
     }
-    message[i] = value;
+    message[i] = value
   }
-  return message;
+  return message
 }

--- a/src/encoders/aztec/index.ts
+++ b/src/encoders/aztec/index.ts
@@ -13,14 +13,10 @@
  * Implementation follows the ZXing reference encoder for correctness.
  */
 
-import { CapacityError, InvalidInputError } from "../../errors";
-import { getWordSize, getModuleCount, getTotalBitCapacity, getBaseMatrixSize } from "./tables";
-import { encodeHighLevel, stuffBits } from "./encoder";
-import {
-  generateCheckWords,
-  encodeCompactModeMessage,
-  encodeFullModeMessage,
-} from "./reed-solomon";
+import { CapacityError, InvalidInputError } from "../../errors"
+import { getWordSize, getModuleCount, getTotalBitCapacity, getBaseMatrixSize } from "./tables"
+import { encodeHighLevel, stuffBits } from "./encoder"
+import { generateCheckWords, encodeCompactModeMessage, encodeFullModeMessage } from "./reed-solomon"
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -28,11 +24,11 @@ import {
 
 export interface AztecOptions {
   /** Error correction percentage (default 23, meaning 23%) */
-  ecPercent?: number;
+  ecPercent?: number
   /** Force a specific number of layers (1-4 compact, 1-32 full) */
-  layers?: number;
+  layers?: number
   /** Force compact mode (true) or full-range mode (false) */
-  compact?: boolean;
+  compact?: boolean
 }
 
 /**
@@ -44,17 +40,17 @@ export interface AztecOptions {
  */
 export function encodeAztec(text: string, options: AztecOptions = {}): boolean[][] {
   if (text.length === 0) {
-    throw new InvalidInputError("Aztec Code: input text must not be empty");
+    throw new InvalidInputError("Aztec Code: input text must not be empty")
   }
 
-  const ecPercent = options.ecPercent ?? 23;
+  const ecPercent = options.ecPercent ?? 23
 
   // Step 1: Encode text into a bit stream
-  const dataBits = encodeHighLevel(text);
+  const dataBits = encodeHighLevel(text)
 
   // Step 2: Compute minimum EC bits
-  const eccBits = Math.floor((dataBits.length * ecPercent) / 100) + 11;
-  const totalSizeBits = dataBits.length + eccBits;
+  const eccBits = Math.floor((dataBits.length * ecPercent) / 100) + 11
+  const totalSizeBits = dataBits.length + eccBits
 
   // Step 3: Select symbol size
   const { layers, compact, wordSize, totalBitsInLayer, stuffedBits } = selectSize(
@@ -62,43 +58,43 @@ export function encodeAztec(text: string, options: AztecOptions = {}): boolean[]
     totalSizeBits,
     eccBits,
     options,
-  );
+  )
 
   // Step 4: Generate check words (data + EC as a single bit stream)
-  const messageBits = generateCheckWords(stuffedBits, totalBitsInLayer, wordSize);
+  const messageBits = generateCheckWords(stuffedBits, totalBitsInLayer, wordSize)
 
   // Step 5: Compute messageSizeInWords for the mode message
-  const messageSizeInWords = Math.floor(stuffedBits.length / wordSize);
+  const messageSizeInWords = Math.floor(stuffedBits.length / wordSize)
 
   // Step 6: Build the mode message
   const modeMessage = compact
     ? encodeCompactModeMessage(layers, messageSizeInWords)
-    : encodeFullModeMessage(layers, messageSizeInWords);
+    : encodeFullModeMessage(layers, messageSizeInWords)
 
   // Step 7: Build the alignment map and matrix
-  const baseMatrixSize = getBaseMatrixSize(layers, compact);
-  const matrixSize = getModuleCount(layers, compact);
+  const baseMatrixSize = getBaseMatrixSize(layers, compact)
+  const matrixSize = getModuleCount(layers, compact)
 
-  const alignmentMap = buildAlignmentMap(baseMatrixSize, matrixSize, compact);
+  const alignmentMap = buildAlignmentMap(baseMatrixSize, matrixSize, compact)
 
   // Step 8: Create the matrix and place data
-  const matrix = createBoolMatrix(matrixSize);
+  const matrix = createBoolMatrix(matrixSize)
 
   // Place data layers (done first; function patterns are drawn on top)
-  placeDataLayers(matrix, messageBits, layers, compact, baseMatrixSize, alignmentMap);
+  placeDataLayers(matrix, messageBits, layers, compact, baseMatrixSize, alignmentMap)
 
   // Draw mode message around the core
-  drawModeMessage(matrix, modeMessage, compact, matrixSize);
+  drawModeMessage(matrix, modeMessage, compact, matrixSize)
 
   // Draw bullseye and orientation marks (drawn last, on top of everything)
-  drawBullsEye(matrix, Math.floor(matrixSize / 2), compact ? 5 : 7);
+  drawBullsEye(matrix, Math.floor(matrixSize / 2), compact ? 5 : 7)
 
   // Draw reference grid for full-range symbols
   if (!compact) {
-    drawReferenceGrid(matrix, baseMatrixSize, matrixSize);
+    drawReferenceGrid(matrix, baseMatrixSize, matrixSize)
   }
 
-  return matrix;
+  return matrix
 }
 
 // ---------------------------------------------------------------------------
@@ -106,11 +102,11 @@ export function encodeAztec(text: string, options: AztecOptions = {}): boolean[]
 // ---------------------------------------------------------------------------
 
 interface SizeResult {
-  layers: number;
-  compact: boolean;
-  wordSize: number;
-  totalBitsInLayer: number;
-  stuffedBits: number[];
+  layers: number
+  compact: boolean
+  wordSize: number
+  totalBitsInLayer: number
+  stuffedBits: number[]
 }
 
 /**
@@ -123,62 +119,58 @@ function selectSize(
   eccBits: number,
   options: AztecOptions,
 ): SizeResult {
-  const MAX_NB_BITS = 32;
+  const MAX_NB_BITS = 32
 
   if (options.layers !== undefined) {
-    const compact = options.compact ?? options.layers <= 4;
-    const layers = options.layers;
-    const totalBitsInLayer = getTotalBitCapacity(layers, compact);
-    const wordSize = getWordSize(layers);
-    const usableBitsInLayers = totalBitsInLayer - (totalBitsInLayer % wordSize);
-    const stuffedBits = stuffBits(dataBits, wordSize);
+    const compact = options.compact ?? options.layers <= 4
+    const layers = options.layers
+    const totalBitsInLayer = getTotalBitCapacity(layers, compact)
+    const wordSize = getWordSize(layers)
+    const usableBitsInLayers = totalBitsInLayer - (totalBitsInLayer % wordSize)
+    const stuffedBits = stuffBits(dataBits, wordSize)
     if (stuffedBits.length + eccBits > usableBitsInLayers) {
       throw new CapacityError(
         `Aztec Code: data exceeds capacity of ${compact ? "compact" : "full"} ${layers}-layer symbol`,
-      );
+      )
     }
     if (compact && stuffedBits.length > wordSize * 64) {
-      throw new CapacityError(
-        `Aztec Code: data exceeds capacity of compact ${layers}-layer symbol`,
-      );
+      throw new CapacityError(`Aztec Code: data exceeds capacity of compact ${layers}-layer symbol`)
     }
-    return { layers, compact, wordSize, totalBitsInLayer, stuffedBits };
+    return { layers, compact, wordSize, totalBitsInLayer, stuffedBits }
   }
 
-  let wordSize = 0;
-  let stuffedBits: number[] | null = null;
+  let wordSize = 0
+  let stuffedBits: number[] | null = null
 
   for (let i = 0; ; i++) {
     if (i > MAX_NB_BITS) {
-      throw new CapacityError(
-        `Aztec Code: data (${dataBits.length} bits) exceeds maximum capacity`,
-      );
+      throw new CapacityError(`Aztec Code: data (${dataBits.length} bits) exceeds maximum capacity`)
     }
 
-    const compact = i <= 3;
-    const layers = compact ? i + 1 : i;
-    const totalBitsInLayer = getTotalBitCapacity(layers, compact);
+    const compact = i <= 3
+    const layers = compact ? i + 1 : i
+    const totalBitsInLayer = getTotalBitCapacity(layers, compact)
 
     if (totalSizeBits > totalBitsInLayer) {
-      continue;
+      continue
     }
 
-    const newWordSize = getWordSize(layers);
+    const newWordSize = getWordSize(layers)
     if (stuffedBits === null || wordSize !== newWordSize) {
-      wordSize = newWordSize;
-      stuffedBits = stuffBits(dataBits, wordSize);
+      wordSize = newWordSize
+      stuffedBits = stuffBits(dataBits, wordSize)
     }
 
-    const usableBitsInLayers = totalBitsInLayer - (totalBitsInLayer % wordSize);
+    const usableBitsInLayers = totalBitsInLayer - (totalBitsInLayer % wordSize)
 
     if (compact && stuffedBits.length > wordSize * 64) {
-      continue;
+      continue
     }
 
     if (stuffedBits.length + eccBits <= usableBitsInLayers) {
       // Check if compact is explicitly excluded
-      if (compact && options.compact === false) continue;
-      if (!compact && options.compact === true) continue;
+      if (compact && options.compact === false) continue
+      if (!compact && options.compact === true) continue
 
       return {
         layers,
@@ -186,7 +178,7 @@ function selectSize(
         wordSize,
         totalBitsInLayer,
         stuffedBits,
-      };
+      }
     }
   }
 }
@@ -197,7 +189,7 @@ function selectSize(
 
 /** Create a boolean matrix initialized to all false */
 function createBoolMatrix(size: number): boolean[][] {
-  return Array.from({ length: size }, () => Array.from<boolean>({ length: size }).fill(false));
+  return Array.from({ length: size }, () => Array.from<boolean>({ length: size }).fill(false))
 }
 
 // ---------------------------------------------------------------------------
@@ -213,24 +205,24 @@ function createBoolMatrix(size: number): boolean[][] {
  * from the center, which shifts coordinate positions.
  */
 function buildAlignmentMap(baseMatrixSize: number, matrixSize: number, compact: boolean): number[] {
-  const alignmentMap = Array.from<number>({ length: baseMatrixSize });
+  const alignmentMap = Array.from<number>({ length: baseMatrixSize })
 
   if (compact) {
     for (let i = 0; i < baseMatrixSize; i++) {
-      alignmentMap[i] = i;
+      alignmentMap[i] = i
     }
   } else {
-    const origCenter = Math.floor(baseMatrixSize / 2);
-    const center = Math.floor(matrixSize / 2);
+    const origCenter = Math.floor(baseMatrixSize / 2)
+    const center = Math.floor(matrixSize / 2)
 
     for (let i = 0; i < origCenter; i++) {
-      const newOffset = i + Math.floor(i / 15);
-      alignmentMap[origCenter - i - 1] = center - newOffset - 1;
-      alignmentMap[origCenter + i] = center + newOffset + 1;
+      const newOffset = i + Math.floor(i / 15)
+      alignmentMap[origCenter - i - 1] = center - newOffset - 1
+      alignmentMap[origCenter + i] = center + newOffset + 1
     }
   }
 
-  return alignmentMap;
+  return alignmentMap
 }
 
 // ---------------------------------------------------------------------------
@@ -256,41 +248,41 @@ function placeDataLayers(
   baseMatrixSize: number,
   alignmentMap: number[],
 ): void {
-  let rowOffset = 0;
+  let rowOffset = 0
 
   for (let i = 0; i < layers; i++) {
-    const rowSize = (layers - i) * 4 + (compact ? 9 : 12);
+    const rowSize = (layers - i) * 4 + (compact ? 9 : 12)
 
     for (let j = 0; j < rowSize; j++) {
-      const columnOffset = j * 2;
+      const columnOffset = j * 2
 
       for (let k = 0; k < 2; k++) {
         // ZXing: set(x, y) where x=col, y=row -> matrix[y][x] = matrix[row][col]
         // Top side: set(alignmentMap[i*2+k], alignmentMap[i*2+j])
         if (messageBits[rowOffset + columnOffset + k]) {
-          matrix[alignmentMap[i * 2 + j]!]![alignmentMap[i * 2 + k]!] = true;
+          matrix[alignmentMap[i * 2 + j]!]![alignmentMap[i * 2 + k]!] = true
         }
 
         // Right side: set(alignmentMap[i*2+j], alignmentMap[base-1-i*2-k])
         if (messageBits[rowOffset + rowSize * 2 + columnOffset + k]) {
-          matrix[alignmentMap[baseMatrixSize - 1 - i * 2 - k]!]![alignmentMap[i * 2 + j]!] = true;
+          matrix[alignmentMap[baseMatrixSize - 1 - i * 2 - k]!]![alignmentMap[i * 2 + j]!] = true
         }
 
         // Bottom side: set(alignmentMap[base-1-i*2-k], alignmentMap[base-1-i*2-j])
         if (messageBits[rowOffset + rowSize * 4 + columnOffset + k]) {
           matrix[alignmentMap[baseMatrixSize - 1 - i * 2 - j]!]![
             alignmentMap[baseMatrixSize - 1 - i * 2 - k]!
-          ] = true;
+          ] = true
         }
 
         // Left side: set(alignmentMap[base-1-i*2-j], alignmentMap[i*2+k])
         if (messageBits[rowOffset + rowSize * 6 + columnOffset + k]) {
-          matrix[alignmentMap[i * 2 + k]!]![alignmentMap[baseMatrixSize - 1 - i * 2 - j]!] = true;
+          matrix[alignmentMap[i * 2 + k]!]![alignmentMap[baseMatrixSize - 1 - i * 2 - j]!] = true
         }
       }
     }
 
-    rowOffset += rowSize * 8;
+    rowOffset += rowSize * 8
   }
 }
 
@@ -315,47 +307,47 @@ function drawModeMessage(
   compact: boolean,
   matrixSize: number,
 ): void {
-  const center = Math.floor(matrixSize / 2);
+  const center = Math.floor(matrixSize / 2)
 
   // ZXing: set(x, y) -> matrix[y][x] (row=y, col=x)
   if (compact) {
     for (let i = 0; i < 7; i++) {
-      const offset = center - 3 + i;
+      const offset = center - 3 + i
       // set(offset, center-5) -> matrix[center-5][offset]
       if (modeMessage[i]) {
-        matrix[center - 5]![offset] = true;
+        matrix[center - 5]![offset] = true
       }
       // set(center+5, offset) -> matrix[offset][center+5]
       if (modeMessage[i + 7]) {
-        matrix[offset]![center + 5] = true;
+        matrix[offset]![center + 5] = true
       }
       // set(offset, center+5) -> matrix[center+5][offset]
       if (modeMessage[20 - i]) {
-        matrix[center + 5]![offset] = true;
+        matrix[center + 5]![offset] = true
       }
       // set(center-5, offset) -> matrix[offset][center-5]
       if (modeMessage[27 - i]) {
-        matrix[offset]![center - 5] = true;
+        matrix[offset]![center - 5] = true
       }
     }
   } else {
     for (let i = 0; i < 10; i++) {
-      const offset = center - 5 + i + Math.floor(i / 5);
+      const offset = center - 5 + i + Math.floor(i / 5)
       // set(offset, center-7) -> matrix[center-7][offset]
       if (modeMessage[i]) {
-        matrix[center - 7]![offset] = true;
+        matrix[center - 7]![offset] = true
       }
       // set(center+7, offset) -> matrix[offset][center+7]
       if (modeMessage[i + 10]) {
-        matrix[offset]![center + 7] = true;
+        matrix[offset]![center + 7] = true
       }
       // set(offset, center+7) -> matrix[center+7][offset]
       if (modeMessage[29 - i]) {
-        matrix[center + 7]![offset] = true;
+        matrix[center + 7]![offset] = true
       }
       // set(center-7, offset) -> matrix[offset][center-7]
       if (modeMessage[39 - i]) {
-        matrix[offset]![center - 7] = true;
+        matrix[offset]![center - 7] = true
       }
     }
   }
@@ -385,30 +377,30 @@ function drawBullsEye(matrix: boolean[][], center: number, size: number): void {
   for (let i = 0; i < size; i += 2) {
     for (let j = center - i; j <= center + i; j++) {
       // set(j, center-i) -> matrix[center-i][j]
-      matrix[center - i]![j] = true;
+      matrix[center - i]![j] = true
       // set(j, center+i) -> matrix[center+i][j]
-      matrix[center + i]![j] = true;
+      matrix[center + i]![j] = true
       // set(center-i, j) -> matrix[j][center-i]
-      matrix[j]![center - i] = true;
+      matrix[j]![center - i] = true
       // set(center+i, j) -> matrix[j][center+i]
-      matrix[j]![center + i] = true;
+      matrix[j]![center + i] = true
     }
   }
 
   // Orientation marks — 6 dark modules that create an asymmetric pattern.
   // ZXing: set(x, y) -> matrix[y][x]
   // set(center-size, center-size) -> matrix[center-size][center-size]
-  matrix[center - size]![center - size] = true;
+  matrix[center - size]![center - size] = true
   // set(center-size+1, center-size) -> matrix[center-size][center-size+1]
-  matrix[center - size]![center - size + 1] = true;
+  matrix[center - size]![center - size + 1] = true
   // set(center-size, center-size+1) -> matrix[center-size+1][center-size]
-  matrix[center - size + 1]![center - size] = true;
+  matrix[center - size + 1]![center - size] = true
   // set(center+size, center-size) -> matrix[center-size][center+size]
-  matrix[center - size]![center + size] = true;
+  matrix[center - size]![center + size] = true
   // set(center+size, center-size+1) -> matrix[center-size+1][center+size]
-  matrix[center - size + 1]![center + size] = true;
+  matrix[center - size + 1]![center + size] = true
   // set(center+size, center+size-1) -> matrix[center+size-1][center+size]
-  matrix[center + size - 1]![center + size] = true;
+  matrix[center + size - 1]![center + size] = true
 }
 
 // ---------------------------------------------------------------------------
@@ -427,17 +419,17 @@ function drawBullsEye(matrix: boolean[][], center: number, size: number): void {
  *     draw alternating modules on rows/cols at center +/- j
  */
 function drawReferenceGrid(matrix: boolean[][], baseMatrixSize: number, matrixSize: number): void {
-  const center = Math.floor(matrixSize / 2);
-  const centerParity = center & 1;
+  const center = Math.floor(matrixSize / 2)
+  const centerParity = center & 1
 
   for (let i = 0, j = 0; i < Math.floor(baseMatrixSize / 2) - 1; i += 15, j += 16) {
     for (let k = centerParity; k < matrixSize; k += 2) {
       // Horizontal lines at rows center-j and center+j
-      matrix[center - j]![k] = true;
-      matrix[center + j]![k] = true;
+      matrix[center - j]![k] = true
+      matrix[center + j]![k] = true
       // Vertical lines at cols center-j and center+j
-      matrix[k]![center - j] = true;
-      matrix[k]![center + j] = true;
+      matrix[k]![center - j] = true
+      matrix[k]![center + j] = true
     }
   }
 }

--- a/src/encoders/aztec/reed-solomon.ts
+++ b/src/encoders/aztec/reed-solomon.ts
@@ -17,58 +17,58 @@
  *   GF(4096): x^12 + x^6 + x^4 + x + 1        (0x1069)
  */
 
-import { GF_POLY } from "./tables";
+import { GF_POLY } from "./tables"
 
 // ---------------------------------------------------------------------------
 // Galois Field arithmetic
 // ---------------------------------------------------------------------------
 
 interface GFTables {
-  exp: number[];
-  log: number[];
-  size: number; // 2^wordSize
-  max: number; // size - 1
+  exp: number[]
+  log: number[]
+  size: number // 2^wordSize
+  max: number // size - 1
 }
 
 /** Cache of initialized GF tables keyed by word size */
-const gfCache = new Map<number, GFTables>();
+const gfCache = new Map<number, GFTables>()
 
 /** Initialize or retrieve GF lookup tables for a given word size */
 function getGF(wordSize: number): GFTables {
-  const cached = gfCache.get(wordSize);
-  if (cached) return cached;
+  const cached = gfCache.get(wordSize)
+  if (cached) return cached
 
-  const poly = GF_POLY[wordSize];
+  const poly = GF_POLY[wordSize]
   if (poly === undefined) {
-    throw new Error(`No primitive polynomial defined for GF(2^${wordSize})`);
+    throw new Error(`No primitive polynomial defined for GF(2^${wordSize})`)
   }
 
-  const size = 1 << wordSize;
-  const max = size - 1;
-  const exp = Array.from<number>({ length: size * 2 });
-  const log = Array.from<number>({ length: size }).fill(0);
+  const size = 1 << wordSize
+  const max = size - 1
+  const exp = Array.from<number>({ length: size * 2 })
+  const log = Array.from<number>({ length: size }).fill(0)
 
-  let x = 1;
+  let x = 1
   for (let i = 0; i < max; i++) {
-    exp[i] = x;
-    log[x] = i;
-    x = x << 1;
-    if (x >= size) x ^= poly;
+    exp[i] = x
+    log[x] = i
+    x = x << 1
+    if (x >= size) x ^= poly
   }
   // Extend exp table for easier modular arithmetic
   for (let i = max; i < size * 2; i++) {
-    exp[i] = exp[i - max]!;
+    exp[i] = exp[i - max]!
   }
 
-  const tables: GFTables = { exp, log, size, max };
-  gfCache.set(wordSize, tables);
-  return tables;
+  const tables: GFTables = { exp, log, size, max }
+  gfCache.set(wordSize, tables)
+  return tables
 }
 
 /** Multiply two GF elements */
 function gfMul(gf: GFTables, a: number, b: number): number {
-  if (a === 0 || b === 0) return 0;
-  return gf.exp[(gf.log[a]! + gf.log[b]!) % gf.max]!;
+  if (a === 0 || b === 0) return 0
+  return gf.exp[(gf.log[a]! + gf.log[b]!) % gf.max]!
 }
 
 // ---------------------------------------------------------------------------
@@ -84,37 +84,37 @@ function gfMul(gf: GFTables, a: number, b: number): number {
  * @returns Array of `ecCount` error correction codewords
  */
 export function rsEncode(data: number[], ecCount: number, wordSize: number): number[] {
-  const gf = getGF(wordSize);
+  const gf = getGF(wordSize)
 
   // Build generator polynomial: g(x) = (x - a^1)(x - a^2)...(x - a^ecCount)
   // Aztec RS uses roots starting at a^1, not a^0.
   // Coefficients stored in descending degree: gen[0]*x^n + gen[1]*x^(n-1) + ... + gen[n]
-  let gen = [1];
+  let gen = [1]
   for (let i = 1; i <= ecCount; i++) {
-    const root = gf.exp[i]!;
-    const newGen = Array.from<number>({ length: gen.length + 1 }).fill(0);
+    const root = gf.exp[i]!
+    const newGen = Array.from<number>({ length: gen.length + 1 }).fill(0)
     for (let j = 0; j < gen.length; j++) {
-      newGen[j] ^= gen[j]!;
-      newGen[j + 1] ^= gfMul(gf, gen[j]!, root);
+      newGen[j] ^= gen[j]!
+      newGen[j + 1] ^= gfMul(gf, gen[j]!, root)
     }
-    gen = newGen;
+    gen = newGen
   }
 
   // Polynomial long division: (data * x^ecCount) mod gen
   // Create dividend = data codewords followed by ecCount zeros
-  const dividend = [...data, ...Array.from<number>({ length: ecCount }).fill(0)];
+  const dividend = [...data, ...Array.from<number>({ length: ecCount }).fill(0)]
 
   for (let i = 0; i < data.length; i++) {
     if (dividend[i] !== 0) {
-      const coeff = dividend[i]!;
+      const coeff = dividend[i]!
       for (let j = 0; j < gen.length; j++) {
-        dividend[i + j] ^= gfMul(gf, coeff, gen[j]!);
+        dividend[i + j] ^= gfMul(gf, coeff, gen[j]!)
       }
     }
   }
 
   // The remainder is the last ecCount entries of the dividend
-  return dividend.slice(data.length);
+  return dividend.slice(data.length)
 }
 
 /**
@@ -135,43 +135,43 @@ export function generateCheckWords(
   totalBits: number,
   wordSize: number,
 ): number[] {
-  const messageSizeInWords = Math.floor(stuffedBits.length / wordSize);
-  const totalWords = Math.floor(totalBits / wordSize);
+  const messageSizeInWords = Math.floor(stuffedBits.length / wordSize)
+  const totalWords = Math.floor(totalBits / wordSize)
 
   // Convert stuffed bits to codewords (first messageSizeInWords positions filled)
-  const messageWords = Array.from<number>({ length: totalWords }).fill(0);
+  const messageWords = Array.from<number>({ length: totalWords }).fill(0)
   for (let i = 0; i < messageSizeInWords; i++) {
-    let value = 0;
+    let value = 0
     for (let j = 0; j < wordSize; j++) {
-      value |= (stuffedBits[i * wordSize + j]! ? 1 : 0) << (wordSize - j - 1);
+      value |= (stuffedBits[i * wordSize + j]! ? 1 : 0) << (wordSize - j - 1)
     }
-    messageWords[i] = value;
+    messageWords[i] = value
   }
 
   // RS-encode: fills positions messageSizeInWords..totalWords-1 with EC
-  const ecCount = totalWords - messageSizeInWords;
-  const ec = rsEncode(messageWords.slice(0, messageSizeInWords), ecCount, wordSize);
+  const ecCount = totalWords - messageSizeInWords
+  const ec = rsEncode(messageWords.slice(0, messageSizeInWords), ecCount, wordSize)
   for (let i = 0; i < ecCount; i++) {
-    messageWords[messageSizeInWords + i] = ec[i]!;
+    messageWords[messageSizeInWords + i] = ec[i]!
   }
 
   // Convert to bits with startPad
-  const startPad = totalBits % wordSize;
-  const result: number[] = [];
+  const startPad = totalBits % wordSize
+  const result: number[] = []
 
   // Add padding zeros at the start
   for (let i = 0; i < startPad; i++) {
-    result.push(0);
+    result.push(0)
   }
 
   // Add all codewords as bits
   for (const cw of messageWords) {
     for (let b = wordSize - 1; b >= 0; b--) {
-      result.push((cw >> b) & 1);
+      result.push((cw >> b) & 1)
     }
   }
 
-  return result;
+  return result
 }
 
 /**
@@ -185,20 +185,20 @@ export function generateCheckWords(
  * @returns 28-bit array (MSB first)
  */
 export function encodeCompactModeMessage(layers: number, dataCodewords: number): number[] {
-  const val = ((layers - 1) << 6) | (dataCodewords - 1);
-  const cw0 = (val >> 4) & 0x0f;
-  const cw1 = val & 0x0f;
+  const val = ((layers - 1) << 6) | (dataCodewords - 1)
+  const cw0 = (val >> 4) & 0x0f
+  const cw1 = val & 0x0f
 
-  const ec = rsEncode([cw0, cw1], 5, 4);
+  const ec = rsEncode([cw0, cw1], 5, 4)
 
   // Convert all 7 codewords to a 28-bit array
-  const bits: number[] = [];
+  const bits: number[] = []
   for (const cw of [cw0, cw1, ...ec]) {
     for (let b = 3; b >= 0; b--) {
-      bits.push((cw >> b) & 1);
+      bits.push((cw >> b) & 1)
     }
   }
-  return bits;
+  return bits
 }
 
 /**
@@ -215,20 +215,20 @@ export function encodeCompactModeMessage(layers: number, dataCodewords: number):
  */
 export function encodeFullModeMessage(layers: number, dataCodewords: number): number[] {
   // Pack 16 bits: 5 bits (layers-1) + 11 bits (dataCW-1)
-  const val = ((layers - 1) << 11) | (dataCodewords - 1);
-  const cw0 = (val >> 12) & 0x0f;
-  const cw1 = (val >> 8) & 0x0f;
-  const cw2 = (val >> 4) & 0x0f;
-  const cw3 = val & 0x0f;
+  const val = ((layers - 1) << 11) | (dataCodewords - 1)
+  const cw0 = (val >> 12) & 0x0f
+  const cw1 = (val >> 8) & 0x0f
+  const cw2 = (val >> 4) & 0x0f
+  const cw3 = val & 0x0f
 
-  const ec = rsEncode([cw0, cw1, cw2, cw3], 6, 4);
+  const ec = rsEncode([cw0, cw1, cw2, cw3], 6, 4)
 
   // Convert all 10 codewords to a 40-bit array
-  const bits: number[] = [];
+  const bits: number[] = []
   for (const cw of [cw0, cw1, cw2, cw3, ...ec]) {
     for (let b = 3; b >= 0; b--) {
-      bits.push((cw >> b) & 1);
+      bits.push((cw >> b) & 1)
     }
   }
-  return bits;
+  return bits
 }

--- a/src/encoders/aztec/tables.ts
+++ b/src/encoders/aztec/tables.ts
@@ -25,7 +25,7 @@ export const MODE_BITS: Record<Mode, number> = {
   [Mode.Mixed]: 5,
   [Mode.Punct]: 5,
   [Mode.Digit]: 4,
-};
+}
 
 // ---------------------------------------------------------------------------
 // Character-to-codeword value tables for each mode
@@ -105,7 +105,7 @@ export const PUNCT_PAIRS: ReadonlyMap<string, number> = new Map([
   [". ", 3],
   [", ", 4],
   [": ", 5],
-]);
+])
 
 /**
  * Digit mode (4-bit codewords)
@@ -126,7 +126,7 @@ export const CHAR_TABLE: ReadonlyArray<Readonly<Record<string, number>>> = [
   MIXED_TABLE,
   PUNCT_TABLE,
   DIGIT_TABLE,
-];
+]
 
 // ---------------------------------------------------------------------------
 // Mode transition (latch & shift) codes
@@ -145,9 +145,9 @@ export const CHAR_TABLE: ReadonlyArray<Readonly<Record<string, number>>> = [
  */
 
 export interface ModeSwitch {
-  codes: number[];
-  modes: Mode[];
-  totalBits: number;
+  codes: number[]
+  modes: Mode[]
+  totalBits: number
 }
 
 /**
@@ -155,7 +155,7 @@ export interface ModeSwitch {
  * Each step is a { code, bitsInCurrentMode } pair.
  */
 export function getLatchSequence(from: Mode, to: Mode): ModeSwitch {
-  if (from === to) return { codes: [], modes: [], totalBits: 0 };
+  if (from === to) return { codes: [], modes: [], totalBits: 0 }
 
   // Direct latches between modes
   // Upper -> Lower: 28 (5 bits)
@@ -168,80 +168,80 @@ export function getLatchSequence(from: Mode, to: Mode): ModeSwitch {
     case Mode.Upper:
       switch (to) {
         case Mode.Lower:
-          return { codes: [28], modes: [Mode.Upper], totalBits: 5 };
+          return { codes: [28], modes: [Mode.Upper], totalBits: 5 }
         case Mode.Mixed:
-          return { codes: [29], modes: [Mode.Upper], totalBits: 5 };
+          return { codes: [29], modes: [Mode.Upper], totalBits: 5 }
         case Mode.Punct:
-          return { codes: [29, 30], modes: [Mode.Upper, Mode.Mixed], totalBits: 10 };
+          return { codes: [29, 30], modes: [Mode.Upper, Mode.Mixed], totalBits: 10 }
         case Mode.Digit:
-          return { codes: [30], modes: [Mode.Upper], totalBits: 5 };
+          return { codes: [30], modes: [Mode.Upper], totalBits: 5 }
       }
-      break;
+      break
     case Mode.Lower:
       // Lower: 28=AS(shift Upper), 29=ML(latch Mixed), 30=DL(latch Digit), 31=BS
       switch (to) {
         case Mode.Upper:
           // Lower -ML(29)-> Mixed -UL(29)-> Upper
-          return { codes: [29, 29], modes: [Mode.Lower, Mode.Mixed], totalBits: 10 };
+          return { codes: [29, 29], modes: [Mode.Lower, Mode.Mixed], totalBits: 10 }
         case Mode.Mixed:
           // Lower -ML(29)-> Mixed
-          return { codes: [29], modes: [Mode.Lower], totalBits: 5 };
+          return { codes: [29], modes: [Mode.Lower], totalBits: 5 }
         case Mode.Punct:
           // Lower -ML(29)-> Mixed -PL(30)-> Punct
-          return { codes: [29, 30], modes: [Mode.Lower, Mode.Mixed], totalBits: 10 };
+          return { codes: [29, 30], modes: [Mode.Lower, Mode.Mixed], totalBits: 10 }
         case Mode.Digit:
           // Lower -DL(30)-> Digit
-          return { codes: [30], modes: [Mode.Lower], totalBits: 5 };
+          return { codes: [30], modes: [Mode.Lower], totalBits: 5 }
       }
-      break;
+      break
     case Mode.Mixed:
       // Mixed: 28=LL(latch Lower), 29=UL(latch Upper), 30=PL(latch Punct), 31=BS
       switch (to) {
         case Mode.Upper:
-          return { codes: [29], modes: [Mode.Mixed], totalBits: 5 };
+          return { codes: [29], modes: [Mode.Mixed], totalBits: 5 }
         case Mode.Lower:
-          return { codes: [28], modes: [Mode.Mixed], totalBits: 5 };
+          return { codes: [28], modes: [Mode.Mixed], totalBits: 5 }
         case Mode.Punct:
-          return { codes: [30], modes: [Mode.Mixed], totalBits: 5 };
+          return { codes: [30], modes: [Mode.Mixed], totalBits: 5 }
         case Mode.Digit:
           // Mixed -LL(28)-> Lower -DL(30)-> Digit
-          return { codes: [28, 30], modes: [Mode.Mixed, Mode.Lower], totalBits: 10 };
+          return { codes: [28, 30], modes: [Mode.Mixed, Mode.Lower], totalBits: 10 }
       }
-      break;
+      break
     case Mode.Punct:
       // Punct can only latch back to Upper (code 31)
       switch (to) {
         case Mode.Upper:
-          return { codes: [31], modes: [Mode.Punct], totalBits: 5 };
+          return { codes: [31], modes: [Mode.Punct], totalBits: 5 }
         case Mode.Lower:
-          return { codes: [31, 28], modes: [Mode.Punct, Mode.Upper], totalBits: 10 };
+          return { codes: [31, 28], modes: [Mode.Punct, Mode.Upper], totalBits: 10 }
         case Mode.Mixed:
-          return { codes: [31, 29], modes: [Mode.Punct, Mode.Upper], totalBits: 10 };
+          return { codes: [31, 29], modes: [Mode.Punct, Mode.Upper], totalBits: 10 }
         case Mode.Digit:
-          return { codes: [31, 30], modes: [Mode.Punct, Mode.Upper], totalBits: 10 };
+          return { codes: [31, 30], modes: [Mode.Punct, Mode.Upper], totalBits: 10 }
       }
-      break;
+      break
     case Mode.Digit:
       // Digit latch to Upper is code 14 (4 bits)
       switch (to) {
         case Mode.Upper:
-          return { codes: [14], modes: [Mode.Digit], totalBits: 4 };
+          return { codes: [14], modes: [Mode.Digit], totalBits: 4 }
         case Mode.Lower:
-          return { codes: [14, 28], modes: [Mode.Digit, Mode.Upper], totalBits: 9 };
+          return { codes: [14, 28], modes: [Mode.Digit, Mode.Upper], totalBits: 9 }
         case Mode.Mixed:
-          return { codes: [14, 29], modes: [Mode.Digit, Mode.Upper], totalBits: 9 };
+          return { codes: [14, 29], modes: [Mode.Digit, Mode.Upper], totalBits: 9 }
         case Mode.Punct:
           return {
             codes: [14, 29, 30],
             modes: [Mode.Digit, Mode.Upper, Mode.Mixed],
             totalBits: 14,
-          };
+          }
       }
-      break;
+      break
   }
 
   // Should be unreachable
-  return { codes: [], modes: [], totalBits: 0 };
+  return { codes: [], modes: [], totalBits: 0 }
 }
 
 /**
@@ -257,10 +257,10 @@ export const SHIFT_TO_PUNCT: Record<number, number> = {
   [Mode.Upper]: 0,
   [Mode.Lower]: 0,
   [Mode.Mixed]: 0,
-};
+}
 
 /** Shift to Upper from Lower: code 28 */
-export const SHIFT_LOWER_TO_UPPER = 28;
+export const SHIFT_LOWER_TO_UPPER = 28
 
 /** Binary shift code value (from Upper/Lower/Mixed: code 31, from Digit: code 15) */
 export const BINARY_SHIFT: Record<number, { code: number; bits: number }> = {
@@ -268,20 +268,20 @@ export const BINARY_SHIFT: Record<number, { code: number; bits: number }> = {
   [Mode.Lower]: { code: 31, bits: 5 },
   [Mode.Mixed]: { code: 31, bits: 5 },
   [Mode.Digit]: { code: 15, bits: 4 },
-};
+}
 
 // ---------------------------------------------------------------------------
 // Symbol size and capacity tables
 // ---------------------------------------------------------------------------
 
 export interface AztecSize {
-  layers: number;
-  compact: boolean;
-  modules: number;
+  layers: number
+  compact: boolean
+  modules: number
   /** Total data bits available in the data layers (before error correction) */
-  totalBits: number;
+  totalBits: number
   /** Codeword size in bits for this symbol */
-  wordSize: number;
+  wordSize: number
 }
 
 /**
@@ -301,7 +301,7 @@ const WORD_SIZE: readonly number[] = [
  * The word size depends only on the layer count, NOT on compact vs full.
  */
 export function getWordSize(layers: number, _compact?: boolean): number {
-  return WORD_SIZE[layers]!;
+  return WORD_SIZE[layers]!
 }
 
 // ---------------------------------------------------------------------------
@@ -314,7 +314,7 @@ export function getWordSize(layers: number, _compact?: boolean): number {
  * Full:    14 + layers * 4
  */
 export function getBaseMatrixSize(layers: number, compact: boolean): number {
-  return (compact ? 11 : 14) + layers * 4;
+  return (compact ? 11 : 14) + layers * 4
 }
 
 /**
@@ -324,9 +324,9 @@ export function getBaseMatrixSize(layers: number, compact: boolean): number {
  * reference grid lines inserted every 15 modules from center.
  */
 export function getModuleCount(layers: number, compact: boolean): number {
-  const base = getBaseMatrixSize(layers, compact);
-  if (compact) return base;
-  return base + 1 + 2 * Math.floor((Math.floor(base / 2) - 1) / 15);
+  const base = getBaseMatrixSize(layers, compact)
+  if (compact) return base
+  return base + 1 + 2 * Math.floor((Math.floor(base / 2) - 1) / 15)
 }
 
 /**
@@ -334,7 +334,7 @@ export function getModuleCount(layers: number, compact: boolean): number {
  * Formula: ((compact ? 88 : 112) + 16 * layers) * layers
  */
 export function getTotalBitCapacity(layers: number, compact: boolean): number {
-  return ((compact ? 88 : 112) + 16 * layers) * layers;
+  return ((compact ? 88 : 112) + 16 * layers) * layers
 }
 
 // ---------------------------------------------------------------------------
@@ -348,14 +348,14 @@ export const GF_POLY: Record<number, number> = {
   8: 0x12d, // x^8 + x^5 + x^3 + x^2 + 1
   10: 0x409, // x^10 + x^3 + 1
   12: 0x1069, // x^12 + x^6 + x^4 + x + 1
-};
+}
 
 // ---------------------------------------------------------------------------
 // Mode message parameters
 // ---------------------------------------------------------------------------
 
 /** Compact mode message: 28 bits total (2 bits layers + 6 bits data codewords + 5 EC bits encoded to 28 via RS) */
-export const COMPACT_MODE_MSG_BITS = 28;
+export const COMPACT_MODE_MSG_BITS = 28
 
 /** Full-range mode message: 40 bits total (5 bits layers + 11 bits data codewords + EC encoded to 40) */
-export const FULL_MODE_MSG_BITS = 40;
+export const FULL_MODE_MSG_BITS = 40

--- a/src/encoders/codabar.ts
+++ b/src/encoders/codabar.ts
@@ -5,7 +5,7 @@
  * Start/stop characters: A, B, C, D (case-insensitive)
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Codabar character patterns: 7 elements each (BSBSBSB)
 // Narrow = 1, Wide = 3
@@ -31,16 +31,16 @@ const PATTERNS: Record<string, number[]> = {
   B: [1, 3, 1, 3, 1, 1, 3],
   C: [1, 1, 1, 3, 1, 3, 3],
   D: [1, 1, 1, 3, 3, 3, 1],
-};
+}
 
 // Valid data characters (between start/stop)
-const DATA_CHARS = new Set("0123456789-$:/.+");
+const DATA_CHARS = new Set("0123456789-$:/.+")
 
 // Valid start/stop characters
-const START_STOP_CHARS = new Set("ABCD");
+const START_STOP_CHARS = new Set("ABCD")
 
 // Narrow inter-character gap
-const GAP = 1;
+const GAP = 1
 
 /**
  * Encode a Codabar barcode
@@ -54,76 +54,76 @@ const GAP = 1;
  */
 export function encodeCodabar(text: string, options?: { start?: string; stop?: string }): number[] {
   if (text.length === 0) {
-    throw new InvalidInputError("Codabar input must not be empty");
+    throw new InvalidInputError("Codabar input must not be empty")
   }
 
-  const upper = text.toUpperCase();
+  const upper = text.toUpperCase()
 
-  let startChar: string;
-  let stopChar: string;
-  let data: string;
+  let startChar: string
+  let stopChar: string
+  let data: string
 
   // Check if text already includes start/stop characters
-  const firstChar = upper[0]!;
-  const lastChar = upper[upper.length - 1]!;
+  const firstChar = upper[0]!
+  const lastChar = upper[upper.length - 1]!
 
   if (upper.length >= 2 && START_STOP_CHARS.has(firstChar) && START_STOP_CHARS.has(lastChar)) {
     // Text includes start/stop characters
-    startChar = firstChar;
-    stopChar = lastChar;
-    data = upper.slice(1, -1);
+    startChar = firstChar
+    stopChar = lastChar
+    data = upper.slice(1, -1)
   } else {
     // Use provided or default start/stop
-    startChar = (options?.start ?? "A").toUpperCase();
-    stopChar = (options?.stop ?? "A").toUpperCase();
-    data = upper;
+    startChar = (options?.start ?? "A").toUpperCase()
+    stopChar = (options?.stop ?? "A").toUpperCase()
+    data = upper
   }
 
   // Validate start/stop characters
   if (!START_STOP_CHARS.has(startChar)) {
     throw new InvalidInputError(
       `Invalid Codabar start character: '${startChar}'. Must be A, B, C, or D`,
-    );
+    )
   }
   if (!START_STOP_CHARS.has(stopChar)) {
     throw new InvalidInputError(
       `Invalid Codabar stop character: '${stopChar}'. Must be A, B, C, or D`,
-    );
+    )
   }
 
   // Validate data characters
   for (let i = 0; i < data.length; i++) {
-    const ch = data[i]!;
+    const ch = data[i]!
     if (!DATA_CHARS.has(ch)) {
-      throw new InvalidInputError(`Invalid Codabar character: '${ch}' at position ${i}`);
+      throw new InvalidInputError(`Invalid Codabar character: '${ch}' at position ${i}`)
     }
   }
 
-  const bars: number[] = [];
+  const bars: number[] = []
 
   // Start character
-  const startPattern = PATTERNS[startChar]!;
+  const startPattern = PATTERNS[startChar]!
   for (const w of startPattern) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Inter-character gap after start
-  bars.push(GAP);
+  bars.push(GAP)
 
   // Data characters
   for (let i = 0; i < data.length; i++) {
-    const pattern = PATTERNS[data[i]!]!;
+    const pattern = PATTERNS[data[i]!]!
     for (const w of pattern) {
-      bars.push(w);
+      bars.push(w)
     }
-    bars.push(GAP); // inter-character gap
+    bars.push(GAP) // inter-character gap
   }
 
   // Stop character
-  const stopPattern = PATTERNS[stopChar]!;
+  const stopPattern = PATTERNS[stopChar]!
   for (const w of stopPattern) {
-    bars.push(w);
+    bars.push(w)
   }
 
-  return bars;
+  return bars
 }

--- a/src/encoders/codablock-f.ts
+++ b/src/encoders/codablock-f.ts
@@ -6,13 +6,13 @@
  * Each row: Start C + row indicator + data codewords + check + Stop
  */
 
-import { InvalidInputError, CapacityError } from "../errors";
+import { InvalidInputError, CapacityError } from "../errors"
 
 // Code 128 constants
-const START_C = 105;
-const CODE_A = 101;
-const CODE_B = 100;
-const CODE_C = 99;
+const START_C = 105
+const CODE_A = 101
+const CODE_B = 100
+const CODE_C = 99
 
 // Full Code 128 encoding patterns (bar/space widths), indices 0-105
 // Each pattern is 6 elements: bar, space, bar, space, bar, space
@@ -123,25 +123,25 @@ const PATTERNS: number[][] = [
   [2, 1, 1, 4, 1, 2], // 103 (START_A)
   [2, 1, 1, 2, 1, 4], // 104 (START_B)
   [2, 1, 1, 2, 3, 2], // 105 (START_C)
-];
+]
 
-const STOP_PATTERN = [2, 3, 3, 1, 1, 1, 2];
+const STOP_PATTERN = [2, 3, 3, 1, 1, 1, 2]
 
 export interface CodablockFResult {
-  matrix: boolean[][];
-  rows: number;
-  cols: number;
+  matrix: boolean[][]
+  rows: number
+  cols: number
 }
 
 /** Count consecutive digit characters from a given position */
 function countDigitsFrom(text: string, pos: number): number {
-  let count = 0;
+  let count = 0
   while (pos + count < text.length) {
-    const c = text.charCodeAt(pos + count);
-    if (c < 48 || c > 57) break;
-    count++;
+    const c = text.charCodeAt(pos + count)
+    if (c < 48 || c > 57) break
+    count++
   }
-  return count;
+  return count
 }
 
 /**
@@ -149,9 +149,9 @@ function countDigitsFrom(text: string, pos: number): number {
  * Returns "A" for control chars (0-31), "B" for printable ASCII (32-126), or null if unsupported.
  */
 function charsetFor(charCode: number): "A" | "B" | null {
-  if (charCode >= 0 && charCode < 32) return "A";
-  if (charCode >= 32 && charCode <= 126) return "B";
-  return null;
+  if (charCode >= 0 && charCode < 32) return "A"
+  if (charCode >= 32 && charCode <= 126) return "B"
+  return null
 }
 
 /**
@@ -159,87 +159,87 @@ function charsetFor(charCode: number): "A" | "B" | null {
  * Supports Code A (control chars), Code B (printable ASCII), and Code C (digit pairs).
  */
 function encodeValues(text: string): number[] {
-  const values: number[] = [];
-  let pos = 0;
+  const values: number[] = []
+  let pos = 0
 
   // Determine initial charset
-  const initialDigits = countDigitsFrom(text, 0);
-  let currentCharset: "A" | "B" | "C";
+  const initialDigits = countDigitsFrom(text, 0)
+  let currentCharset: "A" | "B" | "C"
   if (initialDigits >= 4 || (initialDigits >= 2 && initialDigits === text.length)) {
-    currentCharset = "C";
+    currentCharset = "C"
   } else if (text.length > 0 && text.charCodeAt(0) < 32) {
-    currentCharset = "A";
+    currentCharset = "A"
   } else {
-    currentCharset = "B";
+    currentCharset = "B"
   }
 
   while (pos < text.length) {
     if (currentCharset === "C") {
-      const digits = countDigitsFrom(text, pos);
+      const digits = countDigitsFrom(text, pos)
       if (digits >= 2) {
         // Encode digit pairs
-        const pairCount = Math.floor(digits / 2);
+        const pairCount = Math.floor(digits / 2)
         for (let i = 0; i < pairCount; i++) {
-          const d1 = text.charCodeAt(pos) - 48;
-          const d2 = text.charCodeAt(pos + 1) - 48;
-          values.push(d1 * 10 + d2);
-          pos += 2;
+          const d1 = text.charCodeAt(pos) - 48
+          const d2 = text.charCodeAt(pos + 1) - 48
+          values.push(d1 * 10 + d2)
+          pos += 2
         }
       } else {
         // Switch out of Code C
-        const charCode = pos < text.length ? text.charCodeAt(pos) : -1;
-        const cs = charCode >= 0 ? charsetFor(charCode) : "B";
+        const charCode = pos < text.length ? text.charCodeAt(pos) : -1
+        const cs = charCode >= 0 ? charsetFor(charCode) : "B"
         if (cs === "A") {
-          values.push(CODE_A);
-          currentCharset = "A";
+          values.push(CODE_A)
+          currentCharset = "A"
         } else {
-          values.push(CODE_B);
-          currentCharset = "B";
+          values.push(CODE_B)
+          currentCharset = "B"
         }
       }
     } else {
       // Code A or Code B
-      const numRun = countDigitsFrom(text, pos);
+      const numRun = countDigitsFrom(text, pos)
       if (numRun >= 4 || (numRun >= 2 && pos + numRun >= text.length)) {
-        values.push(CODE_C);
-        currentCharset = "C";
-        continue;
+        values.push(CODE_C)
+        currentCharset = "C"
+        continue
       }
 
-      const charCode = text.charCodeAt(pos);
-      const needed = charsetFor(charCode);
+      const charCode = text.charCodeAt(pos)
+      const needed = charsetFor(charCode)
       if (needed === null) {
         throw new InvalidInputError(
           `Codablock F: unsupported character "${text[pos]}" (code ${charCode})`,
-        );
+        )
       }
 
       if (needed !== currentCharset) {
         if (needed === "A") {
-          values.push(CODE_A);
-          currentCharset = "A";
+          values.push(CODE_A)
+          currentCharset = "A"
         } else {
-          values.push(CODE_B);
-          currentCharset = "B";
+          values.push(CODE_B)
+          currentCharset = "B"
         }
       }
 
       if (currentCharset === "A") {
         // Code A: control chars 0-31 → values 64-95, printable 32-95 → values 0-63
         if (charCode < 32) {
-          values.push(charCode + 64);
+          values.push(charCode + 64)
         } else {
-          values.push(charCode - 32);
+          values.push(charCode - 32)
         }
       } else {
         // Code B: printable 32-126 → values 0-94
-        values.push(charCode - 32);
+        values.push(charCode - 32)
       }
-      pos++;
+      pos++
     }
   }
 
-  return values;
+  return values
 }
 
 /**
@@ -250,85 +250,85 @@ function encodeValues(text: string): number[] {
  */
 export function encodeCodablockF(text: string, options?: { columns?: number }): CodablockFResult {
   if (text.length === 0) {
-    throw new InvalidInputError("Codablock F input must not be empty");
+    throw new InvalidInputError("Codablock F input must not be empty")
   }
 
   // Encode text into Code 128 codeword values
-  const values = encodeValues(text);
+  const values = encodeValues(text)
 
   // Determine columns per row
-  const cols = options?.columns ?? Math.min(10, Math.max(4, Math.ceil(values.length / 5)));
-  const maxDataPerRow = cols;
+  const cols = options?.columns ?? Math.min(10, Math.max(4, Math.ceil(values.length / 5)))
+  const maxDataPerRow = cols
 
   // Split into rows
-  const rowData: number[][] = [];
+  const rowData: number[][] = []
   for (let i = 0; i < values.length; i += maxDataPerRow) {
-    rowData.push(values.slice(i, i + maxDataPerRow));
+    rowData.push(values.slice(i, i + maxDataPerRow))
   }
 
   if (rowData.length > 44) {
-    throw new CapacityError("Codablock F: data exceeds maximum 44 rows");
+    throw new CapacityError("Codablock F: data exceeds maximum 44 rows")
   }
 
   // Build each row as bar pattern
-  const matrix: boolean[][] = [];
+  const matrix: boolean[][] = []
 
   for (let r = 0; r < rowData.length; r++) {
-    const row = rowData[r]!;
-    const codes: number[] = [START_C]; // Start Code C
+    const row = rowData[r]!
+    const codes: number[] = [START_C] // Start Code C
 
     // Row indicator: row number encoded as Code C value
-    codes.push(r);
+    codes.push(r)
 
     // Switch to Code B for data
-    codes.push(CODE_B);
+    codes.push(CODE_B)
 
     // Data codewords
     for (const v of row) {
-      codes.push(v);
+      codes.push(v)
     }
 
     // Pad remaining columns
     while (codes.length - 3 < maxDataPerRow) {
-      codes.push(0); // space padding
+      codes.push(0) // space padding
     }
 
     // Checksum
-    let checksum = codes[0]!;
+    let checksum = codes[0]!
     for (let i = 1; i < codes.length; i++) {
-      checksum += codes[i]! * i;
+      checksum += codes[i]! * i
     }
-    codes.push(checksum % 103);
+    codes.push(checksum % 103)
 
     // Convert to bar pattern
-    const modules: boolean[] = [];
+    const modules: boolean[] = []
 
     for (const code of codes) {
-      const pattern = PATTERNS[code]!;
-      let isBar = true;
+      const pattern = PATTERNS[code]!
+      let isBar = true
       for (const w of pattern) {
         for (let i = 0; i < w; i++) {
-          modules.push(isBar);
+          modules.push(isBar)
         }
-        isBar = !isBar;
+        isBar = !isBar
       }
     }
 
     // Stop pattern
-    let isBar = true;
+    let isBar = true
     for (const w of STOP_PATTERN) {
       for (let i = 0; i < w; i++) {
-        modules.push(isBar);
+        modules.push(isBar)
       }
-      isBar = !isBar;
+      isBar = !isBar
     }
 
-    matrix.push(modules);
+    matrix.push(modules)
   }
 
   return {
     matrix,
     rows: matrix.length,
     cols: matrix[0]?.length ?? 0,
-  };
+  }
 }

--- a/src/encoders/code11.ts
+++ b/src/encoders/code11.ts
@@ -4,7 +4,7 @@
  * Includes automatic check digits (C and optionally K)
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Code 11 character patterns: 6 elements each
 // First 5 elements are BSBSB (the character itself)
@@ -23,18 +23,18 @@ const PATTERNS: number[][] = [
   [2, 1, 1, 2, 1, 1], // 8
   [2, 1, 1, 1, 1, 1], // 9
   [1, 1, 2, 1, 1, 1], // 10 = '-'
-];
+]
 
 // Start/stop pattern (6 elements: BSBSB + trailing space)
-const START_STOP = [1, 1, 2, 2, 1, 1];
+const START_STOP = [1, 1, 2, 2, 1, 1]
 
 // Character set for mapping
-const CHARSET = "0123456789-";
+const CHARSET = "0123456789-"
 
 // Character value lookup
-const CHAR_VALUES = new Map<string, number>();
+const CHAR_VALUES = new Map<string, number>()
 for (let i = 0; i < CHARSET.length; i++) {
-  CHAR_VALUES.set(CHARSET[i]!, i);
+  CHAR_VALUES.set(CHARSET[i]!, i)
 }
 
 /**
@@ -43,16 +43,16 @@ for (let i = 0; i < CHARSET.length; i++) {
  * Result mod 11; if 10, the check digit character is '-'
  */
 function calculateCheckC(values: number[]): number {
-  let sum = 0;
-  let weight = 1;
+  let sum = 0
+  let weight = 1
   for (let i = values.length - 1; i >= 0; i--) {
-    sum += values[i]! * weight;
-    weight++;
+    sum += values[i]! * weight
+    weight++
     if (weight > 10) {
-      weight = 1;
+      weight = 1
     }
   }
-  return sum % 11;
+  return sum % 11
 }
 
 /**
@@ -61,16 +61,16 @@ function calculateCheckC(values: number[]): number {
  * Result mod 11; if 10, the check digit character is '-'
  */
 function calculateCheckK(values: number[]): number {
-  let sum = 0;
-  let weight = 1;
+  let sum = 0
+  let weight = 1
   for (let i = values.length - 1; i >= 0; i--) {
-    sum += values[i]! * weight;
-    weight++;
+    sum += values[i]! * weight
+    weight++
     if (weight > 9) {
-      weight = 1;
+      weight = 1
     }
   }
-  return sum % 11;
+  return sum % 11
 }
 
 /**
@@ -85,50 +85,50 @@ function calculateCheckK(values: number[]): number {
  */
 export function encodeCode11(text: string): number[] {
   if (text.length === 0) {
-    throw new InvalidInputError("Code 11 input must not be empty");
+    throw new InvalidInputError("Code 11 input must not be empty")
   }
 
   // Validate and collect character values
-  const values: number[] = [];
+  const values: number[] = []
   for (let i = 0; i < text.length; i++) {
-    const ch = text[i]!;
-    const value = CHAR_VALUES.get(ch);
+    const ch = text[i]!
+    const value = CHAR_VALUES.get(ch)
     if (value === undefined) {
       throw new InvalidInputError(
         `Invalid Code 11 character: '${ch}' at position ${i}. Valid characters: 0-9 and -`,
-      );
+      )
     }
-    values.push(value);
+    values.push(value)
   }
 
   // Calculate check digit C (always)
-  const checkC = calculateCheckC(values);
-  const valuesWithC = [...values, checkC];
+  const checkC = calculateCheckC(values)
+  const valuesWithC = [...values, checkC]
 
   // Calculate check digit K (only if data length > 10)
-  const includeK = text.length > 10;
-  const allValues = includeK ? [...valuesWithC, calculateCheckK(valuesWithC)] : valuesWithC;
+  const includeK = text.length > 10
+  const allValues = includeK ? [...valuesWithC, calculateCheckK(valuesWithC)] : valuesWithC
 
-  const bars: number[] = [];
+  const bars: number[] = []
 
   // Start pattern
-  const startPattern = START_STOP;
+  const startPattern = START_STOP
   for (const w of startPattern) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Data + check digit characters
   for (const value of allValues) {
-    const pattern = PATTERNS[value]!;
+    const pattern = PATTERNS[value]!
     for (const w of pattern) {
-      bars.push(w);
+      bars.push(w)
     }
   }
 
   // Stop pattern: same BSBSB as start, without trailing inter-character space
   for (let i = 0; i < 5; i++) {
-    bars.push(START_STOP[i]!);
+    bars.push(START_STOP[i]!)
   }
 
-  return bars;
+  return bars
 }

--- a/src/encoders/code128.ts
+++ b/src/encoders/code128.ts
@@ -4,13 +4,13 @@
  * and forced charset selection (A, B, or C)
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
-export type Code128Charset = "auto" | "A" | "B" | "C";
+export type Code128Charset = "auto" | "A" | "B" | "C"
 
 export interface Code128Options {
   /** Force a specific Code 128 charset (A, B, or C). Defaults to 'auto'. */
-  charset?: Code128Charset;
+  charset?: Code128Charset
 }
 
 // Code 128 encoding patterns (bar/space widths)
@@ -122,17 +122,17 @@ const PATTERNS: number[][] = [
   [2, 1, 1, 4, 1, 2], // 103 (START_A)
   [2, 1, 1, 2, 1, 4], // 104 (START_B)
   [2, 1, 1, 2, 3, 2], // 105 (START_C)
-];
+]
 
-const STOP_PATTERN = [2, 3, 3, 1, 1, 1, 2]; // 7 elements
+const STOP_PATTERN = [2, 3, 3, 1, 1, 1, 2] // 7 elements
 
-const START_A = 103;
-const START_B = 104;
-const START_C = 105;
-const CODE_A = 101;
-const CODE_B = 100;
-const CODE_C = 99;
-const SHIFT = 98;
+const START_A = 103
+const START_B = 104
+const START_C = 105
+const CODE_A = 101
+const CODE_B = 100
+const CODE_C = 99
+const SHIFT = 98
 
 /**
  * Encode text as Code 128 barcode
@@ -146,152 +146,152 @@ const SHIFT = 98;
  *   - `'C'`: Force Code 128C (digit pairs only, input must be even-length digits)
  */
 export function encodeCode128(text: string, options?: Code128Options): number[] {
-  const charset = options?.charset ?? "auto";
+  const charset = options?.charset ?? "auto"
 
-  let codes: number[];
+  let codes: number[]
   switch (charset) {
     case "auto":
-      codes = autoEncode(text);
-      break;
+      codes = autoEncode(text)
+      break
     case "A":
-      codes = encodeCharsetA(text);
-      break;
+      codes = encodeCharsetA(text)
+      break
     case "B":
-      codes = encodeCharsetB(text);
-      break;
+      codes = encodeCharsetB(text)
+      break
     case "C":
-      codes = encodeCharsetC(text);
-      break;
+      codes = encodeCharsetC(text)
+      break
     default:
-      throw new InvalidInputError(`Invalid Code 128 charset: ${charset}`);
+      throw new InvalidInputError(`Invalid Code 128 charset: ${charset}`)
   }
 
-  const bars: number[] = [];
+  const bars: number[] = []
 
   for (const code of codes) {
-    const pattern = PATTERNS[code]!;
+    const pattern = PATTERNS[code]!
     for (const width of pattern) {
-      bars.push(width);
+      bars.push(width)
     }
   }
 
   // Stop pattern
   for (const width of STOP_PATTERN) {
-    bars.push(width);
+    bars.push(width)
   }
 
-  return bars;
+  return bars
 }
 
 function autoEncode(text: string): number[] {
   // Determine optimal start code
-  const codes: number[] = [];
-  let pos = 0;
+  const codes: number[] = []
+  let pos = 0
 
   // Check if we should start with Code C (numeric pairs)
-  const numericRun = countNumericFromPos(text, 0);
+  const numericRun = countNumericFromPos(text, 0)
 
   if (numericRun >= 4) {
-    codes.push(START_C);
-    pos = encodeCodeC(text, pos, codes);
+    codes.push(START_C)
+    pos = encodeCodeC(text, pos, codes)
   } else {
-    codes.push(START_B);
+    codes.push(START_B)
   }
 
-  let currentSet: "A" | "B" | "C" = codes[0] === START_C ? "C" : "B";
+  let currentSet: "A" | "B" | "C" = codes[0] === START_C ? "C" : "B"
 
   while (pos < text.length) {
     if (currentSet === "C") {
       // In Code C, check if we should switch
-      const remaining = countNumericFromPos(text, pos);
+      const remaining = countNumericFromPos(text, pos)
       if (remaining >= 2) {
-        pos = encodeCodeC(text, pos, codes);
+        pos = encodeCodeC(text, pos, codes)
       } else {
-        codes.push(CODE_B);
-        currentSet = "B";
+        codes.push(CODE_B)
+        currentSet = "B"
       }
     } else {
       // In Code B (or A), check if switching to C is beneficial
-      const numRun = countNumericFromPos(text, pos);
+      const numRun = countNumericFromPos(text, pos)
       if (numRun >= 4 || (numRun >= 2 && pos + numRun >= text.length)) {
-        codes.push(CODE_C);
-        currentSet = "C";
-        pos = encodeCodeC(text, pos, codes);
+        codes.push(CODE_C)
+        currentSet = "C"
+        pos = encodeCodeC(text, pos, codes)
       } else {
-        const charCode = text.charCodeAt(pos);
+        const charCode = text.charCodeAt(pos)
         if (charCode >= 32 && charCode <= 126) {
           // Printable character — needs Code B
           if (currentSet === "A") {
-            codes.push(CODE_B);
-            currentSet = "B";
+            codes.push(CODE_B)
+            currentSet = "B"
           }
-          codes.push(charCode - 32);
+          codes.push(charCode - 32)
         } else if (charCode >= 0 && charCode < 32) {
           // Control character — needs Code A
           if (currentSet !== "A") {
             // Check if this is a single control char followed by printable text
             // If so, use SHIFT to temporarily access Code A for one character
-            const nextCharCode = pos + 1 < text.length ? text.charCodeAt(pos + 1) : -1;
+            const nextCharCode = pos + 1 < text.length ? text.charCodeAt(pos + 1) : -1
             if (nextCharCode >= 32 && nextCharCode <= 126) {
               // Single control char surrounded by printable text — use SHIFT
-              codes.push(SHIFT);
-              codes.push(charCode + 64);
+              codes.push(SHIFT)
+              codes.push(charCode + 64)
               // currentSet stays as "B" since SHIFT is temporary
             } else {
               // Multiple control chars or end of string — switch to Code A
-              codes.push(CODE_A);
-              currentSet = "A";
-              codes.push(charCode + 64);
+              codes.push(CODE_A)
+              currentSet = "A"
+              codes.push(charCode + 64)
             }
           } else {
-            codes.push(charCode + 64);
+            codes.push(charCode + 64)
           }
         }
-        pos++;
+        pos++
       }
     }
   }
 
   // Calculate checksum
-  let checksum = codes[0]!;
+  let checksum = codes[0]!
   for (let i = 1; i < codes.length; i++) {
-    checksum += codes[i]! * i;
+    checksum += codes[i]! * i
   }
-  codes.push(checksum % 103);
+  codes.push(checksum % 103)
 
-  return codes;
+  return codes
 }
 
 function encodeCodeC(text: string, pos: number, codes: number[]): number {
   while (pos + 1 < text.length) {
-    const d1 = text.charCodeAt(pos) - 48;
-    const d2 = text.charCodeAt(pos + 1) - 48;
-    if (d1 < 0 || d1 > 9 || d2 < 0 || d2 > 9) break;
-    codes.push(d1 * 10 + d2);
-    pos += 2;
+    const d1 = text.charCodeAt(pos) - 48
+    const d2 = text.charCodeAt(pos + 1) - 48
+    if (d1 < 0 || d1 > 9 || d2 < 0 || d2 > 9) break
+    codes.push(d1 * 10 + d2)
+    pos += 2
   }
-  return pos;
+  return pos
 }
 
 function countNumericFromPos(text: string, pos: number): number {
-  let count = 0;
+  let count = 0
   while (pos + count < text.length) {
-    const c = text.charCodeAt(pos + count);
-    if (c < 48 || c > 57) break;
-    count++;
+    const c = text.charCodeAt(pos + count)
+    if (c < 48 || c > 57) break
+    count++
   }
-  return count;
+  return count
 }
 
 /**
  * Calculate Code 128 checksum and append it to the codes array
  */
 function appendChecksum(codes: number[]): void {
-  let checksum = codes[0]!;
+  let checksum = codes[0]!
   for (let i = 1; i < codes.length; i++) {
-    checksum += codes[i]! * i;
+    checksum += codes[i]! * i
   }
-  codes.push(checksum % 103);
+  codes.push(checksum % 103)
 }
 
 /**
@@ -299,26 +299,26 @@ function appendChecksum(codes: number[]): void {
  * Code 128A supports: ASCII 0-95 (control chars 0-31, space, digits, uppercase, some symbols)
  */
 function encodeCharsetA(text: string): number[] {
-  const codes: number[] = [START_A];
+  const codes: number[] = [START_A]
 
   for (let i = 0; i < text.length; i++) {
-    const charCode = text.charCodeAt(i);
+    const charCode = text.charCodeAt(i)
     if (charCode >= 0 && charCode < 32) {
       // Control characters: value = charCode + 64
-      codes.push(charCode + 64);
+      codes.push(charCode + 64)
     } else if (charCode >= 32 && charCode <= 95) {
       // Space (32) through underscore (95): value = charCode - 32
-      codes.push(charCode - 32);
+      codes.push(charCode - 32)
     } else {
       throw new InvalidInputError(
         `Character '${text[i]}' (code ${charCode}) is not encodable in Code 128A. ` +
           `Code 128A supports control characters (0-31) and printable ASCII 32-95 (uppercase, digits, symbols).`,
-      );
+      )
     }
   }
 
-  appendChecksum(codes);
-  return codes;
+  appendChecksum(codes)
+  return codes
 }
 
 /**
@@ -326,23 +326,23 @@ function encodeCharsetA(text: string): number[] {
  * Code 128B supports: ASCII 32-127 (space, digits, uppercase, lowercase, symbols)
  */
 function encodeCharsetB(text: string): number[] {
-  const codes: number[] = [START_B];
+  const codes: number[] = [START_B]
 
   for (let i = 0; i < text.length; i++) {
-    const charCode = text.charCodeAt(i);
+    const charCode = text.charCodeAt(i)
     if (charCode >= 32 && charCode <= 127) {
       // Printable ASCII: value = charCode - 32
-      codes.push(charCode - 32);
+      codes.push(charCode - 32)
     } else {
       throw new InvalidInputError(
         `Character code ${charCode} is not encodable in Code 128B. ` +
           `Code 128B supports printable ASCII characters (32-127).`,
-      );
+      )
     }
   }
 
-  appendChecksum(codes);
-  return codes;
+  appendChecksum(codes)
+  return codes
 }
 
 /**
@@ -352,28 +352,28 @@ function encodeCharsetB(text: string): number[] {
 function encodeCharsetC(text: string): number[] {
   // Validate: must be all digits
   for (let i = 0; i < text.length; i++) {
-    const c = text.charCodeAt(i);
+    const c = text.charCodeAt(i)
     if (c < 48 || c > 57) {
       throw new InvalidInputError(
         `Character '${text[i]}' is not encodable in Code 128C. ` +
           `Code 128C supports only digits (0-9).`,
-      );
+      )
     }
   }
 
   // Validate: must be even length
   if (text.length % 2 !== 0) {
-    throw new InvalidInputError(`Code 128C requires an even number of digits, got ${text.length}.`);
+    throw new InvalidInputError(`Code 128C requires an even number of digits, got ${text.length}.`)
   }
 
-  const codes: number[] = [START_C];
+  const codes: number[] = [START_C]
 
   for (let i = 0; i < text.length; i += 2) {
-    const d1 = text.charCodeAt(i) - 48;
-    const d2 = text.charCodeAt(i + 1) - 48;
-    codes.push(d1 * 10 + d2);
+    const d1 = text.charCodeAt(i) - 48
+    const d2 = text.charCodeAt(i + 1) - 48
+    codes.push(d1 * 10 + d2)
   }
 
-  appendChecksum(codes);
-  return codes;
+  appendChecksum(codes)
+  return codes
 }

--- a/src/encoders/code16k.ts
+++ b/src/encoders/code16k.ts
@@ -6,7 +6,7 @@
  * Uses Code 128 bar patterns with row-specific start codes
  */
 
-import { InvalidInputError, CapacityError } from "../errors";
+import { InvalidInputError, CapacityError } from "../errors"
 
 // Code 128 encoding patterns (bar/space widths)
 // Each pattern is 6 elements: bar, space, bar, space, bar, space (11 modules total)
@@ -36,16 +36,16 @@ const PATTERNS: number[][] = [
   [2,1,1,2,3,2],
 ];
 
-const STOP_PATTERN = [2, 3, 3, 1, 1, 1, 2]; // 7 elements, 13 modules
+const STOP_PATTERN = [2, 3, 3, 1, 1, 1, 2] // 7 elements, 13 modules
 
 // Code 16K uses Code 128 value 96 (CODE_A) as the start for each row
 // The first data codeword in each row encodes mode + row information
-const CODE_B = 100;
+const CODE_B = 100
 
 export interface Code16KResult {
-  matrix: boolean[][];
-  rows: number;
-  cols: number;
+  matrix: boolean[][]
+  rows: number
+  cols: number
 }
 
 /**
@@ -56,83 +56,83 @@ export interface Code16KResult {
  */
 export function encodeCode16K(text: string): Code16KResult {
   if (text.length === 0) {
-    throw new InvalidInputError("Code 16K input must not be empty");
+    throw new InvalidInputError("Code 16K input must not be empty")
   }
 
   // Encode as Code 128B values
-  const values: number[] = [];
+  const values: number[] = []
   for (const ch of text) {
-    const code = ch.charCodeAt(0);
+    const code = ch.charCodeAt(0)
     if (code < 32 || code > 126) {
-      throw new InvalidInputError(`Code 16K: unsupported character (code ${code})`);
+      throw new InvalidInputError(`Code 16K: unsupported character (code ${code})`)
     }
-    values.push(code - 32);
+    values.push(code - 32)
   }
 
   // 5 data symbol characters per row, max 16 rows
-  const cwPerRow = 5;
-  const rows = Math.min(16, Math.max(2, Math.ceil(values.length / cwPerRow)));
+  const cwPerRow = 5
+  const rows = Math.min(16, Math.max(2, Math.ceil(values.length / cwPerRow)))
 
   if (values.length > rows * cwPerRow) {
-    throw new CapacityError("Code 16K: data exceeds maximum capacity (16 rows × 5 codewords)");
+    throw new CapacityError("Code 16K: data exceeds maximum capacity (16 rows × 5 codewords)")
   }
 
   // Pad to fill rows
   while (values.length < rows * cwPerRow) {
-    values.push(0); // space padding (Code B value 0 = space)
+    values.push(0) // space padding (Code B value 0 = space)
   }
 
-  const matrix: boolean[][] = [];
+  const matrix: boolean[][] = []
 
   for (let r = 0; r < rows; r++) {
     // Build codeword sequence for this row
-    const rowCodes: number[] = [];
+    const rowCodes: number[] = []
 
     // Start symbol: Code 128 Start B (value 104)
-    rowCodes.push(104);
+    rowCodes.push(104)
 
     // First codeword: row indicator using CODE_B + row number mod
     // For Code 16K, the first symbol after start encodes the row mode
-    rowCodes.push(CODE_B); // Switch to Code B
-    rowCodes.push(r); // Row number as first data codeword
+    rowCodes.push(CODE_B) // Switch to Code B
+    rowCodes.push(r) // Row number as first data codeword
 
     // Data codewords for this row
     for (let c = 0; c < cwPerRow; c++) {
-      rowCodes.push(values[r * cwPerRow + c]!);
+      rowCodes.push(values[r * cwPerRow + c]!)
     }
 
     // Calculate check digit (mod 103, same as Code 128)
-    let checksum = rowCodes[0]!;
+    let checksum = rowCodes[0]!
     for (let i = 1; i < rowCodes.length; i++) {
-      checksum += rowCodes[i]! * i;
+      checksum += rowCodes[i]! * i
     }
-    rowCodes.push(checksum % 103);
+    rowCodes.push(checksum % 103)
 
     // Convert codewords to module pattern
-    const modules: boolean[] = [];
-    let isBar = true;
+    const modules: boolean[] = []
+    let isBar = true
 
     // Encode all codewords using Code 128 patterns
     for (const cw of rowCodes) {
-      const pattern = PATTERNS[cw]!;
+      const pattern = PATTERNS[cw]!
       for (const w of pattern) {
         for (let i = 0; i < w; i++) {
-          modules.push(isBar);
+          modules.push(isBar)
         }
-        isBar = !isBar;
+        isBar = !isBar
       }
     }
 
     // Stop pattern
     for (const w of STOP_PATTERN) {
       for (let i = 0; i < w; i++) {
-        modules.push(isBar);
+        modules.push(isBar)
       }
-      isBar = !isBar;
+      isBar = !isBar
     }
 
-    matrix.push(modules);
+    matrix.push(modules)
   }
 
-  return { matrix, rows, cols: matrix[0]?.length ?? 0 };
+  return { matrix, rows, cols: matrix[0]?.length ?? 0 }
 }

--- a/src/encoders/code39.ts
+++ b/src/encoders/code39.ts
@@ -3,15 +3,15 @@
  * Supports optional modulo-43 check digit
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Code 39 character set in index order:
 // 0-9 = indices 0-9, A-Z = indices 10-35,
 // - = 36, . = 37, (space) = 38, $ = 39, / = 40, + = 41, % = 42
-const CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%";
+const CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%"
 
 // Start/stop character (*)
-const START_STOP_INDEX = 43;
+const START_STOP_INDEX = 43
 
 // Patterns: 9 elements per character (B S B S B S B S B)
 // narrow = 1, wide = 3
@@ -60,15 +60,15 @@ const PATTERNS: readonly number[][] = [
   [1, 3, 1, 1, 1, 3, 1, 3, 1], // + (41)
   [1, 1, 1, 3, 1, 3, 1, 3, 1], // % (42)
   [1, 3, 1, 1, 3, 1, 3, 1, 1], // * (43, start/stop)
-];
+]
 
 // Narrow inter-character gap
-const GAP = 1;
+const GAP = 1
 
 // Character index lookup for fast validation
-const CHAR_INDEX = new Map<string, number>();
+const CHAR_INDEX = new Map<string, number>()
 for (let i = 0; i < CHARSET.length; i++) {
-  CHAR_INDEX.set(CHARSET[i]!, i);
+  CHAR_INDEX.set(CHARSET[i]!, i)
 }
 
 /**
@@ -214,15 +214,15 @@ const EXTENDED_MAP: string[] = [
   "%R", // 125 }
   "%S", // 126 ~
   "%T", // 127 DEL
-];
+]
 
 /**
  * Append a character's pattern to the bars array
  */
 function appendPattern(bars: number[], index: number): void {
-  const pattern = PATTERNS[index]!;
+  const pattern = PATTERNS[index]!
   for (const width of pattern) {
-    bars.push(width);
+    bars.push(width)
   }
 }
 
@@ -230,11 +230,11 @@ function appendPattern(bars: number[], index: number): void {
  * Calculate modulo-43 check digit for given character indices
  */
 function calculateCheckDigit(indices: number[]): number {
-  let sum = 0;
+  let sum = 0
   for (const index of indices) {
-    sum += index;
+    sum += index
   }
-  return sum % 43;
+  return sum % 43
 }
 
 /**
@@ -246,50 +246,50 @@ function calculateCheckDigit(indices: number[]): number {
  * @returns Array of bar widths (alternating bar/space)
  */
 export function encodeCode39(text: string, options?: { checkDigit?: boolean }): number[] {
-  const includeCheckDigit = options?.checkDigit ?? false;
+  const includeCheckDigit = options?.checkDigit ?? false
 
   if (text.length === 0) {
-    throw new InvalidInputError("Code 39 input must not be empty");
+    throw new InvalidInputError("Code 39 input must not be empty")
   }
 
   if (text.includes("*")) {
-    throw new InvalidInputError("Code 39 input must not contain the start/stop character (*)");
+    throw new InvalidInputError("Code 39 input must not contain the start/stop character (*)")
   }
 
   // Validate and collect character indices
-  const indices: number[] = [];
+  const indices: number[] = []
   for (let i = 0; i < text.length; i++) {
-    const ch = text[i]!;
-    const index = CHAR_INDEX.get(ch);
+    const ch = text[i]!
+    const index = CHAR_INDEX.get(ch)
     if (index === undefined) {
-      throw new InvalidInputError(`Invalid Code 39 character: '${ch}' at position ${i}`);
+      throw new InvalidInputError(`Invalid Code 39 character: '${ch}' at position ${i}`)
     }
-    indices.push(index);
+    indices.push(index)
   }
 
   // Optionally compute check digit
   if (includeCheckDigit) {
-    indices.push(calculateCheckDigit(indices));
+    indices.push(calculateCheckDigit(indices))
   }
 
-  const bars: number[] = [];
+  const bars: number[] = []
 
   // Start character (*)
-  appendPattern(bars, START_STOP_INDEX);
+  appendPattern(bars, START_STOP_INDEX)
 
   // Inter-character gap
-  bars.push(GAP);
+  bars.push(GAP)
 
   // Data characters
   for (let i = 0; i < indices.length; i++) {
-    appendPattern(bars, indices[i]!);
-    bars.push(GAP); // inter-character gap (also before stop)
+    appendPattern(bars, indices[i]!)
+    bars.push(GAP) // inter-character gap (also before stop)
   }
 
   // Stop character (*)
-  appendPattern(bars, START_STOP_INDEX);
+  appendPattern(bars, START_STOP_INDEX)
 
-  return bars;
+  return bars
 }
 
 /**
@@ -302,21 +302,21 @@ export function encodeCode39(text: string, options?: { checkDigit?: boolean }): 
  */
 export function encodeCode39Extended(text: string, options?: { checkDigit?: boolean }): number[] {
   if (text.length === 0) {
-    throw new InvalidInputError("Code 39 Extended input must not be empty");
+    throw new InvalidInputError("Code 39 Extended input must not be empty")
   }
 
   // Map each ASCII character to Code 39 character(s)
-  let mapped = "";
+  let mapped = ""
   for (let i = 0; i < text.length; i++) {
-    const code = text.charCodeAt(i);
+    const code = text.charCodeAt(i)
     if (code < 0 || code > 127) {
       throw new InvalidInputError(
         `Invalid Code 39 Extended character: '${text[i]}' (code ${code}) at position ${i} — only ASCII 0-127 supported`,
-      );
+      )
     }
-    mapped += EXTENDED_MAP[code]!;
+    mapped += EXTENDED_MAP[code]!
   }
 
   // Encode the mapped string as standard Code 39
-  return encodeCode39(mapped, options);
+  return encodeCode39(mapped, options)
 }

--- a/src/encoders/code93.ts
+++ b/src/encoders/code93.ts
@@ -4,10 +4,10 @@
  * Each character encoded as 9 modules (3 bars, 3 spaces)
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Code 93 character set (47 characters + 4 shift characters)
-const CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%";
+const CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%"
 // Shift characters at indices 43-46: ($), (%), (/), (+)
 
 // Binary patterns for each character value (9 modules, 1=bar, 0=space)
@@ -59,139 +59,139 @@ const BINARY_PATTERNS: string[] = [
   "111011010", // 44: (%) shift
   "111010110", // 45: (/) shift
   "100110010", // 46: (+) shift
-];
+]
 
-const START_STOP_BINARY = "101011110";
+const START_STOP_BINARY = "101011110"
 
 /**
  * Convert a binary pattern string (e.g. '101001000') to bar/space widths
  * Starting with bar (1s), alternating bar/space
  */
 function binaryToWidths(binary: string): number[] {
-  const widths: number[] = [];
-  let i = 0;
+  const widths: number[] = []
+  let i = 0
   while (i < binary.length) {
-    const currentBit = binary[i];
-    let count = 0;
+    const currentBit = binary[i]
+    let count = 0
     while (i < binary.length && binary[i] === currentBit) {
-      count++;
-      i++;
+      count++
+      i++
     }
-    widths.push(count);
+    widths.push(count)
   }
-  return widths;
+  return widths
 }
 
 // Pre-compute all width patterns
-const WIDTH_PATTERNS: number[][] = BINARY_PATTERNS.map(binaryToWidths);
-const START_STOP_PATTERN: number[] = binaryToWidths(START_STOP_BINARY);
+const WIDTH_PATTERNS: number[][] = BINARY_PATTERNS.map(binaryToWidths)
+const START_STOP_PATTERN: number[] = binaryToWidths(START_STOP_BINARY)
 
 // Extended ASCII mapping: each ASCII char (0-127) maps to a sequence of Code 93 values
 // Shift characters: ($)=43, (%)=44, (/)=45, (+)=46
-const EXTENDED_MAP: (number[] | null)[] = buildExtendedMap();
+const EXTENDED_MAP: (number[] | null)[] = buildExtendedMap()
 
 function buildExtendedMap(): (number[] | null)[] {
-  const map: (number[] | null)[] = Array.from<number[] | null>({ length: 128 }).fill(null);
+  const map: (number[] | null)[] = Array.from<number[] | null>({ length: 128 }).fill(null)
 
   // ASCII 0: (%U)
-  map[0] = [44, 30];
+  map[0] = [44, 30]
 
   // ASCII 1-26: ($A) through ($Z)
   for (let i = 1; i <= 26; i++) {
-    map[i] = [43, i + 9]; // ($) + A-Z
+    map[i] = [43, i + 9] // ($) + A-Z
   }
 
   // ASCII 27-31: (%A) through (%E)
   for (let i = 27; i <= 31; i++) {
-    map[i] = [44, i - 27 + 10]; // (%) + A-E
+    map[i] = [44, i - 27 + 10] // (%) + A-E
   }
 
   // ASCII 32 (space): native value 38
-  map[32] = [38];
+  map[32] = [38]
 
   // ASCII 33-47: punctuation and symbols
-  map[33] = [45, 10]; // ! = (/A)
-  map[34] = [45, 11]; // " = (/B)
-  map[35] = [45, 12]; // # = (/C)
-  map[36] = [39]; // $ (native)
-  map[37] = [42]; // % (native)
-  map[38] = [45, 15]; // & = (/F)
-  map[39] = [45, 16]; // ' = (/G)
-  map[40] = [45, 17]; // ( = (/H)
-  map[41] = [45, 18]; // ) = (/I)
-  map[42] = [45, 19]; // * = (/J)
-  map[43] = [41]; // + (native)
-  map[44] = [45, 21]; // , = (/L)
-  map[45] = [36]; // - (native)
-  map[46] = [37]; // . (native)
-  map[47] = [40]; // / (native)
+  map[33] = [45, 10] // ! = (/A)
+  map[34] = [45, 11] // " = (/B)
+  map[35] = [45, 12] // # = (/C)
+  map[36] = [39] // $ (native)
+  map[37] = [42] // % (native)
+  map[38] = [45, 15] // & = (/F)
+  map[39] = [45, 16] // ' = (/G)
+  map[40] = [45, 17] // ( = (/H)
+  map[41] = [45, 18] // ) = (/I)
+  map[42] = [45, 19] // * = (/J)
+  map[43] = [41] // + (native)
+  map[44] = [45, 21] // , = (/L)
+  map[45] = [36] // - (native)
+  map[46] = [37] // . (native)
+  map[47] = [40] // / (native)
 
   // ASCII 48-57: digits 0-9 (native values 0-9)
   for (let i = 48; i <= 57; i++) {
-    map[i] = [i - 48];
+    map[i] = [i - 48]
   }
 
   // ASCII 58-64: punctuation
-  map[58] = [45, 35]; // : = (/Z)
-  map[59] = [44, 15]; // ; = (%F)
-  map[60] = [44, 16]; // < = (%G)
-  map[61] = [44, 17]; // = = (%H)
-  map[62] = [44, 18]; // > = (%I)
-  map[63] = [44, 19]; // ? = (%J)
-  map[64] = [44, 31]; // @ = (%V)
+  map[58] = [45, 35] // : = (/Z)
+  map[59] = [44, 15] // ; = (%F)
+  map[60] = [44, 16] // < = (%G)
+  map[61] = [44, 17] // = = (%H)
+  map[62] = [44, 18] // > = (%I)
+  map[63] = [44, 19] // ? = (%J)
+  map[64] = [44, 31] // @ = (%V)
 
   // ASCII 65-90: A-Z (native values 10-35)
   for (let i = 65; i <= 90; i++) {
-    map[i] = [i - 55];
+    map[i] = [i - 55]
   }
 
   // ASCII 91-96: brackets and related
-  map[91] = [44, 20]; // [ = (%K)
-  map[92] = [44, 21]; // \ = (%L)
-  map[93] = [44, 22]; // ] = (%M)
-  map[94] = [44, 23]; // ^ = (%N)
-  map[95] = [44, 24]; // _ = (%O)
-  map[96] = [44, 32]; // ` = (%W)
+  map[91] = [44, 20] // [ = (%K)
+  map[92] = [44, 21] // \ = (%L)
+  map[93] = [44, 22] // ] = (%M)
+  map[94] = [44, 23] // ^ = (%N)
+  map[95] = [44, 24] // _ = (%O)
+  map[96] = [44, 32] // ` = (%W)
 
   // ASCII 97-122: a-z = (+A) through (+Z)
   for (let i = 97; i <= 122; i++) {
-    map[i] = [46, i - 87]; // (+) + A-Z
+    map[i] = [46, i - 87] // (+) + A-Z
   }
 
   // ASCII 123-127: braces and special
-  map[123] = [44, 25]; // { = (%P)
-  map[124] = [44, 26]; // | = (%Q)
-  map[125] = [44, 27]; // } = (%R)
-  map[126] = [44, 28]; // ~ = (%S)
-  map[127] = [44, 29]; // DEL = (%T)
+  map[123] = [44, 25] // { = (%P)
+  map[124] = [44, 26] // | = (%Q)
+  map[125] = [44, 27] // } = (%R)
+  map[126] = [44, 28] // ~ = (%S)
+  map[127] = [44, 29] // DEL = (%T)
 
-  return map;
+  return map
 }
 
 /**
  * Look up the Code 93 value for a native character
  */
 function charToValue(ch: string): number {
-  const idx = CHARSET.indexOf(ch);
+  const idx = CHARSET.indexOf(ch)
   if (idx === -1) {
     throw new InvalidInputError(
       `Invalid Code 93 character: '${ch}'. Valid characters: 0-9, A-Z, -, ., space, $, /, +, %`,
-    );
+    )
   }
-  return idx;
+  return idx
 }
 
 /**
  * Calculate check digit C (modulo 47, weights cycle 1-20 from right)
  */
 function calculateCheckC(values: number[]): number {
-  let sum = 0;
-  const len = values.length;
+  let sum = 0
+  const len = values.length
   for (let i = 0; i < len; i++) {
-    const weight = ((len - 1 - i) % 20) + 1;
-    sum += values[i]! * weight;
+    const weight = ((len - 1 - i) % 20) + 1
+    sum += values[i]! * weight
   }
-  return sum % 47;
+  return sum % 47
 }
 
 /**
@@ -199,13 +199,13 @@ function calculateCheckC(values: number[]): number {
  * Includes check digit C in the calculation
  */
 function calculateCheckK(values: number[]): number {
-  let sum = 0;
-  const len = values.length;
+  let sum = 0
+  const len = values.length
   for (let i = 0; i < len; i++) {
-    const weight = ((len - 1 - i) % 15) + 1;
-    sum += values[i]! * weight;
+    const weight = ((len - 1 - i) % 15) + 1
+    sum += values[i]! * weight
   }
-  return sum % 47;
+  return sum % 47
 }
 
 /**
@@ -216,54 +216,54 @@ function calculateCheckK(values: number[]): number {
  */
 export function encodeCode93(text: string): number[] {
   if (text.length === 0) {
-    throw new InvalidInputError("Code 93 input must not be empty");
+    throw new InvalidInputError("Code 93 input must not be empty")
   }
 
   // Convert text to values
-  const values: number[] = [];
+  const values: number[] = []
   for (const ch of text) {
-    values.push(charToValue(ch));
+    values.push(charToValue(ch))
   }
 
   // Calculate check digits
-  const checkC = calculateCheckC(values);
-  const valuesWithC = [...values, checkC];
-  const checkK = calculateCheckK(valuesWithC);
+  const checkC = calculateCheckC(values)
+  const valuesWithC = [...values, checkC]
+  const checkK = calculateCheckK(valuesWithC)
 
   // Build bar widths
-  const bars: number[] = [];
+  const bars: number[] = []
 
   // Start sentinel
   for (const w of START_STOP_PATTERN) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Data characters
   for (const val of values) {
     for (const w of WIDTH_PATTERNS[val]!) {
-      bars.push(w);
+      bars.push(w)
     }
   }
 
   // Check digit C
   for (const w of WIDTH_PATTERNS[checkC]!) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Check digit K
   for (const w of WIDTH_PATTERNS[checkK]!) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Stop sentinel
   for (const w of START_STOP_PATTERN) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Termination bar (single module bar)
-  bars.push(1);
+  bars.push(1)
 
-  return bars;
+  return bars
 }
 
 /**
@@ -273,66 +273,66 @@ export function encodeCode93(text: string): number[] {
  */
 export function encodeCode93Extended(text: string): number[] {
   if (text.length === 0) {
-    throw new InvalidInputError("Code 93 Extended input must not be empty");
+    throw new InvalidInputError("Code 93 Extended input must not be empty")
   }
 
   // Convert full ASCII text to Code 93 values using extended mapping
-  const values: number[] = [];
+  const values: number[] = []
   for (let i = 0; i < text.length; i++) {
-    const code = text.charCodeAt(i);
+    const code = text.charCodeAt(i)
     if (code < 0 || code > 127) {
       throw new InvalidInputError(
         `Code 93 Extended only supports ASCII characters (0-127), got character code ${code} at position ${i}`,
-      );
+      )
     }
-    const mapping = EXTENDED_MAP[code];
+    const mapping = EXTENDED_MAP[code]
     if (mapping === null) {
       throw new InvalidInputError(
         `No Code 93 Extended mapping for character code ${code} at position ${i}`,
-      );
+      )
     }
     for (const val of mapping) {
-      values.push(val);
+      values.push(val)
     }
   }
 
   // Calculate check digits
-  const checkC = calculateCheckC(values);
-  const valuesWithC = [...values, checkC];
-  const checkK = calculateCheckK(valuesWithC);
+  const checkC = calculateCheckC(values)
+  const valuesWithC = [...values, checkC]
+  const checkK = calculateCheckK(valuesWithC)
 
   // Build bar widths
-  const bars: number[] = [];
+  const bars: number[] = []
 
   // Start sentinel
   for (const w of START_STOP_PATTERN) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Data characters
   for (const val of values) {
     for (const w of WIDTH_PATTERNS[val]!) {
-      bars.push(w);
+      bars.push(w)
     }
   }
 
   // Check digit C
   for (const w of WIDTH_PATTERNS[checkC]!) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Check digit K
   for (const w of WIDTH_PATTERNS[checkK]!) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Stop sentinel
   for (const w of START_STOP_PATTERN) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Termination bar (single module bar)
-  bars.push(1);
+  bars.push(1)
 
-  return bars;
+  return bars
 }

--- a/src/encoders/datamatrix/encoder.ts
+++ b/src/encoders/datamatrix/encoder.ts
@@ -3,7 +3,7 @@
  * Converts input text into data codewords per ISO/IEC 16022
  */
 
-import { InvalidInputError } from "../../errors";
+import { InvalidInputError } from "../../errors"
 
 /**
  * Encode text into Data Matrix data codewords using ASCII encoding.
@@ -14,16 +14,16 @@ import { InvalidInputError } from "../../errors";
  * - Extended ASCII 128-255: codeword 235 (Upper Shift) followed by value - 127
  */
 export function encodeASCII(text: string): number[] {
-  const codewords: number[] = [];
-  let i = 0;
+  const codewords: number[] = []
+  let i = 0
 
   while (i < text.length) {
-    const charCode = text.charCodeAt(i);
+    const charCode = text.charCodeAt(i)
 
     if (charCode > 255) {
       throw new InvalidInputError(
         `Data Matrix ASCII mode does not support character: "${text[i]}" (U+${charCode.toString(16).padStart(4, "0")})`,
-      );
+      )
     }
 
     // Check for digit pair optimization
@@ -34,22 +34,22 @@ export function encodeASCII(text: string): number[] {
       text.charCodeAt(i + 1) >= 48 &&
       text.charCodeAt(i + 1) <= 57 // next char is '0'-'9'
     ) {
-      const pairValue = (charCode - 48) * 10 + (text.charCodeAt(i + 1) - 48);
-      codewords.push(pairValue + 130);
-      i += 2;
+      const pairValue = (charCode - 48) * 10 + (text.charCodeAt(i + 1) - 48)
+      codewords.push(pairValue + 130)
+      i += 2
     } else if (charCode >= 128) {
       // Extended ASCII: Upper Shift + (value - 127)
-      codewords.push(235);
-      codewords.push(charCode - 127);
-      i++;
+      codewords.push(235)
+      codewords.push(charCode - 127)
+      i++
     } else {
       // Standard ASCII: value + 1
-      codewords.push(charCode + 1);
-      i++;
+      codewords.push(charCode + 1)
+      i++
     }
   }
 
-  return codewords;
+  return codewords
 }
 
 /**
@@ -57,21 +57,21 @@ export function encodeASCII(text: string): number[] {
  * Uses pad value 129 with the 253-state randomization algorithm.
  */
 export function padCodewords(codewords: number[], capacity: number): number[] {
-  const padded = [...codewords];
+  const padded = [...codewords]
 
   if (padded.length < capacity) {
     // First pad codeword is always 129
-    padded.push(129);
+    padded.push(129)
   }
 
   // Remaining pad codewords use the 253-state randomization
   while (padded.length < capacity) {
-    const position = padded.length + 1; // 1-based position
-    const randomized = randomizePad(129, position);
-    padded.push(randomized);
+    const position = padded.length + 1 // 1-based position
+    const randomized = randomizePad(129, position)
+    padded.push(randomized)
   }
 
-  return padded;
+  return padded
 }
 
 /**
@@ -79,9 +79,9 @@ export function padCodewords(codewords: number[], capacity: number): number[] {
  * Ensures pad values appear pseudo-random to avoid false patterns.
  */
 function randomizePad(padValue: number, position: number): number {
-  const pseudoRandom = ((149 * position) % 253) + 1;
-  const result = padValue + pseudoRandom;
-  return result <= 254 ? result : result - 254;
+  const pseudoRandom = ((149 * position) % 253) + 1
+  const result = padValue + pseudoRandom
+  return result <= 254 ? result : result - 254
 }
 
 // C40 character set values
@@ -90,30 +90,30 @@ function randomizePad(padValue: number, position: number): number {
 // Set 2 (shift 2): !"#$%&'()*+,-./:;<=>?@[\]^_
 // Set 3 (shift 3): `a-z{|}~DEL
 function c40Value(ch: number): { set: number; value: number } {
-  if (ch === 32) return { set: 0, value: 3 }; // space
-  if (ch >= 48 && ch <= 57) return { set: 0, value: ch - 48 + 4 }; // 0-9
-  if (ch >= 65 && ch <= 90) return { set: 0, value: ch - 65 + 14 }; // A-Z
-  if (ch >= 0 && ch <= 31) return { set: 1, value: ch }; // control
-  if (ch >= 33 && ch <= 47) return { set: 2, value: ch - 33 }; // !"#$%&'()*+,-./
-  if (ch >= 58 && ch <= 64) return { set: 2, value: ch - 58 + 15 }; // :;<=>?@
-  if (ch >= 91 && ch <= 95) return { set: 2, value: ch - 91 + 22 }; // [\]^_
-  if (ch >= 96 && ch <= 127) return { set: 3, value: ch - 96 }; // `a-z{|}~
-  return { set: -1, value: 0 }; // not C40 encodable
+  if (ch === 32) return { set: 0, value: 3 } // space
+  if (ch >= 48 && ch <= 57) return { set: 0, value: ch - 48 + 4 } // 0-9
+  if (ch >= 65 && ch <= 90) return { set: 0, value: ch - 65 + 14 } // A-Z
+  if (ch >= 0 && ch <= 31) return { set: 1, value: ch } // control
+  if (ch >= 33 && ch <= 47) return { set: 2, value: ch - 33 } // !"#$%&'()*+,-./
+  if (ch >= 58 && ch <= 64) return { set: 2, value: ch - 58 + 15 } // :;<=>?@
+  if (ch >= 91 && ch <= 95) return { set: 2, value: ch - 91 + 22 } // [\]^_
+  if (ch >= 96 && ch <= 127) return { set: 3, value: ch - 96 } // `a-z{|}~
+  return { set: -1, value: 0 } // not C40 encodable
 }
 
 // Text mode: same as C40 but swaps upper/lowercase
 function textValue(ch: number): { set: number; value: number } {
-  if (ch === 32) return { set: 0, value: 3 };
-  if (ch >= 48 && ch <= 57) return { set: 0, value: ch - 48 + 4 };
-  if (ch >= 97 && ch <= 122) return { set: 0, value: ch - 97 + 14 }; // a-z in basic set
-  if (ch >= 0 && ch <= 31) return { set: 1, value: ch };
-  if (ch >= 33 && ch <= 47) return { set: 2, value: ch - 33 };
-  if (ch >= 58 && ch <= 64) return { set: 2, value: ch - 58 + 15 };
-  if (ch >= 91 && ch <= 95) return { set: 2, value: ch - 91 + 22 };
-  if (ch === 96) return { set: 3, value: 0 }; // backtick
-  if (ch >= 65 && ch <= 90) return { set: 3, value: ch - 65 + 1 }; // A-Z in shift 3
-  if (ch >= 123 && ch <= 127) return { set: 3, value: ch - 123 + 27 };
-  return { set: -1, value: 0 };
+  if (ch === 32) return { set: 0, value: 3 }
+  if (ch >= 48 && ch <= 57) return { set: 0, value: ch - 48 + 4 }
+  if (ch >= 97 && ch <= 122) return { set: 0, value: ch - 97 + 14 } // a-z in basic set
+  if (ch >= 0 && ch <= 31) return { set: 1, value: ch }
+  if (ch >= 33 && ch <= 47) return { set: 2, value: ch - 33 }
+  if (ch >= 58 && ch <= 64) return { set: 2, value: ch - 58 + 15 }
+  if (ch >= 91 && ch <= 95) return { set: 2, value: ch - 91 + 22 }
+  if (ch === 96) return { set: 3, value: 0 } // backtick
+  if (ch >= 65 && ch <= 90) return { set: 3, value: ch - 65 + 1 } // A-Z in shift 3
+  if (ch >= 123 && ch <= 127) return { set: 3, value: ch - 123 + 27 }
+  return { set: -1, value: 0 }
 }
 
 /**
@@ -122,7 +122,7 @@ function textValue(ch: number): { set: number; value: number } {
  * Latch: codeword 230
  */
 export function encodeC40(text: string): number[] {
-  return encodeC40Text(text, 230, c40Value);
+  return encodeC40Text(text, 230, c40Value)
 }
 
 /**
@@ -131,7 +131,7 @@ export function encodeC40(text: string): number[] {
  * Latch: codeword 239
  */
 export function encodeTextMode(text: string): number[] {
-  return encodeC40Text(text, 239, textValue);
+  return encodeC40Text(text, 239, textValue)
 }
 
 function encodeC40Text(
@@ -139,40 +139,40 @@ function encodeC40Text(
   latchCW: number,
   valueFn: (ch: number) => { set: number; value: number },
 ): number[] {
-  const codewords: number[] = [latchCW]; // Latch to C40/Text
-  const values: number[] = [];
+  const codewords: number[] = [latchCW] // Latch to C40/Text
+  const values: number[] = []
   // Track which source character index each value came from
-  const valueCharIndex: number[] = [];
+  const valueCharIndex: number[] = []
 
   // Index of the first character that cannot be represented in C40/Text and
   // must therefore be encoded in ASCII, or text.length when there is none.
-  let fallbackFrom = text.length;
+  let fallbackFrom = text.length
 
   for (let i = 0; i < text.length; i++) {
-    const ch = text.charCodeAt(i);
-    const { set, value } = valueFn(ch);
+    const ch = text.charCodeAt(i)
+    const { set, value } = valueFn(ch)
     if (set === -1) {
-      fallbackFrom = i;
-      break;
+      fallbackFrom = i
+      break
     }
     if (set > 0) {
-      values.push(set - 1); // Shift indicator (0=shift1, 1=shift2, 2=shift3)
-      valueCharIndex.push(i);
-      values.push(value);
-      valueCharIndex.push(i);
+      values.push(set - 1) // Shift indicator (0=shift1, 1=shift2, 2=shift3)
+      valueCharIndex.push(i)
+      values.push(value)
+      valueCharIndex.push(i)
     } else {
-      values.push(value);
-      valueCharIndex.push(i);
+      values.push(value)
+      valueCharIndex.push(i)
     }
   }
 
   // Pack triplets into codeword pairs
-  let i = 0;
+  let i = 0
   while (i + 2 < values.length) {
-    const v = values[i]! * 1600 + values[i + 1]! * 40 + values[i + 2]! + 1;
-    codewords.push(Math.floor(v / 256));
-    codewords.push(v % 256);
-    i += 3;
+    const v = values[i]! * 1600 + values[i + 1]! * 40 + values[i + 2]! + 1
+    codewords.push(Math.floor(v / 256))
+    codewords.push(v % 256)
+    i += 3
   }
 
   // Unlatch, then encode in ASCII everything the triplets did not cover: any
@@ -183,13 +183,13 @@ function encodeC40Text(
   // are interpreted in ASCII mode. Per ISO 16022 an exact fit makes the unlatch
   // redundant, but the symbol size is not known here; encodeAuto() discards
   // C40/Text whenever the extra codeword makes it longer than plain ASCII.
-  const asciiFrom = i < values.length ? valueCharIndex[i]! : fallbackFrom;
-  codewords.push(254); // Unlatch to ASCII
+  const asciiFrom = i < values.length ? valueCharIndex[i]! : fallbackFrom
+  codewords.push(254) // Unlatch to ASCII
   if (asciiFrom < text.length) {
-    codewords.push(...encodeASCII(text.substring(asciiFrom)));
+    codewords.push(...encodeASCII(text.substring(asciiFrom)))
   }
 
-  return codewords;
+  return codewords
 }
 
 /**
@@ -198,28 +198,28 @@ function encodeC40Text(
  */
 export function encodeAuto(text: string): number[] {
   // Count uppercase vs lowercase to decide
-  let upper = 0;
-  let lower = 0;
-  let digits = 0;
+  let upper = 0
+  let lower = 0
+  let digits = 0
   for (const ch of text) {
-    const c = ch.charCodeAt(0);
-    if (c >= 65 && c <= 90) upper++;
-    else if (c >= 97 && c <= 122) lower++;
-    else if (c >= 48 && c <= 57) digits++;
+    const c = ch.charCodeAt(0)
+    if (c >= 65 && c <= 90) upper++
+    else if (c >= 97 && c <= 122) lower++
+    else if (c >= 48 && c <= 57) digits++
   }
 
   // C40 is best for uppercase-heavy, Text for lowercase-heavy
-  const asciiCW = encodeASCII(text);
+  const asciiCW = encodeASCII(text)
 
   if (upper + digits > text.length * 0.6) {
-    const c40CW = encodeC40(text);
-    if (c40CW.length < asciiCW.length) return c40CW;
+    const c40CW = encodeC40(text)
+    if (c40CW.length < asciiCW.length) return c40CW
   }
 
   if (lower + digits > text.length * 0.6) {
-    const textCW = encodeTextMode(text);
-    if (textCW.length < asciiCW.length) return textCW;
+    const textCW = encodeTextMode(text)
+    if (textCW.length < asciiCW.length) return textCW
   }
 
-  return asciiCW;
+  return asciiCW
 }

--- a/src/encoders/datamatrix/index.ts
+++ b/src/encoders/datamatrix/index.ts
@@ -5,12 +5,12 @@
  * Based on ISO/IEC 16022
  */
 
-import { InvalidInputError, CapacityError } from "../../errors";
-import { encodeAuto, padCodewords } from "./encoder";
-import { selectSymbolSize } from "./tables";
-import { generateInterleavedEC } from "./reed-solomon";
-import { placeModules } from "./placement";
-import { parseAIString, isVariableLength } from "../gs1-128";
+import { InvalidInputError, CapacityError } from "../../errors"
+import { encodeAuto, padCodewords } from "./encoder"
+import { selectSymbolSize } from "./tables"
+import { generateInterleavedEC } from "./reed-solomon"
+import { placeModules } from "./placement"
+import { parseAIString, isVariableLength } from "../gs1-128"
 
 /**
  * Encode text as a Data Matrix ECC 200 symbol.
@@ -27,35 +27,35 @@ import { parseAIString, isVariableLength } from "../gs1-128";
  */
 export function encodeDataMatrix(text: string): boolean[][] {
   if (text.length === 0) {
-    throw new InvalidInputError("Data Matrix input must not be empty");
+    throw new InvalidInputError("Data Matrix input must not be empty")
   }
 
   // Step 1: Encode text to data codewords (auto-select best mode)
-  const dataCodewords = encodeAuto(text);
+  const dataCodewords = encodeAuto(text)
 
   // Step 2: Select the smallest symbol size that fits the data
-  const symbol = selectSymbolSize(dataCodewords.length);
+  const symbol = selectSymbolSize(dataCodewords.length)
   if (!symbol) {
     throw new CapacityError(
       `Data too long for Data Matrix: ${dataCodewords.length} codewords needed, maximum is 1558`,
-    );
+    )
   }
 
   // Step 3: Pad data codewords to fill symbol capacity
-  const paddedData = padCodewords(dataCodewords, symbol.totalDataCodewords);
+  const paddedData = padCodewords(dataCodewords, symbol.totalDataCodewords)
 
   // Step 4: Generate error correction codewords
   const ecCodewords = generateInterleavedEC(
     paddedData,
     symbol.ecCodewords,
     symbol.interleavedBlocks,
-  );
+  )
 
   // Step 5: Combine data and EC codewords
-  const allCodewords = [...paddedData, ...ecCodewords];
+  const allCodewords = [...paddedData, ...ecCodewords]
 
   // Step 6: Place codewords into the matrix with finder patterns
-  return placeModules(allCodewords, symbol);
+  return placeModules(allCodewords, symbol)
 }
 
 /**
@@ -67,44 +67,44 @@ export function encodeDataMatrix(text: string): boolean[][] {
  */
 export function encodeGS1DataMatrix(text: string): boolean[][] {
   if (text.length === 0) {
-    throw new InvalidInputError("GS1 DataMatrix input must not be empty");
+    throw new InvalidInputError("GS1 DataMatrix input must not be empty")
   }
 
-  const fields = parseAIString(text);
+  const fields = parseAIString(text)
 
   // Build codewords: FNC1 (232) + AI data with FNC1 separators
-  const codewords: number[] = [232]; // FNC1 in first position
+  const codewords: number[] = [232] // FNC1 in first position
 
   for (let i = 0; i < fields.length; i++) {
-    const field = fields[i]!;
+    const field = fields[i]!
     // Encode AI digits
     for (const ch of field.ai) {
-      codewords.push(ch.charCodeAt(0) + 1);
+      codewords.push(ch.charCodeAt(0) + 1)
     }
     // Encode data
     for (const ch of field.data) {
-      codewords.push(ch.charCodeAt(0) + 1);
+      codewords.push(ch.charCodeAt(0) + 1)
     }
     // FNC1 separator after variable-length fields (except last)
     if (i < fields.length - 1 && isVariableLength(field.ai)) {
-      codewords.push(232);
+      codewords.push(232)
     }
   }
 
   // Select symbol, pad, EC, place — same as standard DataMatrix
-  const symbol = selectSymbolSize(codewords.length);
+  const symbol = selectSymbolSize(codewords.length)
   if (!symbol) {
     throw new CapacityError(
       `Data too long for GS1 DataMatrix: ${codewords.length} codewords needed`,
-    );
+    )
   }
 
-  const paddedData = padCodewords(codewords, symbol.totalDataCodewords);
+  const paddedData = padCodewords(codewords, symbol.totalDataCodewords)
   const ecCodewords = generateInterleavedEC(
     paddedData,
     symbol.ecCodewords,
     symbol.interleavedBlocks,
-  );
-  const allCodewords = [...paddedData, ...ecCodewords];
-  return placeModules(allCodewords, symbol);
+  )
+  const allCodewords = [...paddedData, ...ecCodewords]
+  return placeModules(allCodewords, symbol)
 }

--- a/src/encoders/datamatrix/placement.ts
+++ b/src/encoders/datamatrix/placement.ts
@@ -4,8 +4,8 @@
  * and finder/alignment pattern generation.
  */
 
-import type { SymbolSize } from "./tables";
-import { getDataRegionCount } from "./tables";
+import type { SymbolSize } from "./tables"
+import { getDataRegionCount } from "./tables"
 
 /**
  * Build the module placement mapping for the data region.
@@ -19,52 +19,52 @@ import { getDataRegionCount } from "./tables";
  * These are the "logical" coordinates without finder/alignment patterns.
  */
 export function buildPlacementMap(mappingRows: number, mappingCols: number): number[] {
-  const totalModules = mappingRows * mappingCols;
+  const totalModules = mappingRows * mappingCols
   // Array storing which bit position goes in which cell
   // placed[row * mappingCols + col] = bit position (0-based), -1 = unassigned
-  const placed = new Int32Array(totalModules).fill(-1);
+  const placed = new Int32Array(totalModules).fill(-1)
 
-  let bitPos = 0;
-  let row = 4;
-  let col = 0;
+  let bitPos = 0
+  let row = 4
+  let col = 0
 
   // Main diagonal sweep
   while (row < mappingRows || col < mappingCols) {
     // Going up-right
     if (row === mappingRows && col === 0) {
-      bitPos = placeCorner1(placed, mappingRows, mappingCols, bitPos);
+      bitPos = placeCorner1(placed, mappingRows, mappingCols, bitPos)
     }
     if (row === mappingRows - 2 && col === 0 && mappingCols % 4 !== 0) {
-      bitPos = placeCorner2(placed, mappingRows, mappingCols, bitPos);
+      bitPos = placeCorner2(placed, mappingRows, mappingCols, bitPos)
     }
     if (row === mappingRows - 2 && col === 0 && mappingCols % 8 === 4) {
-      bitPos = placeCorner3(placed, mappingRows, mappingCols, bitPos);
+      bitPos = placeCorner3(placed, mappingRows, mappingCols, bitPos)
     }
     if (row === mappingRows + 4 && col === 2 && mappingCols % 8 === 0) {
-      bitPos = placeCorner4(placed, mappingRows, mappingCols, bitPos);
+      bitPos = placeCorner4(placed, mappingRows, mappingCols, bitPos)
     }
 
     // Sweep up-right
     while (row >= 0 && col < mappingCols) {
       if (row < mappingRows && col >= 0 && placed[row * mappingCols + col] === -1) {
-        bitPos = placeUtah(placed, mappingRows, mappingCols, row, col, bitPos);
+        bitPos = placeUtah(placed, mappingRows, mappingCols, row, col, bitPos)
       }
-      row -= 2;
-      col += 2;
+      row -= 2
+      col += 2
     }
-    row += 1;
-    col += 3;
+    row += 1
+    col += 3
 
     // Sweep down-left
     while (row < mappingRows && col >= 0) {
       if (row >= 0 && col < mappingCols && placed[row * mappingCols + col] === -1) {
-        bitPos = placeUtah(placed, mappingRows, mappingCols, row, col, bitPos);
+        bitPos = placeUtah(placed, mappingRows, mappingCols, row, col, bitPos)
       }
-      row += 2;
-      col -= 2;
+      row += 2
+      col -= 2
     }
-    row += 3;
-    col += 1;
+    row += 3
+    col += 1
   }
 
   // Fill unused corners with fixed pattern (required by spec)
@@ -72,11 +72,11 @@ export function buildPlacementMap(mappingRows: number, mappingCols: number): num
   // and the module diagonally above-left also gets dark.
   // Use special marker -2 to indicate "always dark" modules.
   if (placed[(mappingRows - 1) * mappingCols + (mappingCols - 1)] === -1) {
-    placed[(mappingRows - 1) * mappingCols + (mappingCols - 1)] = -2; // bottom-right: dark
-    placed[(mappingRows - 2) * mappingCols + (mappingCols - 2)] = -2; // diagonal: dark
+    placed[(mappingRows - 1) * mappingCols + (mappingCols - 1)] = -2 // bottom-right: dark
+    placed[(mappingRows - 2) * mappingCols + (mappingCols - 2)] = -2 // diagonal: dark
   }
 
-  return Array.from(placed);
+  return Array.from(placed)
 }
 
 /**
@@ -91,15 +91,15 @@ function placeUtah(
   col: number,
   bitPos: number,
 ): number {
-  placeModule(placed, numRows, numCols, row - 2, col - 2, bitPos, 0);
-  placeModule(placed, numRows, numCols, row - 2, col - 1, bitPos, 1);
-  placeModule(placed, numRows, numCols, row - 1, col - 2, bitPos, 2);
-  placeModule(placed, numRows, numCols, row - 1, col - 1, bitPos, 3);
-  placeModule(placed, numRows, numCols, row - 1, col, bitPos, 4);
-  placeModule(placed, numRows, numCols, row, col - 2, bitPos, 5);
-  placeModule(placed, numRows, numCols, row, col - 1, bitPos, 6);
-  placeModule(placed, numRows, numCols, row, col, bitPos, 7);
-  return bitPos + 8;
+  placeModule(placed, numRows, numCols, row - 2, col - 2, bitPos, 0)
+  placeModule(placed, numRows, numCols, row - 2, col - 1, bitPos, 1)
+  placeModule(placed, numRows, numCols, row - 1, col - 2, bitPos, 2)
+  placeModule(placed, numRows, numCols, row - 1, col - 1, bitPos, 3)
+  placeModule(placed, numRows, numCols, row - 1, col, bitPos, 4)
+  placeModule(placed, numRows, numCols, row, col - 2, bitPos, 5)
+  placeModule(placed, numRows, numCols, row, col - 1, bitPos, 6)
+  placeModule(placed, numRows, numCols, row, col, bitPos, 7)
+  return bitPos + 8
 }
 
 /** Place a single module, wrapping around if needed */
@@ -114,16 +114,16 @@ function placeModule(
 ): void {
   // Wrap around
   if (row < 0) {
-    row += numRows;
-    col += 4 - ((numRows + 4) % 8);
+    row += numRows
+    col += 4 - ((numRows + 4) % 8)
   }
   if (col < 0) {
-    col += numCols;
-    row += 4 - ((numCols + 4) % 8);
+    col += numCols
+    row += 4 - ((numCols + 4) % 8)
   }
 
   if (row >= 0 && row < numRows && col >= 0 && col < numCols) {
-    placed[row * numCols + col] = bitPos + bitOffset;
+    placed[row * numCols + col] = bitPos + bitOffset
   }
 }
 
@@ -136,15 +136,15 @@ function placeCorner1(
   numCols: number,
   bitPos: number,
 ): number {
-  placeModule(placed, numRows, numCols, numRows - 1, 0, bitPos, 0);
-  placeModule(placed, numRows, numCols, numRows - 1, 1, bitPos, 1);
-  placeModule(placed, numRows, numCols, numRows - 1, 2, bitPos, 2);
-  placeModule(placed, numRows, numCols, 0, numCols - 2, bitPos, 3);
-  placeModule(placed, numRows, numCols, 0, numCols - 1, bitPos, 4);
-  placeModule(placed, numRows, numCols, 1, numCols - 1, bitPos, 5);
-  placeModule(placed, numRows, numCols, 2, numCols - 1, bitPos, 6);
-  placeModule(placed, numRows, numCols, 3, numCols - 1, bitPos, 7);
-  return bitPos + 8;
+  placeModule(placed, numRows, numCols, numRows - 1, 0, bitPos, 0)
+  placeModule(placed, numRows, numCols, numRows - 1, 1, bitPos, 1)
+  placeModule(placed, numRows, numCols, numRows - 1, 2, bitPos, 2)
+  placeModule(placed, numRows, numCols, 0, numCols - 2, bitPos, 3)
+  placeModule(placed, numRows, numCols, 0, numCols - 1, bitPos, 4)
+  placeModule(placed, numRows, numCols, 1, numCols - 1, bitPos, 5)
+  placeModule(placed, numRows, numCols, 2, numCols - 1, bitPos, 6)
+  placeModule(placed, numRows, numCols, 3, numCols - 1, bitPos, 7)
+  return bitPos + 8
 }
 
 /**
@@ -156,15 +156,15 @@ function placeCorner2(
   numCols: number,
   bitPos: number,
 ): number {
-  placeModule(placed, numRows, numCols, numRows - 3, 0, bitPos, 0);
-  placeModule(placed, numRows, numCols, numRows - 2, 0, bitPos, 1);
-  placeModule(placed, numRows, numCols, numRows - 1, 0, bitPos, 2);
-  placeModule(placed, numRows, numCols, 0, numCols - 4, bitPos, 3);
-  placeModule(placed, numRows, numCols, 0, numCols - 3, bitPos, 4);
-  placeModule(placed, numRows, numCols, 0, numCols - 2, bitPos, 5);
-  placeModule(placed, numRows, numCols, 0, numCols - 1, bitPos, 6);
-  placeModule(placed, numRows, numCols, 1, numCols - 1, bitPos, 7);
-  return bitPos + 8;
+  placeModule(placed, numRows, numCols, numRows - 3, 0, bitPos, 0)
+  placeModule(placed, numRows, numCols, numRows - 2, 0, bitPos, 1)
+  placeModule(placed, numRows, numCols, numRows - 1, 0, bitPos, 2)
+  placeModule(placed, numRows, numCols, 0, numCols - 4, bitPos, 3)
+  placeModule(placed, numRows, numCols, 0, numCols - 3, bitPos, 4)
+  placeModule(placed, numRows, numCols, 0, numCols - 2, bitPos, 5)
+  placeModule(placed, numRows, numCols, 0, numCols - 1, bitPos, 6)
+  placeModule(placed, numRows, numCols, 1, numCols - 1, bitPos, 7)
+  return bitPos + 8
 }
 
 /**
@@ -176,15 +176,15 @@ function placeCorner3(
   numCols: number,
   bitPos: number,
 ): number {
-  placeModule(placed, numRows, numCols, numRows - 3, 0, bitPos, 0);
-  placeModule(placed, numRows, numCols, numRows - 2, 0, bitPos, 1);
-  placeModule(placed, numRows, numCols, numRows - 1, 0, bitPos, 2);
-  placeModule(placed, numRows, numCols, 0, numCols - 2, bitPos, 3);
-  placeModule(placed, numRows, numCols, 0, numCols - 1, bitPos, 4);
-  placeModule(placed, numRows, numCols, 1, numCols - 1, bitPos, 5);
-  placeModule(placed, numRows, numCols, 2, numCols - 1, bitPos, 6);
-  placeModule(placed, numRows, numCols, 3, numCols - 1, bitPos, 7);
-  return bitPos + 8;
+  placeModule(placed, numRows, numCols, numRows - 3, 0, bitPos, 0)
+  placeModule(placed, numRows, numCols, numRows - 2, 0, bitPos, 1)
+  placeModule(placed, numRows, numCols, numRows - 1, 0, bitPos, 2)
+  placeModule(placed, numRows, numCols, 0, numCols - 2, bitPos, 3)
+  placeModule(placed, numRows, numCols, 0, numCols - 1, bitPos, 4)
+  placeModule(placed, numRows, numCols, 1, numCols - 1, bitPos, 5)
+  placeModule(placed, numRows, numCols, 2, numCols - 1, bitPos, 6)
+  placeModule(placed, numRows, numCols, 3, numCols - 1, bitPos, 7)
+  return bitPos + 8
 }
 
 /**
@@ -196,15 +196,15 @@ function placeCorner4(
   numCols: number,
   bitPos: number,
 ): number {
-  placeModule(placed, numRows, numCols, numRows - 1, 0, bitPos, 0);
-  placeModule(placed, numRows, numCols, numRows - 1, numCols - 1, bitPos, 1);
-  placeModule(placed, numRows, numCols, 0, numCols - 3, bitPos, 2);
-  placeModule(placed, numRows, numCols, 0, numCols - 2, bitPos, 3);
-  placeModule(placed, numRows, numCols, 0, numCols - 1, bitPos, 4);
-  placeModule(placed, numRows, numCols, 1, numCols - 3, bitPos, 5);
-  placeModule(placed, numRows, numCols, 1, numCols - 2, bitPos, 6);
-  placeModule(placed, numRows, numCols, 1, numCols - 1, bitPos, 7);
-  return bitPos + 8;
+  placeModule(placed, numRows, numCols, numRows - 1, 0, bitPos, 0)
+  placeModule(placed, numRows, numCols, numRows - 1, numCols - 1, bitPos, 1)
+  placeModule(placed, numRows, numCols, 0, numCols - 3, bitPos, 2)
+  placeModule(placed, numRows, numCols, 0, numCols - 2, bitPos, 3)
+  placeModule(placed, numRows, numCols, 0, numCols - 1, bitPos, 4)
+  placeModule(placed, numRows, numCols, 1, numCols - 3, bitPos, 5)
+  placeModule(placed, numRows, numCols, 1, numCols - 2, bitPos, 6)
+  placeModule(placed, numRows, numCols, 1, numCols - 1, bitPos, 7)
+  return bitPos + 8
 }
 
 /**
@@ -216,32 +216,32 @@ function placeCorner4(
  * @returns 2D boolean matrix (true = dark module)
  */
 export function placeModules(allCodewords: number[], symbol: SymbolSize): boolean[][] {
-  const { horizontalRegions, verticalRegions } = getDataRegionCount(symbol);
-  const mappingRows = symbol.dataRegionRows * verticalRegions;
-  const mappingCols = symbol.dataRegionCols * horizontalRegions;
+  const { horizontalRegions, verticalRegions } = getDataRegionCount(symbol)
+  const mappingRows = symbol.dataRegionRows * verticalRegions
+  const mappingCols = symbol.dataRegionCols * horizontalRegions
 
   // Build placement map
-  const placementMap = buildPlacementMap(mappingRows, mappingCols);
+  const placementMap = buildPlacementMap(mappingRows, mappingCols)
 
   // Create the mapping (logical) matrix
   const mappingMatrix: boolean[][] = Array.from({ length: mappingRows }, () =>
     Array.from<boolean>({ length: mappingCols }).fill(false),
-  );
+  )
 
   // Place codeword bits into the mapping matrix
   for (let r = 0; r < mappingRows; r++) {
     for (let c = 0; c < mappingCols; c++) {
-      const bitIndex = placementMap[r * mappingCols + c]!;
+      const bitIndex = placementMap[r * mappingCols + c]!
       if (bitIndex === -2) {
         // Fixed dark module (bottom-right corner pattern)
-        mappingMatrix[r]![c] = true;
+        mappingMatrix[r]![c] = true
       } else if (bitIndex >= 0) {
-        const codewordIndex = Math.floor(bitIndex / 8);
-        const bitOffset = bitIndex % 8;
+        const codewordIndex = Math.floor(bitIndex / 8)
+        const bitOffset = bitIndex % 8
         if (codewordIndex < allCodewords.length) {
           // MSB first: bit 0 is the most significant bit
-          const bitValue = (allCodewords[codewordIndex]! >> (7 - bitOffset)) & 1;
-          mappingMatrix[r]![c] = bitValue === 1;
+          const bitValue = (allCodewords[codewordIndex]! >> (7 - bitOffset)) & 1
+          mappingMatrix[r]![c] = bitValue === 1
         }
       }
     }
@@ -250,46 +250,46 @@ export function placeModules(allCodewords: number[], symbol: SymbolSize): boolea
   // Build the final matrix with finder patterns and alignment patterns
   const finalMatrix: boolean[][] = Array.from({ length: symbol.rows }, () =>
     Array.from<boolean>({ length: symbol.cols }).fill(false),
-  );
+  )
 
   // Draw finder patterns and clock tracks for each data region
   for (let vr = 0; vr < verticalRegions; vr++) {
     for (let hr = 0; hr < horizontalRegions; hr++) {
-      const regionStartRow = vr * (symbol.dataRegionRows + 2);
-      const regionStartCol = hr * (symbol.dataRegionCols + 2);
+      const regionStartRow = vr * (symbol.dataRegionRows + 2)
+      const regionStartCol = hr * (symbol.dataRegionCols + 2)
 
       // Clock track: alternating top edge and right edge
       for (let c = 0; c < symbol.dataRegionCols + 2; c++) {
         // Top alternating line: even columns dark, odd columns light
-        finalMatrix[regionStartRow]![regionStartCol + c] = c % 2 === 0;
+        finalMatrix[regionStartRow]![regionStartCol + c] = c % 2 === 0
       }
       for (let r = 0; r < symbol.dataRegionRows + 2; r++) {
         // Right alternating line: even rows light, odd rows dark
-        finalMatrix[regionStartRow + r]![regionStartCol + symbol.dataRegionCols + 1] = r % 2 !== 0;
+        finalMatrix[regionStartRow + r]![regionStartCol + symbol.dataRegionCols + 1] = r % 2 !== 0
       }
 
       // L-shaped finder pattern (drawn after clock track so solid edges take precedence at corners)
       for (let c = 0; c < symbol.dataRegionCols + 2; c++) {
         // Bottom solid line
-        finalMatrix[regionStartRow + symbol.dataRegionRows + 1]![regionStartCol + c] = true;
+        finalMatrix[regionStartRow + symbol.dataRegionRows + 1]![regionStartCol + c] = true
       }
       for (let r = 0; r < symbol.dataRegionRows + 2; r++) {
         // Left solid line
-        finalMatrix[regionStartRow + r]![regionStartCol] = true;
+        finalMatrix[regionStartRow + r]![regionStartCol] = true
       }
 
       // Copy data modules from mapping matrix into the data region
       for (let dr = 0; dr < symbol.dataRegionRows; dr++) {
         for (let dc = 0; dc < symbol.dataRegionCols; dc++) {
-          const mappingRow = vr * symbol.dataRegionRows + dr;
-          const mappingCol = hr * symbol.dataRegionCols + dc;
-          const finalRow = regionStartRow + 1 + dr;
-          const finalCol = regionStartCol + 1 + dc;
-          finalMatrix[finalRow]![finalCol] = mappingMatrix[mappingRow]![mappingCol]!;
+          const mappingRow = vr * symbol.dataRegionRows + dr
+          const mappingCol = hr * symbol.dataRegionCols + dc
+          const finalRow = regionStartRow + 1 + dr
+          const finalCol = regionStartCol + 1 + dc
+          finalMatrix[finalRow]![finalCol] = mappingMatrix[mappingRow]![mappingCol]!
         }
       }
     }
   }
 
-  return finalMatrix;
+  return finalMatrix
 }

--- a/src/encoders/datamatrix/reed-solomon.ts
+++ b/src/encoders/datamatrix/reed-solomon.ts
@@ -4,28 +4,28 @@
  */
 
 // Galois Field GF(256) lookup tables for polynomial 0x12D
-const GF_EXP = new Uint8Array(512);
-const GF_LOG = new Uint8Array(256);
+const GF_EXP = new Uint8Array(512)
+const GF_LOG = new Uint8Array(256)
 
 // Initialize GF(256) tables with primitive polynomial 0x12D
-(function initGF() {
-  let x = 1;
+;(function initGF() {
+  let x = 1
   for (let i = 0; i < 255; i++) {
-    GF_EXP[i] = x;
-    GF_LOG[x] = i;
-    x = x << 1;
-    if (x >= 256) x ^= 0x12d;
+    GF_EXP[i] = x
+    GF_LOG[x] = i
+    x = x << 1
+    if (x >= 256) x ^= 0x12d
   }
   // Extend exp table for easier modular arithmetic
   for (let i = 255; i < 512; i++) {
-    GF_EXP[i] = GF_EXP[i - 255]!;
+    GF_EXP[i] = GF_EXP[i - 255]!
   }
-})();
+})()
 
 /** Multiply two GF(256) elements */
 function gfMultiply(a: number, b: number): number {
-  if (a === 0 || b === 0) return 0;
-  return GF_EXP[(GF_LOG[a]! + GF_LOG[b]!) % 255]!;
+  if (a === 0 || b === 0) return 0
+  return GF_EXP[(GF_LOG[a]! + GF_LOG[b]!) % 255]!
 }
 
 /**
@@ -38,29 +38,29 @@ function gfMultiply(a: number, b: number): number {
 export function generateECCodewords(data: number[], ecCount: number): number[] {
   // Build generator polynomial per ISO 16022:
   // g(x) = (x - a^1)(x - a^2)...(x - a^ecCount)
-  const gen: number[] = Array.from({ length: ecCount + 1 }, () => 0);
-  gen[0] = 1;
+  const gen: number[] = Array.from({ length: ecCount + 1 }, () => 0)
+  gen[0] = 1
 
   for (let i = 1; i <= ecCount; i++) {
     for (let j = gen.length - 1; j >= 1; j--) {
-      gen[j] = gen[j - 1]! ^ gfMultiply(gen[j]!, GF_EXP[i]!);
+      gen[j] = gen[j - 1]! ^ gfMultiply(gen[j]!, GF_EXP[i]!)
     }
-    gen[0] = gfMultiply(gen[0]!, GF_EXP[i]!);
+    gen[0] = gfMultiply(gen[0]!, GF_EXP[i]!)
   }
 
   // Polynomial long division: data polynomial / generator polynomial
   // gen[0] = constant term, gen[ecCount] = leading coefficient (1)
   // Division needs coefficients in descending degree order
-  const result = Array.from({ length: ecCount }, () => 0);
+  const result = Array.from({ length: ecCount }, () => 0)
   for (const byte of data) {
-    const lead = byte ^ result[0]!;
+    const lead = byte ^ result[0]!
     for (let j = 0; j < ecCount - 1; j++) {
-      result[j] = result[j + 1]! ^ gfMultiply(lead, gen[ecCount - 1 - j]!);
+      result[j] = result[j + 1]! ^ gfMultiply(lead, gen[ecCount - 1 - j]!)
     }
-    result[ecCount - 1] = gfMultiply(lead, gen[0]!);
+    result[ecCount - 1] = gfMultiply(lead, gen[0]!)
   }
 
-  return result;
+  return result
 }
 
 /**
@@ -77,36 +77,36 @@ export function generateInterleavedEC(
   ecCodewordsTotal: number,
   interleavedBlocks: number,
 ): number[] {
-  const ecPerBlock = ecCodewordsTotal / interleavedBlocks;
-  const dataLength = dataCodewords.length;
-  const baseBlockSize = Math.floor(dataLength / interleavedBlocks);
-  const largerBlocks = dataLength % interleavedBlocks;
+  const ecPerBlock = ecCodewordsTotal / interleavedBlocks
+  const dataLength = dataCodewords.length
+  const baseBlockSize = Math.floor(dataLength / interleavedBlocks)
+  const largerBlocks = dataLength % interleavedBlocks
 
   // Split data into interleaved blocks
-  const blocks: number[][] = [];
-  let pos = 0;
+  const blocks: number[][] = []
+  let pos = 0
 
   for (let b = 0; b < interleavedBlocks; b++) {
     // First (interleavedBlocks - largerBlocks) blocks get baseBlockSize codewords,
     // remaining largerBlocks blocks get baseBlockSize + 1
-    const blockSize = b < interleavedBlocks - largerBlocks ? baseBlockSize : baseBlockSize + 1;
-    blocks.push(dataCodewords.slice(pos, pos + blockSize));
-    pos += blockSize;
+    const blockSize = b < interleavedBlocks - largerBlocks ? baseBlockSize : baseBlockSize + 1
+    blocks.push(dataCodewords.slice(pos, pos + blockSize))
+    pos += blockSize
   }
 
   // Generate EC for each block
-  const ecBlocks: number[][] = [];
+  const ecBlocks: number[][] = []
   for (const block of blocks) {
-    ecBlocks.push(generateECCodewords(block, ecPerBlock));
+    ecBlocks.push(generateECCodewords(block, ecPerBlock))
   }
 
   // Interleave EC codewords
-  const result: number[] = [];
+  const result: number[] = []
   for (let i = 0; i < ecPerBlock; i++) {
     for (let b = 0; b < interleavedBlocks; b++) {
-      result.push(ecBlocks[b]![i]!);
+      result.push(ecBlocks[b]![i]!)
     }
   }
 
-  return result;
+  return result
 }

--- a/src/encoders/datamatrix/tables.ts
+++ b/src/encoders/datamatrix/tables.ts
@@ -4,13 +4,13 @@
  */
 
 export interface SymbolSize {
-  rows: number;
-  cols: number;
-  dataRegionRows: number;
-  dataRegionCols: number;
-  totalDataCodewords: number;
-  ecCodewords: number;
-  interleavedBlocks: number;
+  rows: number
+  cols: number
+  dataRegionRows: number
+  dataRegionCols: number
+  totalDataCodewords: number
+  ecCodewords: number
+  interleavedBlocks: number
 }
 
 // prettier-ignore
@@ -54,10 +54,10 @@ export const SYMBOL_SIZES: readonly SymbolSize[] = [
 export function selectSymbolSize(dataCodewords: number): SymbolSize | undefined {
   for (const size of SYMBOL_SIZES) {
     if (size.totalDataCodewords >= dataCodewords) {
-      return size;
+      return size
     }
   }
-  return undefined;
+  return undefined
 }
 
 /**
@@ -66,10 +66,10 @@ export function selectSymbolSize(dataCodewords: number): SymbolSize | undefined 
  * into multiple data regions separated by alignment patterns.
  */
 export function getDataRegionCount(symbol: SymbolSize): {
-  horizontalRegions: number;
-  verticalRegions: number;
+  horizontalRegions: number
+  verticalRegions: number
 } {
-  const horizontalRegions = symbol.cols / (symbol.dataRegionCols + 2);
-  const verticalRegions = symbol.rows / (symbol.dataRegionRows + 2);
-  return { horizontalRegions, verticalRegions };
+  const horizontalRegions = symbol.cols / (symbol.dataRegionCols + 2)
+  const verticalRegions = symbol.rows / (symbol.dataRegionRows + 2)
+  return { horizontalRegions, verticalRegions }
 }

--- a/src/encoders/deutsche-post.ts
+++ b/src/encoders/deutsche-post.ts
@@ -3,19 +3,19 @@
  * Based on Interleaved 2 of 5 with modulo 10 check digit (weights 4,9)
  */
 
-import { InvalidInputError } from "../errors";
-import { encodeITF } from "./itf";
+import { InvalidInputError } from "../errors"
+import { encodeITF } from "./itf"
 
 /**
  * Calculate Deutsche Post check digit (mod 10, weights 4 and 9 alternating)
  */
 export function dpCheckDigit(digits: string): number {
-  let sum = 0;
+  let sum = 0
   for (let i = 0; i < digits.length; i++) {
-    const weight = i % 2 === 0 ? 4 : 9;
-    sum += Number.parseInt(digits[i]!, 10) * weight;
+    const weight = i % 2 === 0 ? 4 : 9
+    sum += Number.parseInt(digits[i]!, 10) * weight
   }
-  return (10 - (sum % 10)) % 10;
+  return (10 - (sum % 10)) % 10
 }
 
 /**
@@ -26,28 +26,28 @@ export function dpCheckDigit(digits: string): number {
  * @returns Bar widths array (Interleaved 2 of 5 encoding)
  */
 export function encodeIdentcode(text: string): number[] {
-  const digits = text.replace(/\s/g, "");
+  const digits = text.replace(/\s/g, "")
   if (!/^\d+$/.test(digits)) {
-    throw new InvalidInputError("Identcode only accepts digits");
+    throw new InvalidInputError("Identcode only accepts digits")
   }
 
-  let data: string;
+  let data: string
   if (digits.length === 11) {
-    data = digits + dpCheckDigit(digits);
+    data = digits + dpCheckDigit(digits)
   } else if (digits.length === 12) {
-    const expected = dpCheckDigit(digits.slice(0, 11));
-    const provided = Number(digits[11]);
+    const expected = dpCheckDigit(digits.slice(0, 11))
+    const provided = Number(digits[11])
     if (provided !== expected) {
       throw new InvalidInputError(
         `Identcode check digit mismatch: expected ${expected}, got ${provided}`,
-      );
+      )
     }
-    data = digits;
+    data = digits
   } else {
-    throw new InvalidInputError("Identcode requires 11 or 12 digits");
+    throw new InvalidInputError("Identcode requires 11 or 12 digits")
   }
 
-  return encodeITF(data);
+  return encodeITF(data)
 }
 
 /**
@@ -58,26 +58,26 @@ export function encodeIdentcode(text: string): number[] {
  * @returns Bar widths array (Interleaved 2 of 5 encoding)
  */
 export function encodeLeitcode(text: string): number[] {
-  const digits = text.replace(/\s/g, "");
+  const digits = text.replace(/\s/g, "")
   if (!/^\d+$/.test(digits)) {
-    throw new InvalidInputError("Leitcode only accepts digits");
+    throw new InvalidInputError("Leitcode only accepts digits")
   }
 
-  let data: string;
+  let data: string
   if (digits.length === 13) {
-    data = digits + dpCheckDigit(digits);
+    data = digits + dpCheckDigit(digits)
   } else if (digits.length === 14) {
-    const expected = dpCheckDigit(digits.slice(0, 13));
-    const provided = Number(digits[13]);
+    const expected = dpCheckDigit(digits.slice(0, 13))
+    const provided = Number(digits[13])
     if (provided !== expected) {
       throw new InvalidInputError(
         `Leitcode check digit mismatch: expected ${expected}, got ${provided}`,
-      );
+      )
     }
-    data = digits;
+    data = digits
   } else {
-    throw new InvalidInputError("Leitcode requires 13 or 14 digits");
+    throw new InvalidInputError("Leitcode requires 13 or 14 digits")
   }
 
-  return encodeITF(data);
+  return encodeITF(data)
 }

--- a/src/encoders/dotcode.ts
+++ b/src/encoders/dotcode.ts
@@ -9,7 +9,7 @@
  * - GF(113) Reed-Solomon error correction (prime field, alpha = 3)
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // ---------------------------------------------------------------------------
 // GF(113) prime field arithmetic
@@ -17,39 +17,39 @@ import { InvalidInputError } from "../errors";
 // Primitive root alpha = 3 (order 112 = p-1).
 // ---------------------------------------------------------------------------
 
-const GF = 113;
-const GF_ORDER = GF - 1; // 112
+const GF = 113
+const GF_ORDER = GF - 1 // 112
 
 /** Exponent table: GF113_EXP[i] = alpha^i mod 113, i = 0..111 */
-const GF113_EXP = new Uint8Array(GF_ORDER);
+const GF113_EXP = new Uint8Array(GF_ORDER)
 
 /** Log table: GF113_LOG[v] = i where alpha^i = v, for v = 1..112 */
-const GF113_LOG = new Uint8Array(GF);
+const GF113_LOG = new Uint8Array(GF)
 
 // Initialize GF(113) lookup tables
-(function initGF113() {
-  let x = 1;
+;(function initGF113() {
+  let x = 1
   for (let i = 0; i < GF_ORDER; i++) {
-    GF113_EXP[i] = x;
-    GF113_LOG[x] = i;
-    x = (x * 3) % GF; // alpha = 3
+    GF113_EXP[i] = x
+    GF113_LOG[x] = i
+    x = (x * 3) % GF // alpha = 3
   }
-})();
+})()
 
 /** Multiply two GF(113) elements */
 function gfMul(a: number, b: number): number {
-  if (a === 0 || b === 0) return 0;
-  return GF113_EXP[(GF113_LOG[a]! + GF113_LOG[b]!) % GF_ORDER]!;
+  if (a === 0 || b === 0) return 0
+  return GF113_EXP[(GF113_LOG[a]! + GF113_LOG[b]!) % GF_ORDER]!
 }
 
 /** Add two GF(113) elements */
 function gfAdd(a: number, b: number): number {
-  return (a + b) % GF;
+  return (a + b) % GF
 }
 
 /** Subtract two GF(113) elements */
 function gfSub(a: number, b: number): number {
-  return (a - b + GF) % GF;
+  return (a - b + GF) % GF
 }
 
 // ---------------------------------------------------------------------------
@@ -65,19 +65,19 @@ function gfSub(a: number, b: number): number {
  * g(x) = g_0 * x^n + g_1 * x^(n-1) + ... + g_n.
  */
 function buildGenerator(n: number): number[] {
-  const gen = Array.from<number>({ length: n + 1 }).fill(0);
-  gen[0] = 1;
+  const gen = Array.from<number>({ length: n + 1 }).fill(0)
+  gen[0] = 1
 
   for (let i = 1; i <= n; i++) {
-    const root = GF113_EXP[i % GF_ORDER]!; // alpha^i
+    const root = GF113_EXP[i % GF_ORDER]! // alpha^i
     // Multiply current gen by (x - root)
     for (let j = i; j >= 1; j--) {
-      gen[j] = gfSub(gen[j - 1]!, gfMul(gen[j]!, root));
+      gen[j] = gfSub(gen[j - 1]!, gfMul(gen[j]!, root))
     }
-    gen[0] = gfMul(gen[0]!, (GF - root) % GF);
+    gen[0] = gfMul(gen[0]!, (GF - root) % GF)
   }
 
-  return gen;
+  return gen
 }
 
 /**
@@ -92,26 +92,26 @@ function buildGenerator(n: number): number[] {
  * @returns Array of `ecCount` EC codewords
  */
 function dotcodeEC(data: number[], ecCount: number): number[] {
-  const gen = buildGenerator(ecCount);
+  const gen = buildGenerator(ecCount)
 
   // Polynomial long division (shift register)
-  const remainder = Array.from<number>({ length: ecCount }).fill(0);
+  const remainder = Array.from<number>({ length: ecCount }).fill(0)
 
   for (const d of data) {
-    const feedback = gfAdd(d, remainder[0]!);
+    const feedback = gfAdd(d, remainder[0]!)
     for (let j = 0; j < ecCount - 1; j++) {
-      remainder[j] = gfSub(remainder[j + 1]!, gfMul(feedback, gen[j + 1]!));
+      remainder[j] = gfSub(remainder[j + 1]!, gfMul(feedback, gen[j + 1]!))
     }
-    remainder[ecCount - 1] = gfSub(0, gfMul(feedback, gen[ecCount]!));
+    remainder[ecCount - 1] = gfSub(0, gfMul(feedback, gen[ecCount]!))
   }
 
   // Negate remainder to get check symbols
-  const ec = Array.from<number>({ length: ecCount });
+  const ec = Array.from<number>({ length: ecCount })
   for (let i = 0; i < ecCount; i++) {
-    ec[i] = (GF - remainder[i]!) % GF;
+    ec[i] = (GF - remainder[i]!) % GF
   }
 
-  return ec;
+  return ec
 }
 
 // ---------------------------------------------------------------------------
@@ -124,95 +124,95 @@ function dotcodeEC(data: number[], ecCount: number): number[] {
  */
 export function encodeDotCode(text: string): boolean[][] {
   if (text.length === 0) {
-    throw new InvalidInputError("DotCode input must not be empty");
+    throw new InvalidInputError("DotCode input must not be empty")
   }
 
   // Encode data as DotCode codewords (Code Set B style: ASCII - 32)
   // DotCode uses Code 128-like encoding with codewords 0..112
   // CW 106 = Upper Shift (FNC3), 107 = binary shift, 108-112 = special
-  const codewords: number[] = [];
+  const codewords: number[] = []
   // Mode indicator: CW 106 signals start of data
-  codewords.push(106);
+  codewords.push(106)
   for (const ch of text) {
-    const code = ch.charCodeAt(0);
+    const code = ch.charCodeAt(0)
     if (code >= 32 && code <= 127) {
       // Printable ASCII: charCode - 32 (Code Set B mapping)
-      codewords.push(code - 32);
+      codewords.push(code - 32)
     } else if (code < 32) {
       // Control characters: direct value
-      codewords.push(code + 64);
+      codewords.push(code + 64)
     } else {
       // Extended: binary shift
-      codewords.push(107);
-      codewords.push(code % GF);
+      codewords.push(107)
+      codewords.push(code % GF)
       if (code >= GF) {
-        codewords.push(Math.floor(code / GF));
+        codewords.push(Math.floor(code / GF))
       }
     }
   }
 
   // Select symbol size per Zint/AIM ISS DotCode algorithm
-  const dataCW = codewords.length;
+  const dataCW = codewords.length
   // EC count: at least half data + 3 overhead
-  const ecCW = Math.max(3, Math.floor(dataCW / 2) + 3);
-  const totalCW = dataCW + ecCW;
+  const ecCW = Math.max(3, Math.floor(dataCW / 2) + 3)
+  const totalCW = dataCW + ecCW
   // min_dots = 9 * totalCW + 2 (mask bits). min_area = min_dots * 2
-  const minDots = 9 * totalCW + 2;
-  const minArea = minDots * 2;
+  const minDots = 9 * totalCW + 2
+  const minArea = minDots * 2
 
   // 3:2 aspect ratio preference (width > height)
-  let height = Math.max(5, Math.round(Math.sqrt(minArea * 0.666)));
-  let width = Math.max(5, Math.round(Math.sqrt(minArea * 1.5)));
+  let height = Math.max(5, Math.round(Math.sqrt(minArea * 0.666)))
+  let width = Math.max(5, Math.round(Math.sqrt(minArea * 1.5)))
 
   // Ensure minimum area
   while (width * height < minArea) {
-    width++;
+    width++
   }
 
   // Ensure height + width is odd
   if ((width + height) % 2 === 0) {
-    width++;
-    if (width * height < minArea) height++;
+    width++
+    if (width * height < minArea) height++
   }
 
   // Pad data codewords to fill available data capacity
-  const paddedData = codewords.slice();
+  const paddedData = codewords.slice()
   while (paddedData.length < dataCW) {
-    paddedData.push(109); // pad codeword
+    paddedData.push(109) // pad codeword
   }
 
   // Generate EC codewords
   // Clamp data values to GF(113) range for RS computation
-  const rsData = paddedData.map((v) => v % GF);
-  const ec = dotcodeEC(rsData, ecCW);
-  const allCW = [...rsData, ...ec];
+  const rsData = paddedData.map((v) => v % GF)
+  const ec = dotcodeEC(rsData, ecCW)
+  const allCW = [...rsData, ...ec]
 
   // Build matrix with checkerboard pattern
   const matrix: boolean[][] = Array.from({ length: height }, () =>
     Array.from({ length: width }, () => false),
-  );
+  )
 
   // Place data as dots in checkerboard positions
-  let cwIdx = 0;
-  let bitIdx = 0;
+  let cwIdx = 0
+  let bitIdx = 0
 
   for (let r = 0; r < height; r++) {
     for (let c = 0; c < width; c++) {
       // Checkerboard: only (r+c) % 2 === 0 positions can have dots
-      if ((r + c) % 2 !== 0) continue;
+      if ((r + c) % 2 !== 0) continue
 
       if (cwIdx < allCW.length) {
         // Each codeword contributes 7 bits (ceil(log2(113)) = 7)
-        const bit = (allCW[cwIdx]! >> (6 - bitIdx)) & 1;
-        matrix[r]![c] = bit === 1;
-        bitIdx++;
+        const bit = (allCW[cwIdx]! >> (6 - bitIdx)) & 1
+        matrix[r]![c] = bit === 1
+        bitIdx++
         if (bitIdx >= 7) {
-          bitIdx = 0;
-          cwIdx++;
+          bitIdx = 0
+          cwIdx++
         }
       }
     }
   }
 
-  return matrix;
+  return matrix
 }

--- a/src/encoders/ean-addon.ts
+++ b/src/encoders/ean-addon.ts
@@ -3,7 +3,7 @@
  * Supplemental barcodes used alongside EAN-13/UPC-A for periodicals and books
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // L patterns (left odd parity) — same as EAN
 const L_PATTERNS: number[][] = [
@@ -17,7 +17,7 @@ const L_PATTERNS: number[][] = [
   [1, 3, 1, 2], // 7
   [1, 2, 1, 3], // 8
   [3, 1, 1, 2], // 9
-];
+]
 
 // G patterns (left even parity) — same as EAN
 const G_PATTERNS: number[][] = [
@@ -31,13 +31,13 @@ const G_PATTERNS: number[][] = [
   [2, 1, 3, 1], // 7
   [3, 1, 2, 1], // 8
   [2, 1, 1, 3], // 9
-];
+]
 
 // Start guard for addon barcodes: bar, space, bar+space pattern (1011)
-const ADDON_START = [1, 1, 2];
+const ADDON_START = [1, 1, 2]
 
 // Delineator between digits (01 = space, bar)
-const ADDON_DELINEATOR = [1, 1];
+const ADDON_DELINEATOR = [1, 1]
 
 // EAN-2 parity based on value mod 4
 // 0 = L pattern, 1 = G pattern
@@ -46,7 +46,7 @@ const EAN2_PARITY: number[][] = [
   [0, 1], // 1: LG
   [1, 0], // 2: GL
   [1, 1], // 3: GG
-];
+]
 
 // EAN-5 parity based on checksum digit
 // 0 = L pattern, 1 = G pattern
@@ -61,19 +61,19 @@ const EAN5_PARITY: number[][] = [
   [0, 1, 0, 1, 0], // 7: LGLGL
   [0, 1, 0, 0, 1], // 8: LGLLG
   [0, 0, 1, 0, 1], // 9: LLGLG
-];
+]
 
 /**
  * Validate that a string contains only digits of the expected length
  */
 function validateDigits(text: string, expected: number, name: string): number[] {
   if (!/^\d+$/.test(text)) {
-    throw new InvalidInputError(`${name} requires digits only (0-9)`);
+    throw new InvalidInputError(`${name} requires digits only (0-9)`)
   }
   if (text.length !== expected) {
-    throw new InvalidInputError(`${name} requires exactly ${expected} digits`);
+    throw new InvalidInputError(`${name} requires exactly ${expected} digits`)
   }
-  return text.split("").map(Number);
+  return text.split("").map(Number)
 }
 
 /**
@@ -83,17 +83,17 @@ function validateDigits(text: string, expected: number, name: string): number[] 
  * @returns Array of bar widths (alternating bar/space)
  */
 export function encodeEAN2(text: string): number[] {
-  const digits = validateDigits(text, 2, "EAN-2");
+  const digits = validateDigits(text, 2, "EAN-2")
 
   // Parity based on the 2-digit value mod 4
-  const value = digits[0]! * 10 + digits[1]!;
-  const parity = EAN2_PARITY[value % 4]!;
+  const value = digits[0]! * 10 + digits[1]!
+  const parity = EAN2_PARITY[value % 4]!
 
-  const bars: number[] = [];
+  const bars: number[] = []
 
   // Start guard
   for (const w of ADDON_START) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Encode each digit
@@ -101,18 +101,18 @@ export function encodeEAN2(text: string): number[] {
     // Delineator between digits (not before the first)
     if (i > 0) {
       for (const w of ADDON_DELINEATOR) {
-        bars.push(w);
+        bars.push(w)
       }
     }
 
-    const digit = digits[i]!;
-    const pattern = parity[i] === 0 ? L_PATTERNS[digit]! : G_PATTERNS[digit]!;
+    const digit = digits[i]!
+    const pattern = parity[i] === 0 ? L_PATTERNS[digit]! : G_PATTERNS[digit]!
     for (const w of pattern) {
-      bars.push(w);
+      bars.push(w)
     }
   }
 
-  return bars;
+  return bars
 }
 
 /**
@@ -120,12 +120,12 @@ export function encodeEAN2(text: string): number[] {
  * Formula: (d1*3 + d2*9 + d3*3 + d4*9 + d5*3) mod 10
  */
 function calculateEAN5Checksum(digits: number[]): number {
-  const weights = [3, 9, 3, 9, 3];
-  let sum = 0;
+  const weights = [3, 9, 3, 9, 3]
+  let sum = 0
   for (let i = 0; i < 5; i++) {
-    sum += digits[i]! * weights[i]!;
+    sum += digits[i]! * weights[i]!
   }
-  return sum % 10;
+  return sum % 10
 }
 
 /**
@@ -135,17 +135,17 @@ function calculateEAN5Checksum(digits: number[]): number {
  * @returns Array of bar widths (alternating bar/space)
  */
 export function encodeEAN5(text: string): number[] {
-  const digits = validateDigits(text, 5, "EAN-5");
+  const digits = validateDigits(text, 5, "EAN-5")
 
   // Calculate checksum to determine parity encoding
-  const checksum = calculateEAN5Checksum(digits);
-  const parity = EAN5_PARITY[checksum]!;
+  const checksum = calculateEAN5Checksum(digits)
+  const parity = EAN5_PARITY[checksum]!
 
-  const bars: number[] = [];
+  const bars: number[] = []
 
   // Start guard
   for (const w of ADDON_START) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Encode each digit
@@ -153,16 +153,16 @@ export function encodeEAN5(text: string): number[] {
     // Delineator between digits (not before the first)
     if (i > 0) {
       for (const w of ADDON_DELINEATOR) {
-        bars.push(w);
+        bars.push(w)
       }
     }
 
-    const digit = digits[i]!;
-    const pattern = parity[i] === 0 ? L_PATTERNS[digit]! : G_PATTERNS[digit]!;
+    const digit = digits[i]!
+    const pattern = parity[i] === 0 ? L_PATTERNS[digit]! : G_PATTERNS[digit]!
     for (const w of pattern) {
-      bars.push(w);
+      bars.push(w)
     }
   }
 
-  return bars;
+  return bars
 }

--- a/src/encoders/ean.ts
+++ b/src/encoders/ean.ts
@@ -2,7 +2,7 @@
  * EAN-13 and EAN-8 barcode encoder
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Encoding patterns for digits
 // L = left odd parity, G = left even parity, R = right
@@ -17,7 +17,7 @@ const L_PATTERNS: number[][] = [
   [1, 3, 1, 2], // 7
   [1, 2, 1, 3], // 8
   [3, 1, 1, 2], // 9
-];
+]
 
 const R_PATTERNS: number[][] = [
   [3, 2, 1, 1], // 0
@@ -30,7 +30,7 @@ const R_PATTERNS: number[][] = [
   [1, 3, 1, 2], // 7
   [1, 2, 1, 3], // 8
   [3, 1, 1, 2], // 9
-];
+]
 
 // G patterns (used for EAN-13 left side based on first digit)
 const G_PATTERNS: number[][] = [
@@ -44,7 +44,7 @@ const G_PATTERNS: number[][] = [
   [2, 1, 3, 1], // 7
   [3, 1, 2, 1], // 8
   [2, 1, 1, 3], // 9
-];
+]
 
 // First digit encoding for EAN-13 (which left digits use L vs G)
 // 0 = L pattern, 1 = G pattern
@@ -59,21 +59,21 @@ const FIRST_DIGIT_ENCODING: number[][] = [
   [0, 1, 0, 1, 0, 1], // 7
   [0, 1, 0, 1, 1, 0], // 8
   [0, 1, 1, 0, 1, 0], // 9
-];
+]
 
-const GUARD_START = [1, 1, 1]; // bar, space, bar
-const GUARD_CENTER = [1, 1, 1, 1, 1]; // space, bar, space, bar, space
-const GUARD_END = [1, 1, 1]; // bar, space, bar
+const GUARD_START = [1, 1, 1] // bar, space, bar
+const GUARD_CENTER = [1, 1, 1, 1, 1] // space, bar, space, bar, space
+const GUARD_END = [1, 1, 1] // bar, space, bar
 
 /**
  * Calculate EAN check digit
  */
 function calculateCheckDigit(digits: number[]): number {
-  let sum = 0;
+  let sum = 0
   for (let i = 0; i < digits.length; i++) {
-    sum += digits[i]! * (i % 2 === 0 ? 1 : 3);
+    sum += digits[i]! * (i % 2 === 0 ? 1 : 3)
   }
-  return (10 - (sum % 10)) % 10;
+  return (10 - (sum % 10)) % 10
 }
 
 /**
@@ -81,70 +81,70 @@ function calculateCheckDigit(digits: number[]): number {
  * Input: 12 or 13 digit string (13th is check digit, auto-calculated if 12)
  */
 export function encodeEAN13(text: string): { bars: number[]; guards: number[] } {
-  const digits = text.replace(/\D/g, "").split("").map(Number);
+  const digits = text.replace(/\D/g, "").split("").map(Number)
 
   if (digits.length === 12) {
-    digits.push(calculateCheckDigit(digits));
+    digits.push(calculateCheckDigit(digits))
   } else if (digits.length === 13) {
-    const expected = calculateCheckDigit(digits.slice(0, 12));
+    const expected = calculateCheckDigit(digits.slice(0, 12))
     if (digits[12] !== expected) {
       throw new InvalidInputError(
         `EAN-13 check digit mismatch: expected ${expected}, got ${digits[12]}`,
-      );
+      )
     }
   } else {
-    throw new InvalidInputError("EAN-13 requires 12 or 13 digits");
+    throw new InvalidInputError("EAN-13 requires 12 or 13 digits")
   }
 
-  const firstDigit = digits[0]!;
-  const encoding = FIRST_DIGIT_ENCODING[firstDigit]!;
+  const firstDigit = digits[0]!
+  const encoding = FIRST_DIGIT_ENCODING[firstDigit]!
 
-  const bars: number[] = [];
-  const guards: number[] = []; // positions of guard bars for rendering
+  const bars: number[] = []
+  const guards: number[] = [] // positions of guard bars for rendering
 
   // Start guard
-  let pos = 0;
-  guards.push(pos);
+  let pos = 0
+  guards.push(pos)
   for (const w of GUARD_START) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
   // Left 6 digits (digits[1] through digits[6])
   for (let i = 0; i < 6; i++) {
-    const digit = digits[i + 1]!;
-    const pattern = encoding[i] === 0 ? L_PATTERNS[digit]! : G_PATTERNS[digit]!;
+    const digit = digits[i + 1]!
+    const pattern = encoding[i] === 0 ? L_PATTERNS[digit]! : G_PATTERNS[digit]!
     for (const w of pattern) {
-      bars.push(w);
-      pos++;
+      bars.push(w)
+      pos++
     }
   }
 
   // Center guard
-  guards.push(pos);
+  guards.push(pos)
   for (const w of GUARD_CENTER) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
   // Right 6 digits (digits[7] through digits[12])
   for (let i = 0; i < 6; i++) {
-    const digit = digits[i + 7]!;
-    const pattern = R_PATTERNS[digit]!;
+    const digit = digits[i + 7]!
+    const pattern = R_PATTERNS[digit]!
     for (const w of pattern) {
-      bars.push(w);
-      pos++;
+      bars.push(w)
+      pos++
     }
   }
 
   // End guard
-  guards.push(pos);
+  guards.push(pos)
   for (const w of GUARD_END) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
-  return { bars, guards };
+  return { bars, guards }
 }
 
 /**
@@ -152,65 +152,65 @@ export function encodeEAN13(text: string): { bars: number[]; guards: number[] } 
  * Input: 7 or 8 digit string (8th is check digit, auto-calculated if 7)
  */
 export function encodeEAN8(text: string): { bars: number[]; guards: number[] } {
-  const digits = text.replace(/\D/g, "").split("").map(Number);
+  const digits = text.replace(/\D/g, "").split("").map(Number)
 
   if (digits.length === 7) {
-    digits.push(calculateCheckDigit(digits));
+    digits.push(calculateCheckDigit(digits))
   } else if (digits.length === 8) {
-    const expected = calculateCheckDigit(digits.slice(0, 7));
+    const expected = calculateCheckDigit(digits.slice(0, 7))
     if (digits[7] !== expected) {
       throw new InvalidInputError(
         `EAN-8 check digit mismatch: expected ${expected}, got ${digits[7]}`,
-      );
+      )
     }
   } else {
-    throw new InvalidInputError("EAN-8 requires 7 or 8 digits");
+    throw new InvalidInputError("EAN-8 requires 7 or 8 digits")
   }
 
-  const bars: number[] = [];
-  const guards: number[] = [];
+  const bars: number[] = []
+  const guards: number[] = []
 
   // Start guard
-  let pos = 0;
-  guards.push(pos);
+  let pos = 0
+  guards.push(pos)
   for (const w of GUARD_START) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
   // Left 4 digits (L encoding only)
   for (let i = 0; i < 4; i++) {
-    const digit = digits[i]!;
-    const pattern = L_PATTERNS[digit]!;
+    const digit = digits[i]!
+    const pattern = L_PATTERNS[digit]!
     for (const w of pattern) {
-      bars.push(w);
-      pos++;
+      bars.push(w)
+      pos++
     }
   }
 
   // Center guard
-  guards.push(pos);
+  guards.push(pos)
   for (const w of GUARD_CENTER) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
   // Right 4 digits
   for (let i = 0; i < 4; i++) {
-    const digit = digits[i + 4]!;
-    const pattern = R_PATTERNS[digit]!;
+    const digit = digits[i + 4]!
+    const pattern = R_PATTERNS[digit]!
     for (const w of pattern) {
-      bars.push(w);
-      pos++;
+      bars.push(w)
+      pos++
     }
   }
 
   // End guard
-  guards.push(pos);
+  guards.push(pos)
   for (const w of GUARD_END) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
-  return { bars, guards };
+  return { bars, guards }
 }

--- a/src/encoders/fourstate.ts
+++ b/src/encoders/fourstate.ts
@@ -9,10 +9,10 @@
  * - Full (F): extends both above and below
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 /** Bar state in a 4-state barcode */
-export type FourState = "T" | "A" | "D" | "F";
+export type FourState = "T" | "A" | "D" | "F"
 
 // RM4SCC encoding derived from 6x6 row/col matrix per Royal Mail specification
 // Characters 0-9, A-Z are assigned sequential indices 0-35 in a 6x6 grid.
@@ -27,37 +27,37 @@ const ROW_COL_BARS: FourState[][] = [
   ["A", "T"], // 3
   ["A", "F"], // 4
   ["F", "T"], // 5
-];
+]
 
-const RM4SCC_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const RM4SCC_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 function rm4sccEncode(ch: string): FourState[] {
-  const idx = RM4SCC_CHARS.indexOf(ch);
-  if (idx === -1) throw new InvalidInputError(`Invalid RM4SCC character: ${ch}`);
-  const row = Math.floor(idx / 6);
-  const col = idx % 6;
-  return [...ROW_COL_BARS[row]!, ...ROW_COL_BARS[col]!];
+  const idx = RM4SCC_CHARS.indexOf(ch)
+  if (idx === -1) throw new InvalidInputError(`Invalid RM4SCC character: ${ch}`)
+  const row = Math.floor(idx / 6)
+  const col = idx % 6
+  return [...ROW_COL_BARS[row]!, ...ROW_COL_BARS[col]!]
 }
 
 // Build lookup table for fast access
-const RM4SCC_TABLE: Record<string, FourState[]> = {};
+const RM4SCC_TABLE: Record<string, FourState[]> = {}
 for (const ch of RM4SCC_CHARS) {
-  RM4SCC_TABLE[ch] = rm4sccEncode(ch);
+  RM4SCC_TABLE[ch] = rm4sccEncode(ch)
 }
 
 /** Calculate RM4SCC check digit (modulo 6 row+col system) */
 function rm4sccCheckDigit(text: string): string {
-  let rowSum = 0;
-  let colSum = 0;
-  const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  let rowSum = 0
+  let colSum = 0
+  const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
   for (const ch of text.toUpperCase()) {
-    const idx = chars.indexOf(ch);
-    if (idx === -1) continue;
-    rowSum += Math.floor(idx / 6);
-    colSum += idx % 6;
+    const idx = chars.indexOf(ch)
+    if (idx === -1) continue
+    rowSum += Math.floor(idx / 6)
+    colSum += idx % 6
   }
-  const checkIdx = (rowSum % 6) * 6 + (colSum % 6);
-  return chars[checkIdx]!;
+  const checkIdx = (rowSum % 6) * 6 + (colSum % 6)
+  return chars[checkIdx]!
 }
 
 /**
@@ -68,25 +68,25 @@ function rm4sccCheckDigit(text: string): string {
  * @returns Array of FourState values
  */
 export function encodeRM4SCC(text: string): FourState[] {
-  const upper = text.toUpperCase().replace(/\s/g, "");
+  const upper = text.toUpperCase().replace(/\s/g, "")
   if (!/^[0-9A-Z]+$/.test(upper)) {
-    throw new InvalidInputError("RM4SCC only accepts A-Z and 0-9");
+    throw new InvalidInputError("RM4SCC only accepts A-Z and 0-9")
   }
 
-  const check = rm4sccCheckDigit(upper);
-  const dataWithCheck = upper + check;
+  const check = rm4sccCheckDigit(upper)
+  const dataWithCheck = upper + check
 
-  const bars: FourState[] = ["A"]; // Start: ascender
+  const bars: FourState[] = ["A"] // Start: ascender
 
   for (const ch of dataWithCheck) {
-    const pattern = RM4SCC_TABLE[ch];
-    if (!pattern) throw new InvalidInputError(`Invalid RM4SCC character: ${ch}`);
-    bars.push(...pattern);
+    const pattern = RM4SCC_TABLE[ch]
+    if (!pattern) throw new InvalidInputError(`Invalid RM4SCC character: ${ch}`)
+    bars.push(...pattern)
   }
 
-  bars.push("F"); // Stop: full bar
+  bars.push("F") // Stop: full bar
 
-  return bars;
+  return bars
 }
 
 /**
@@ -97,20 +97,20 @@ export function encodeRM4SCC(text: string): FourState[] {
  * @returns Array of FourState values
  */
 export function encodeKIX(text: string): FourState[] {
-  const upper = text.toUpperCase().replace(/\s/g, "");
+  const upper = text.toUpperCase().replace(/\s/g, "")
   if (!/^[0-9A-Z]+$/.test(upper)) {
-    throw new InvalidInputError("KIX only accepts A-Z and 0-9");
+    throw new InvalidInputError("KIX only accepts A-Z and 0-9")
   }
 
-  const bars: FourState[] = [];
+  const bars: FourState[] = []
 
   for (const ch of upper) {
-    const pattern = RM4SCC_TABLE[ch];
-    if (!pattern) throw new InvalidInputError(`Invalid KIX character: ${ch}`);
-    bars.push(...pattern);
+    const pattern = RM4SCC_TABLE[ch]
+    if (!pattern) throw new InvalidInputError(`Invalid KIX character: ${ch}`)
+    bars.push(...pattern)
   }
 
-  return bars;
+  return bars
 }
 
 // Australia Post 4-State barcode
@@ -125,31 +125,31 @@ const GF4_MUL: number[][] = [
   [0, 1, 2, 3],
   [0, 2, 3, 1],
   [0, 3, 1, 2],
-];
+]
 
-const BAR_TO_GF4: Record<FourState, number> = { T: 0, A: 1, D: 2, F: 3 };
-const GF4_TO_BAR: FourState[] = ["T", "A", "D", "F"];
+const BAR_TO_GF4: Record<FourState, number> = { T: 0, A: 1, D: 2, F: 3 }
+const GF4_TO_BAR: FourState[] = ["T", "A", "D", "F"]
 
 // Generator polynomial: g(x) = (x-1)(x-α)(x-α²)(x-α³)
 // Since α³=1 in GF(4), this is (x+1)²(x+2)(x+3)
 // = (x²+1)(x²+x+1) = x⁴+x³+x+1
 // Coefficients [x⁴, x³, x², x¹, x⁰] = [1, 1, 0, 1, 1]
-const AUSPOST_GEN = [1, 1, 0, 1, 1];
+const AUSPOST_GEN = [1, 1, 0, 1, 1]
 
 /** Compute 4 Reed-Solomon parity symbols over GF(4) for Australia Post */
 function auspostReedSolomon(data: FourState[]): FourState[] {
-  const n = AUSPOST_GEN.length - 1; // 4 parity symbols
-  const remainder = [0, 0, 0, 0];
+  const n = AUSPOST_GEN.length - 1 // 4 parity symbols
+  const remainder = [0, 0, 0, 0]
 
   for (const bar of data) {
-    const feedback = BAR_TO_GF4[bar] ^ remainder[0]!;
+    const feedback = BAR_TO_GF4[bar] ^ remainder[0]!
     for (let i = 0; i < n - 1; i++) {
-      remainder[i] = remainder[i + 1]! ^ GF4_MUL[feedback]![AUSPOST_GEN[i + 1]!]!;
+      remainder[i] = remainder[i + 1]! ^ GF4_MUL[feedback]![AUSPOST_GEN[i + 1]!]!
     }
-    remainder[n - 1] = GF4_MUL[feedback]![AUSPOST_GEN[n]!]!;
+    remainder[n - 1] = GF4_MUL[feedback]![AUSPOST_GEN[n]!]!
   }
 
-  return remainder.map((v) => GF4_TO_BAR[v]!) as FourState[];
+  return remainder.map((v) => GF4_TO_BAR[v]!) as FourState[]
 }
 
 const AUSPOST_N_TABLE: Record<string, FourState[]> = {
@@ -163,7 +163,7 @@ const AUSPOST_N_TABLE: Record<string, FourState[]> = {
   "7": ["D", "T"],
   "8": ["F", "A"],
   "9": ["F", "D"],
-};
+}
 
 /**
  * Encode Australia Post 4-State barcode
@@ -173,26 +173,26 @@ const AUSPOST_N_TABLE: Record<string, FourState[]> = {
  */
 export function encodeAustraliaPost(fcc: string, dpid: string): FourState[] {
   if (!/^\d{2}$/.test(fcc)) {
-    throw new InvalidInputError("Australia Post FCC must be 2 digits");
+    throw new InvalidInputError("Australia Post FCC must be 2 digits")
   }
   if (!/^\d{8}$/.test(dpid)) {
-    throw new InvalidInputError("Australia Post DPID must be 8 digits");
+    throw new InvalidInputError("Australia Post DPID must be 8 digits")
   }
 
-  const data = fcc + dpid;
-  const bars: FourState[] = ["F", "A"]; // Start
+  const data = fcc + dpid
+  const bars: FourState[] = ["F", "A"] // Start
 
   for (const ch of data) {
-    bars.push(...AUSPOST_N_TABLE[ch]!);
+    bars.push(...AUSPOST_N_TABLE[ch]!)
   }
 
   // Reed-Solomon parity over GF(4)
-  const dataBars = bars.slice(2); // exclude start bars
-  const parity = auspostReedSolomon(dataBars);
-  bars.push(...parity);
-  bars.push("F", "A"); // Stop
+  const dataBars = bars.slice(2) // exclude start bars
+  const parity = auspostReedSolomon(dataBars)
+  bars.push(...parity)
+  bars.push("F", "A") // Stop
 
-  return bars;
+  return bars
 }
 
 // Japan Post 4-State barcode (Kasutama / JP4SCC)
@@ -200,8 +200,8 @@ export function encodeAustraliaPost(fcc: string, dpid: string): FourState[] {
 // KASUT_SET: '1','2','3','4','5','6','7','8','9','0','-','a','b','c','d','e','f','g','h'
 // CH_KASUT_SET defines the order for check digit calculation (mod 19)
 // CH_KASUT_SET: '0','1','2','3','4','5','6','7','8','9','-','a','b','c','d','e','f','g','h'
-const KASUT_SET = "1234567890-abcdefgh";
-const CH_KASUT_SET = "0123456789-abcdefgh";
+const KASUT_SET = "1234567890-abcdefgh"
+const CH_KASUT_SET = "0123456789-abcdefgh"
 
 // JAPAN_TABLE[i] = bar pattern for KASUT_SET[i]
 const JAPAN_TABLE: FourState[][] = [
@@ -224,12 +224,12 @@ const JAPAN_TABLE: FourState[][] = [
   ["T", "A", "D"], // 'f'
   ["T", "T", "F"], // 'g'
   ["F", "F", "F"], // 'h'
-];
+]
 
 // Build lookup from character to bar pattern
-const JP_TABLE: Record<string, FourState[]> = {};
+const JP_TABLE: Record<string, FourState[]> = {}
 for (let i = 0; i < KASUT_SET.length; i++) {
-  JP_TABLE[KASUT_SET[i]!] = JAPAN_TABLE[i]!;
+  JP_TABLE[KASUT_SET[i]!] = JAPAN_TABLE[i]!
 }
 
 /**
@@ -238,21 +238,21 @@ for (let i = 0; i < KASUT_SET.length; i++) {
  * sequences using internal characters a-h.
  */
 function jpExpandChar(c: string): string {
-  if ((c >= "0" && c <= "9") || c === "-") return c;
-  const code = c.charCodeAt(0);
+  if ((c >= "0" && c <= "9") || c === "-") return c
+  const code = c.charCodeAt(0)
   if (code >= 65 && code <= 74) {
     // A-J → 'a' + digit
-    return "a" + CH_KASUT_SET[code - 65]!;
+    return "a" + CH_KASUT_SET[code - 65]!
   }
   if (code >= 75 && code <= 84) {
     // K-T → 'b' + digit
-    return "b" + CH_KASUT_SET[code - 75]!;
+    return "b" + CH_KASUT_SET[code - 75]!
   }
   if (code >= 85 && code <= 90) {
     // U-Z → 'c' + digit
-    return "c" + CH_KASUT_SET[code - 85]!;
+    return "c" + CH_KASUT_SET[code - 85]!
   }
-  throw new InvalidInputError(`Invalid Japan Post character: ${c}`);
+  throw new InvalidInputError(`Invalid Japan Post character: ${c}`)
 }
 
 /**
@@ -262,47 +262,47 @@ function jpExpandChar(c: string): string {
  * @param address - Optional address characters (digits, dash, A-Z; up to 13 chars)
  */
 export function encodeJapanPost(zipcode: string, address?: string): FourState[] {
-  const zip = zipcode.replace(/-/g, "");
+  const zip = zipcode.replace(/-/g, "")
   if (!/^\d{7}$/.test(zip)) {
-    throw new InvalidInputError("Japan Post zipcode must be 7 digits");
+    throw new InvalidInputError("Japan Post zipcode must be 7 digits")
   }
 
   // Build intermediate representation
-  let inter = zip; // zipcode is always digits
+  let inter = zip // zipcode is always digits
   if (address) {
-    const clean = address.toUpperCase().replace(/\s/g, "");
+    const clean = address.toUpperCase().replace(/\s/g, "")
     if (!/^[\dA-Z-]+$/.test(clean)) {
-      throw new InvalidInputError("Japan Post address only accepts digits, dash, and A-Z");
+      throw new InvalidInputError("Japan Post address only accepts digits, dash, and A-Z")
     }
     for (const ch of clean) {
-      inter += jpExpandChar(ch);
+      inter += jpExpandChar(ch)
     }
   }
 
   // Pad to 20 characters with 'd' and truncate
-  while (inter.length < 20) inter += "d";
-  inter = inter.substring(0, 20);
+  while (inter.length < 20) inter += "d"
+  inter = inter.substring(0, 20)
 
   // Check digit: sum of CH_KASUT_SET positions, mod 19
-  let sum = 0;
+  let sum = 0
   for (const ch of inter) {
-    const pos = CH_KASUT_SET.indexOf(ch);
-    if (pos === -1) throw new InvalidInputError(`Invalid Japan Post character: ${ch}`);
-    sum += pos;
+    const pos = CH_KASUT_SET.indexOf(ch)
+    if (pos === -1) throw new InvalidInputError(`Invalid Japan Post character: ${ch}`)
+    sum += pos
   }
-  let check = 19 - (sum % 19);
-  if (check === 19) check = 0;
-  const checkChar = CH_KASUT_SET[check]!;
-  inter += checkChar;
+  let check = 19 - (sum % 19)
+  if (check === 19) check = 0
+  const checkChar = CH_KASUT_SET[check]!
+  inter += checkChar
 
-  const bars: FourState[] = ["F", "D"]; // Start
+  const bars: FourState[] = ["F", "D"] // Start
 
   for (const ch of inter) {
-    const pattern = JP_TABLE[ch];
-    if (!pattern) throw new InvalidInputError(`Invalid Japan Post character: ${ch}`);
-    bars.push(...pattern);
+    const pattern = JP_TABLE[ch]
+    if (!pattern) throw new InvalidInputError(`Invalid Japan Post character: ${ch}`)
+    bars.push(...pattern)
   }
 
-  bars.push("D", "F"); // Stop
-  return bars;
+  bars.push("D", "F") // Stop
+  return bars
 }

--- a/src/encoders/gs1-128.ts
+++ b/src/encoders/gs1-128.ts
@@ -4,7 +4,7 @@
  * and Application Identifier (AI) based data structure
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Code 128 encoding patterns (bar/space widths)
 // Each pattern is 6 elements: bar, space, bar, space, bar, space
@@ -115,17 +115,17 @@ const PATTERNS: number[][] = [
   [2, 1, 1, 4, 1, 2], // 103 (START_A)
   [2, 1, 1, 2, 1, 4], // 104 (START_B)
   [2, 1, 1, 2, 3, 2], // 105 (START_C)
-];
+]
 
-const STOP_PATTERN = [2, 3, 3, 1, 1, 1, 2]; // 7 elements
+const STOP_PATTERN = [2, 3, 3, 1, 1, 1, 2] // 7 elements
 
-const _START_A = 103;
-const START_B = 104;
-const START_C = 105;
-const CODE_A = 101;
-const CODE_B = 100;
-const CODE_C = 99;
-const FNC1 = 102;
+const _START_A = 103
+const START_B = 104
+const START_C = 105
+const CODE_A = 101
+const CODE_B = 100
+const CODE_C = 99
+const FNC1 = 102
 
 /**
  * Application Identifier definitions
@@ -133,20 +133,20 @@ const FNC1 = 102;
  */
 interface AIDefinition {
   /** AI code string */
-  ai: string;
+  ai: string
   /** Fixed data length (excluding AI), or 0 if variable */
-  fixedLength: number;
+  fixedLength: number
   /** Maximum data length for variable-length AIs */
-  maxLength: number;
+  maxLength: number
   /** Regex pattern for validating the data portion */
-  dataPattern: RegExp;
+  dataPattern: RegExp
 }
 
 // Helper: GS1 alphanumeric character class (CSET 82)
 const AN = (max: number) =>
-  new RegExp(`^[\\x21-\\x22\\x25-\\x2F\\x30-\\x39\\x41-\\x5A\\x5F\\x61-\\x7A]{1,${max}}$`);
-const N = (len: number) => new RegExp(`^\\d{${len}}$`);
-const NV = (max: number) => new RegExp(`^\\d{1,${max}}$`);
+  new RegExp(`^[\\x21-\\x22\\x25-\\x2F\\x30-\\x39\\x41-\\x5A\\x5F\\x61-\\x7A]{1,${max}}$`)
+const N = (len: number) => new RegExp(`^\\d{${len}}$`)
+const NV = (max: number) => new RegExp(`^\\d{1,${max}}$`)
 
 const AI_DEFINITIONS: AIDefinition[] = [
   // Identification
@@ -231,7 +231,7 @@ const AI_DEFINITIONS: AIDefinition[] = [
   { ai: "8017", fixedLength: 18, maxLength: 18, dataPattern: N(18) }, // GSRN — provider
   { ai: "8018", fixedLength: 18, maxLength: 18, dataPattern: N(18) }, // GSRN — recipient
   { ai: "8020", fixedLength: 0, maxLength: 25, dataPattern: AN(25) }, // Payment slip reference number
-];
+]
 
 // Trade measures: 310x-369x (x = decimal indicator 0-9)
 // 310x=net weight kg, 311x=length m, 312x=width m, 313x=depth m,
@@ -251,7 +251,7 @@ const AI_DEFINITIONS: AIDefinition[] = [
 // 366x=net volume yd³, 367x=logistic volume in³, 368x=logistic volume ft³, 369x=logistic volume yd³
 for (let prefix = 310; prefix <= 369; prefix++) {
   for (let x = 0; x <= 9; x++) {
-    AI_DEFINITIONS.push({ ai: `${prefix}${x}`, fixedLength: 6, maxLength: 6, dataPattern: N(6) });
+    AI_DEFINITIONS.push({ ai: `${prefix}${x}`, fixedLength: 6, maxLength: 6, dataPattern: N(6) })
   }
 }
 
@@ -263,20 +263,20 @@ for (let prefix = 390; prefix <= 394; prefix++) {
       fixedLength: 0,
       maxLength: 15,
       dataPattern: NV(15),
-    });
+    })
   }
 }
 
 // NHRN (National Healthcare Reimbursement Number): 710-719
 for (let ai = 710; ai <= 719; ai++) {
-  AI_DEFINITIONS.push({ ai: `${ai}`, fixedLength: 0, maxLength: 20, dataPattern: AN(20) });
+  AI_DEFINITIONS.push({ ai: `${ai}`, fixedLength: 0, maxLength: 20, dataPattern: AN(20) })
 }
 
 /**
  * Find the AI definition matching a given AI code
  */
 function findAIDefinition(ai: string): AIDefinition | undefined {
-  return AI_DEFINITIONS.find((def) => def.ai === ai);
+  return AI_DEFINITIONS.find((def) => def.ai === ai)
 }
 
 /**
@@ -284,84 +284,84 @@ function findAIDefinition(ai: string): AIDefinition | undefined {
  * E.g. "(01)12345678901234(17)260101(10)ABC123"
  */
 export function parseAIString(text: string): { ai: string; data: string }[] {
-  const fields: { ai: string; data: string }[] = [];
-  let pos = 0;
+  const fields: { ai: string; data: string }[] = []
+  let pos = 0
 
   while (pos < text.length) {
     if (text[pos] !== "(") {
-      throw new InvalidInputError(`Expected '(' at position ${pos} in GS1-128 AI string`);
+      throw new InvalidInputError(`Expected '(' at position ${pos} in GS1-128 AI string`)
     }
 
-    const closePos = text.indexOf(")", pos + 1);
+    const closePos = text.indexOf(")", pos + 1)
     if (closePos === -1) {
-      throw new InvalidInputError(`Missing closing ')' for AI starting at position ${pos}`);
+      throw new InvalidInputError(`Missing closing ')' for AI starting at position ${pos}`)
     }
 
-    const ai = text.slice(pos + 1, closePos);
+    const ai = text.slice(pos + 1, closePos)
     if (ai.length < 2 || ai.length > 4) {
-      throw new InvalidInputError(`Invalid AI '${ai}' — must be 2-4 digits`);
+      throw new InvalidInputError(`Invalid AI '${ai}' — must be 2-4 digits`)
     }
     if (!/^\d+$/.test(ai)) {
-      throw new InvalidInputError(`Invalid AI '${ai}' — must contain only digits`);
+      throw new InvalidInputError(`Invalid AI '${ai}' — must contain only digits`)
     }
 
     // Find where data ends (at the next '(' or end of string)
-    const dataStart = closePos + 1;
-    let dataEnd = text.indexOf("(", dataStart);
+    const dataStart = closePos + 1
+    let dataEnd = text.indexOf("(", dataStart)
     if (dataEnd === -1) {
-      dataEnd = text.length;
+      dataEnd = text.length
     }
 
-    const data = text.slice(dataStart, dataEnd);
+    const data = text.slice(dataStart, dataEnd)
     if (data.length === 0) {
-      throw new InvalidInputError(`Empty data for AI '${ai}'`);
+      throw new InvalidInputError(`Empty data for AI '${ai}'`)
     }
 
-    fields.push({ ai, data });
-    pos = dataEnd;
+    fields.push({ ai, data })
+    pos = dataEnd
   }
 
   if (fields.length === 0) {
-    throw new InvalidInputError("GS1-128 AI string contains no fields");
+    throw new InvalidInputError("GS1-128 AI string contains no fields")
   }
 
-  return fields;
+  return fields
 }
 
 /**
  * Check if an AI field is variable-length
  */
 export function isVariableLength(ai: string): boolean {
-  const def = findAIDefinition(ai);
+  const def = findAIDefinition(ai)
   if (def) {
-    return def.fixedLength === 0;
+    return def.fixedLength === 0
   }
   // Unknown AIs are treated as variable-length for safety
-  return true;
+  return true
 }
 
 /**
  * Validate AI data against known definitions
  */
 function validateAIField(ai: string, data: string): void {
-  const def = findAIDefinition(ai);
+  const def = findAIDefinition(ai)
   if (!def) {
     // Unknown AI — allow but don't validate content
-    return;
+    return
   }
 
   if (def.fixedLength > 0 && data.length !== def.fixedLength) {
     throw new InvalidInputError(
       `AI '${ai}' requires exactly ${def.fixedLength} characters, got ${data.length}`,
-    );
+    )
   }
 
   if (data.length > def.maxLength) {
-    throw new InvalidInputError(`AI '${ai}' data exceeds maximum length of ${def.maxLength}`);
+    throw new InvalidInputError(`AI '${ai}' data exceeds maximum length of ${def.maxLength}`)
   }
 
   if (!def.dataPattern.test(data)) {
-    throw new InvalidInputError(`AI '${ai}' data '${data}' does not match expected format`);
+    throw new InvalidInputError(`AI '${ai}' data '${data}' does not match expected format`)
   }
 }
 
@@ -369,13 +369,13 @@ function validateAIField(ai: string, data: string): void {
  * Count leading numeric characters from a position
  */
 function countNumericFromPos(text: string, pos: number): number {
-  let count = 0;
+  let count = 0
   while (pos + count < text.length) {
-    const c = text.charCodeAt(pos + count);
-    if (c < 48 || c > 57) break;
-    count++;
+    const c = text.charCodeAt(pos + count)
+    if (c < 48 || c > 57) break
+    count++
   }
-  return count;
+  return count
 }
 
 /**
@@ -383,13 +383,13 @@ function countNumericFromPos(text: string, pos: number): number {
  */
 function encodeCodeC(text: string, pos: number, codes: number[]): number {
   while (pos + 1 < text.length) {
-    const d1 = text.charCodeAt(pos) - 48;
-    const d2 = text.charCodeAt(pos + 1) - 48;
-    if (d1 < 0 || d1 > 9 || d2 < 0 || d2 > 9) break;
-    codes.push(d1 * 10 + d2);
-    pos += 2;
+    const d1 = text.charCodeAt(pos) - 48
+    const d2 = text.charCodeAt(pos + 1) - 48
+    if (d1 < 0 || d1 > 9 || d2 < 0 || d2 > 9) break
+    codes.push(d1 * 10 + d2)
+    pos += 2
   }
-  return pos;
+  return pos
 }
 
 /**
@@ -397,78 +397,78 @@ function encodeCodeC(text: string, pos: number, codes: number[]): number {
  * FNC1 is represented as \xF1 (241) in the internal string
  */
 function buildCodes(data: string): number[] {
-  const codes: number[] = [];
-  let pos = 0;
+  const codes: number[] = []
+  let pos = 0
 
   // Determine optimal start code
   // Check for FNC1 at position 0 — skip it for start code analysis
-  let analyzePos = 0;
+  let analyzePos = 0
   if (analyzePos < data.length && data.charCodeAt(analyzePos) === 0xf1) {
-    analyzePos++;
+    analyzePos++
   }
 
-  const numericRun = countNumericFromPos(data, analyzePos);
+  const numericRun = countNumericFromPos(data, analyzePos)
 
   if (numericRun >= 4) {
-    codes.push(START_C);
+    codes.push(START_C)
   } else {
-    codes.push(START_B);
+    codes.push(START_B)
   }
 
-  let currentSet: "A" | "B" | "C" = codes[0] === START_C ? "C" : "B";
+  let currentSet: "A" | "B" | "C" = codes[0] === START_C ? "C" : "B"
 
   while (pos < data.length) {
     // Handle FNC1 marker
     if (data.charCodeAt(pos) === 0xf1) {
-      codes.push(FNC1);
-      pos++;
-      continue;
+      codes.push(FNC1)
+      pos++
+      continue
     }
 
     if (currentSet === "C") {
-      const remaining = countNumericFromPos(data, pos);
+      const remaining = countNumericFromPos(data, pos)
       if (remaining >= 2) {
-        pos = encodeCodeC(data, pos, codes);
+        pos = encodeCodeC(data, pos, codes)
       } else {
-        codes.push(CODE_B);
-        currentSet = "B";
+        codes.push(CODE_B)
+        currentSet = "B"
       }
     } else {
-      const numRun = countNumericFromPos(data, pos);
+      const numRun = countNumericFromPos(data, pos)
       if (numRun >= 4 || (numRun >= 2 && pos + numRun >= data.length)) {
-        codes.push(CODE_C);
-        currentSet = "C";
-        pos = encodeCodeC(data, pos, codes);
+        codes.push(CODE_C)
+        currentSet = "C"
+        pos = encodeCodeC(data, pos, codes)
       } else {
-        const charCode = data.charCodeAt(pos);
+        const charCode = data.charCodeAt(pos)
         if (charCode >= 32 && charCode <= 126) {
           // Code B
-          codes.push(charCode - 32);
+          codes.push(charCode - 32)
         } else if (charCode >= 0 && charCode < 32) {
           // Need Code A for control chars
           if (currentSet !== "A") {
-            codes.push(CODE_A);
-            currentSet = "A";
+            codes.push(CODE_A)
+            currentSet = "A"
           }
-          codes.push(charCode + 64);
+          codes.push(charCode + 64)
         } else {
           throw new InvalidInputError(
             `Character at position ${pos} (code ${charCode}) is not encodable in GS1-128`,
-          );
+          )
         }
-        pos++;
+        pos++
       }
     }
   }
 
   // Calculate checksum
-  let checksum = codes[0]!;
+  let checksum = codes[0]!
   for (let i = 1; i < codes.length; i++) {
-    checksum += codes[i]! * i;
+    checksum += codes[i]! * i
   }
-  codes.push(checksum % 103);
+  codes.push(checksum % 103)
 
-  return codes;
+  return codes
 }
 
 /**
@@ -483,58 +483,58 @@ function buildCodes(data: string): number[] {
  */
 export function encodeGS1128(text: string): number[] {
   if (text.length === 0) {
-    throw new InvalidInputError("GS1-128 input must not be empty");
+    throw new InvalidInputError("GS1-128 input must not be empty")
   }
 
   // Build the internal data string with FNC1 markers
-  let data: string;
+  let data: string
 
   if (text.startsWith("(")) {
     // Parenthesized AI format — parse and validate
-    const fields = parseAIString(text);
+    const fields = parseAIString(text)
 
     // Validate each field
     for (const field of fields) {
-      validateAIField(field.ai, field.data);
+      validateAIField(field.ai, field.data)
     }
 
     // Build data string: FNC1 + AI1 + data1 [+ FNC1 + AI2 + data2 ...]
     // FNC1 separators are needed after variable-length fields (except the last field)
-    let result = "\xF1"; // Leading FNC1 (GS1-128 identifier)
+    let result = "\xF1" // Leading FNC1 (GS1-128 identifier)
 
     for (let i = 0; i < fields.length; i++) {
-      const field = fields[i]!;
-      result += field.ai + field.data;
+      const field = fields[i]!
+      result += field.ai + field.data
 
       // Insert FNC1 separator after variable-length AIs, except the last field
       if (i < fields.length - 1 && isVariableLength(field.ai)) {
-        result += "\xF1";
+        result += "\xF1"
       }
     }
 
-    data = result;
+    data = result
   } else {
     // Plain string — just prepend FNC1
-    data = "\xF1" + text;
+    data = "\xF1" + text
   }
 
   // Build Code 128 symbol values
-  const codes = buildCodes(data);
+  const codes = buildCodes(data)
 
   // Convert to bar widths
-  const bars: number[] = [];
+  const bars: number[] = []
 
   for (const code of codes) {
-    const pattern = PATTERNS[code]!;
+    const pattern = PATTERNS[code]!
     for (const width of pattern) {
-      bars.push(width);
+      bars.push(width)
     }
   }
 
   // Stop pattern
   for (const width of STOP_PATTERN) {
-    bars.push(width);
+    bars.push(width)
   }
 
-  return bars;
+  return bars
 }

--- a/src/encoders/gs1-composite.ts
+++ b/src/encoders/gs1-composite.ts
@@ -10,22 +10,22 @@
  * that doesn't fit in the primary linear barcode.
  */
 
-import { InvalidInputError } from "../errors";
-import { encodeMicroPDF417 } from "./micropdf417";
-import { encodePDF417 } from "./pdf417/index";
-import { parseAIString } from "./gs1-128";
+import { InvalidInputError } from "../errors"
+import { encodeMicroPDF417 } from "./micropdf417"
+import { encodePDF417 } from "./pdf417/index"
+import { parseAIString } from "./gs1-128"
 
-export type CompositeType = "CC-A" | "CC-B" | "CC-C";
+export type CompositeType = "CC-A" | "CC-B" | "CC-C"
 
 export interface GS1CompositeResult {
   /** The 2D composite component matrix */
-  composite: boolean[][];
+  composite: boolean[][]
   /** Composite type used */
-  type: CompositeType;
+  type: CompositeType
   /** Number of rows in composite */
-  rows: number;
+  rows: number
   /** Width in modules */
-  cols: number;
+  cols: number
 }
 
 /**
@@ -38,12 +38,12 @@ export interface GS1CompositeResult {
  */
 export function encodeGS1Composite(data: string, type: CompositeType = "CC-A"): GS1CompositeResult {
   if (data.length === 0) {
-    throw new InvalidInputError("GS1 Composite: data must not be empty");
+    throw new InvalidInputError("GS1 Composite: data must not be empty")
   }
 
   // Validate AI format if parenthesized
   if (data.includes("(")) {
-    parseAIString(data); // throws on invalid
+    parseAIString(data) // throws on invalid
   }
 
   // Encode based on composite type
@@ -51,26 +51,26 @@ export function encodeGS1Composite(data: string, type: CompositeType = "CC-A"): 
     case "CC-A":
     case "CC-B": {
       // MicroPDF417-based
-      const columns = type === "CC-A" ? 2 : 3;
-      const result = encodeMicroPDF417(data, { columns });
+      const columns = type === "CC-A" ? 2 : 3
+      const result = encodeMicroPDF417(data, { columns })
       return {
         composite: result.matrix,
         type,
         rows: result.rows,
         cols: result.cols,
-      };
+      }
     }
     case "CC-C": {
       // PDF417-based
-      const result = encodePDF417(data, { ecLevel: 2, columns: 4 });
+      const result = encodePDF417(data, { ecLevel: 2, columns: 4 })
       return {
         composite: result.matrix,
         type,
         rows: result.rows,
         cols: result.cols,
-      };
+      }
     }
     default:
-      throw new InvalidInputError(`Invalid composite type: ${type}`);
+      throw new InvalidInputError(`Invalid composite type: ${type}`)
   }
 }

--- a/src/encoders/gs1-databar.ts
+++ b/src/encoders/gs1-databar.ts
@@ -13,8 +13,8 @@
  * as implemented in the zint library (BSD-3-Clause).
  */
 
-import { InvalidInputError } from "../errors";
-import { parseAIString } from "./gs1-128";
+import { InvalidInputError } from "../errors"
+import { parseAIString } from "./gs1-128"
 
 // ─── Combinatorial Encoding Core ────────────────────────────────────────────
 
@@ -23,30 +23,30 @@ import { parseAIString } from "./gs1-128";
  * ISO/IEC 24724 Annex B `combins()`
  */
 function combins(n: number, r: number): number {
-  let maxDenom: number;
-  let minDenom: number;
+  let maxDenom: number
+  let minDenom: number
 
   if (n - r > r) {
-    minDenom = r;
-    maxDenom = n - r;
+    minDenom = r
+    maxDenom = n - r
   } else {
-    minDenom = n - r;
-    maxDenom = r;
+    minDenom = n - r
+    maxDenom = r
   }
 
-  let val = 1;
-  let j = 1;
+  let val = 1
+  let j = 1
   for (let i = n; i > maxDenom; i--) {
-    val *= i;
+    val *= i
     if (j <= minDenom) {
-      val = Math.trunc(val / j);
-      j++;
+      val = Math.trunc(val / j)
+      j++
     }
   }
   for (; j <= minDenom; j++) {
-    val = Math.trunc(val / j);
+    val = Math.trunc(val / j)
   }
-  return val;
+  return val
 }
 
 /**
@@ -67,50 +67,50 @@ function getWidths(
   maxWidth: number,
   noNarrow: boolean,
 ): number[] {
-  const widths: number[] = Array.from<number>({ length: elements });
-  let narrowMask = 0;
+  const widths: number[] = Array.from<number>({ length: elements })
+  let narrowMask = 0
 
   for (let bar = 0; bar < elements - 1; bar++) {
-    let elmWidth = 1;
-    narrowMask |= 1 << bar;
+    let elmWidth = 1
+    narrowMask |= 1 << bar
 
     for (;;) {
       /* Get all combinations */
-      let subVal = combins(n - elmWidth - 1, elements - bar - 2);
+      let subVal = combins(n - elmWidth - 1, elements - bar - 2)
 
       /* Less combinations with no single-module element */
       if (noNarrow && !narrowMask && n - elmWidth - (elements - bar - 1) >= elements - bar - 1) {
-        subVal -= combins(n - elmWidth - (elements - bar), elements - bar - 2);
+        subVal -= combins(n - elmWidth - (elements - bar), elements - bar - 2)
       }
 
       /* Less combinations with elements > maxWidth */
       if (elements - bar - 1 > 1) {
-        let lessVal = 0;
+        let lessVal = 0
         for (
           let mxwElement = n - elmWidth - (elements - bar - 2);
           mxwElement > maxWidth;
           mxwElement--
         ) {
-          lessVal += combins(n - elmWidth - mxwElement - 1, elements - bar - 3);
+          lessVal += combins(n - elmWidth - mxwElement - 1, elements - bar - 3)
         }
-        subVal -= lessVal * (elements - 1 - bar);
+        subVal -= lessVal * (elements - 1 - bar)
       } else if (n - elmWidth > maxWidth) {
-        subVal--;
+        subVal--
       }
 
-      val -= subVal;
+      val -= subVal
       if (val < 0) {
-        val += subVal;
-        n -= elmWidth;
-        widths[bar] = elmWidth;
-        break;
+        val += subVal
+        n -= elmWidth
+        widths[bar] = elmWidth
+        break
       }
-      elmWidth++;
-      narrowMask &= ~(1 << bar);
+      elmWidth++
+      narrowMask &= ~(1 << bar)
     }
   }
-  widths[elements - 1] = n;
-  return widths;
+  widths[elements - 1] = n
+  return widths
 }
 
 /**
@@ -126,59 +126,59 @@ function interleaveWidths(
   maxWidth: number,
   noNarrow: boolean,
 ): number[] {
-  const oddWidths = getWidths(vOdd, nOdd, elements, maxWidth, noNarrow);
-  const evenWidths = getWidths(vEven, nEven, elements, 9 - maxWidth, !noNarrow);
+  const oddWidths = getWidths(vOdd, nOdd, elements, maxWidth, noNarrow)
+  const evenWidths = getWidths(vEven, nEven, elements, 9 - maxWidth, !noNarrow)
 
-  const result: number[] = Array.from<number>({ length: elements * 2 });
+  const result: number[] = Array.from<number>({ length: elements * 2 })
   for (let i = 0; i < elements; i++) {
-    result[i << 1] = oddWidths[i]!;
-    result[(i << 1) + 1] = evenWidths[i]!;
+    result[i << 1] = oddWidths[i]!
+    result[(i << 1) + 1] = evenWidths[i]!
   }
-  return result;
+  return result
 }
 
 // ─── GTIN Check Digit ──────────────────────────────────────────────────────
 
 /** Calculate GTIN check digit (mod 10, weights 3,1 alternating from right) */
 function gtinCheckDigit(digits: string): number {
-  let sum = 0;
+  let sum = 0
   for (let i = 0; i < digits.length; i++) {
-    const weight = (digits.length - i) % 2 === 0 ? 1 : 3;
-    sum += Number.parseInt(digits[i]!, 10) * weight;
+    const weight = (digits.length - i) % 2 === 0 ? 1 : 3
+    sum += Number.parseInt(digits[i]!, 10) * weight
   }
-  return (10 - (sum % 10)) % 10;
+  return (10 - (sum % 10)) % 10
 }
 
 /** Parse and validate a GTIN string, returning 13-digit value (without check digit) */
 function parseGTIN(gtin: string, variant: string): string {
-  const digits = gtin.replace(/\s/g, "");
+  const digits = gtin.replace(/\s/g, "")
   if (!/^\d+$/.test(digits)) {
-    throw new InvalidInputError(`GS1 DataBar ${variant}: GTIN must be numeric`);
+    throw new InvalidInputError(`GS1 DataBar ${variant}: GTIN must be numeric`)
   }
 
   if (digits.length === 13) {
-    return digits;
+    return digits
   }
   if (digits.length === 14) {
     // Verify check digit
-    const expected = gtinCheckDigit(digits.slice(0, 13));
+    const expected = gtinCheckDigit(digits.slice(0, 13))
     if (Number.parseInt(digits[13]!, 10) !== expected) {
       throw new InvalidInputError(
         `GS1 DataBar ${variant}: Invalid check digit '${digits[13]}', expecting '${expected}'`,
-      );
+      )
     }
-    return digits.slice(0, 13);
+    return digits.slice(0, 13)
   }
-  throw new InvalidInputError(`GS1 DataBar ${variant} requires 13 or 14 digit GTIN`);
+  throw new InvalidInputError(`GS1 DataBar ${variant} requires 13 or 14 digit GTIN`)
 }
 
 // ─── DataBar Omnidirectional ────────────────────────────────────────────────
 
 // Tables 1 & 2: Group sum boundaries (outside: indices 0-4, inside: indices 5-8)
-const OMN_G_SUM = [0, 161, 961, 2015, 2715, 0, 336, 1036, 1516];
+const OMN_G_SUM = [0, 161, 961, 2015, 2715, 0, 336, 1036, 1516]
 
 // T_even (outside, indices 0-4) and T_odd (inside, indices 5-8)
-const OMN_T_EVEN_ODD = [1, 10, 34, 70, 126, 4, 20, 48, 81];
+const OMN_T_EVEN_ODD = [1, 10, 34, 70, 126, 4, 20, 48, 81]
 
 // Modules per element: outside odd [0-4], inside odd [5-8],
 // outside even [9-13], inside even [14-17]
@@ -201,10 +201,10 @@ const OMN_MODULES = [
   8,
   6,
   4, // Inside even (15 - inside odd)
-];
+]
 
 // Widest element: outside+inside odd (even = 9 - odd)
-const OMN_WIDEST = [8, 6, 4, 3, 1, 2, 4, 6, 8];
+const OMN_WIDEST = [8, 6, 4, 3, 1, 2, 4, 6, 8]
 
 // Table 4: Finder patterns (9 patterns x 5 elements)
 const OMN_FINDER_PATTERN = [
@@ -217,7 +217,7 @@ const OMN_FINDER_PATTERN = [
   [2, 3, 8, 1, 1],
   [1, 5, 7, 1, 1],
   [1, 3, 9, 1, 1],
-];
+]
 
 // Table 5: Checksum weights (4 data chars x 8 element widths)
 const OMN_CHECKSUM_WEIGHT = [
@@ -225,18 +225,18 @@ const OMN_CHECKSUM_WEIGHT = [
   [4, 12, 36, 29, 8, 24, 72, 58],
   [16, 48, 65, 37, 32, 17, 51, 74],
   [64, 34, 23, 69, 49, 68, 46, 59],
-];
+]
 
 /** Determine group index for an Omnidirectional data character value */
 function omnGroup(val: number, outside: boolean): number {
-  const start = outside ? 0 : 5;
-  const end = outside ? 4 : 8;
+  const start = outside ? 0 : 5
+  const end = outside ? 4 : 8
   for (let i = start; i < end; i++) {
     if (val < OMN_G_SUM[i + 1]!) {
-      return i;
+      return i
     }
   }
-  return end;
+  return end
 }
 
 /**
@@ -246,17 +246,17 @@ function omnGroup(val: number, outside: boolean): number {
  * @returns Array of bar widths (alternating bar/space), 46 elements totaling 96 modules
  */
 export function encodeGS1DataBarOmni(gtin: string): number[] {
-  const digits13 = parseGTIN(gtin, "Omnidirectional");
+  const digits13 = parseGTIN(gtin, "Omnidirectional")
 
   // Convert 13-digit GTIN to numeric value (without check digit)
-  let val = 0n;
+  let val = 0n
   for (let i = 0; i < 13; i++) {
-    val = val * 10n + BigInt(digits13.charCodeAt(i) - 48);
+    val = val * 10n + BigInt(digits13.charCodeAt(i) - 48)
   }
 
   // Split into left and right pair values
-  const leftPair = Number(val / 4537077n);
-  const rightPair = Number(val % 4537077n);
+  const leftPair = Number(val / 4537077n)
+  const rightPair = Number(val % 4537077n)
 
   // Split pairs into 4 data characters
   const dataCharacter = [
@@ -264,22 +264,22 @@ export function encodeGS1DataBarOmni(gtin: string): number[] {
     leftPair % 1597,
     Math.trunc(rightPair / 1597),
     rightPair % 1597,
-  ];
+  ]
 
   // Encode each data character to 8 element widths
-  const dataWidths: number[][] = [];
+  const dataWidths: number[][] = []
 
   for (let i = 0; i < 4; i++) {
     // Characters 0,2 are "outside", characters 1,3 are "inside"
-    const outside = !(i & 1);
-    const group = omnGroup(dataCharacter[i]!, outside);
-    const v = dataCharacter[i]! - OMN_G_SUM[group]!;
-    const vDiv = Math.trunc(v / OMN_T_EVEN_ODD[group]!);
-    const vMod = v % OMN_T_EVEN_ODD[group]!;
+    const outside = !(i & 1)
+    const group = omnGroup(dataCharacter[i]!, outside)
+    const v = dataCharacter[i]! - OMN_G_SUM[group]!
+    const vDiv = Math.trunc(v / OMN_T_EVEN_ODD[group]!)
+    const vMod = v % OMN_T_EVEN_ODD[group]!
 
     // Outside: odd=vDiv, even=vMod; Inside: odd=vMod, even=vDiv
-    const vOdd = outside ? vDiv : vMod;
-    const vEven = outside ? vMod : vDiv;
+    const vOdd = outside ? vDiv : vMod
+    const vEven = outside ? vMod : vDiv
 
     dataWidths.push(
       interleaveWidths(
@@ -291,70 +291,70 @@ export function encodeGS1DataBarOmni(gtin: string): number[] {
         OMN_WIDEST[group]!,
         !outside ? true : false,
       ),
-    );
+    )
   }
 
   // Calculate checksum
-  let checksum = 0;
+  let checksum = 0
   for (let i = 0; i < 4; i++) {
     for (let j = 0; j < 8; j++) {
-      checksum += OMN_CHECKSUM_WEIGHT[i]![j]! * dataWidths[i]![j]!;
+      checksum += OMN_CHECKSUM_WEIGHT[i]![j]! * dataWidths[i]![j]!
     }
   }
-  checksum %= 79;
+  checksum %= 79
 
   // Adjust checksum to skip values 8 and 72
-  if (checksum >= 8) checksum++;
-  if (checksum >= 72) checksum++;
+  if (checksum >= 8) checksum++
+  if (checksum >= 72) checksum++
 
-  const cLeft = Math.trunc(checksum / 9);
-  const cRight = checksum % 9;
+  const cLeft = Math.trunc(checksum / 9)
+  const cRight = checksum % 9
 
   // Assemble 46-element total width array
-  const total: number[] = Array.from<number>({ length: 46 });
+  const total: number[] = Array.from<number>({ length: 46 })
 
   // Guards
-  total[0] = 1;
-  total[1] = 1;
-  total[44] = 1;
-  total[45] = 1;
+  total[0] = 1
+  total[1] = 1
+  total[44] = 1
+  total[45] = 1
 
   // Data characters: 0 forward, 1 reversed, 3 forward, 2 reversed
   for (let i = 0; i < 8; i++) {
-    total[i + 2] = dataWidths[0]![i]!;
-    total[i + 15] = dataWidths[1]![7 - i]!;
-    total[i + 23] = dataWidths[3]![i]!;
-    total[i + 36] = dataWidths[2]![7 - i]!;
+    total[i + 2] = dataWidths[0]![i]!
+    total[i + 15] = dataWidths[1]![7 - i]!
+    total[i + 23] = dataWidths[3]![i]!
+    total[i + 36] = dataWidths[2]![7 - i]!
   }
 
   // Finder patterns
   for (let i = 0; i < 5; i++) {
-    total[i + 10] = OMN_FINDER_PATTERN[cLeft]![i]!;
-    total[i + 31] = OMN_FINDER_PATTERN[cRight]![4 - i]!;
+    total[i + 10] = OMN_FINDER_PATTERN[cLeft]![i]!
+    total[i + 31] = OMN_FINDER_PATTERN[cRight]![4 - i]!
   }
 
-  return total;
+  return total
 }
 
 // ─── DataBar Limited ────────────────────────────────────────────────────────
 
 // Table 6: Group sum boundaries for Limited
-const LTD_G_SUM = [0, 183064, 820064, 1000776, 1491021, 1979845, 1996939];
+const LTD_G_SUM = [0, 183064, 820064, 1000776, 1491021, 1979845, 1996939]
 
 // T_even values per group
-const LTD_T_EVEN = [28, 728, 6454, 203, 2408, 1, 16632];
+const LTD_T_EVEN = [28, 728, 6454, 203, 2408, 1, 16632]
 
 // Modules per group (odd); even = 26 - odd
-const LTD_MODULES = [17, 13, 9, 15, 11, 19, 7];
+const LTD_MODULES = [17, 13, 9, 15, 11, 19, 7]
 
 // Widest element per group (odd); even = 9 - odd
-const LTD_WIDEST = [6, 5, 3, 5, 4, 8, 1];
+const LTD_WIDEST = [6, 5, 3, 5, 4, 8, 1]
 
 // Table 7: Checksum weights (2 pairs x 14 element widths)
 const LTD_CHECKSUM_WEIGHT = [
   [1, 3, 9, 27, 81, 65, 17, 51, 64, 14, 42, 37, 22, 66],
   [20, 60, 2, 6, 18, 54, 73, 41, 34, 13, 39, 28, 84, 74],
-];
+]
 
 // Annex C: Finder patterns for Limited (89 patterns x 14 elements)
 // prettier-ignore
@@ -410,10 +410,10 @@ const LTD_FINDER_PATTERN = [
 function ltdGroup(pairVal: number): { group: number; adjustedVal: number } {
   for (let i = 6; i > 0; i--) {
     if (pairVal >= LTD_G_SUM[i]!) {
-      return { group: i, adjustedVal: pairVal - LTD_G_SUM[i]! };
+      return { group: i, adjustedVal: pairVal - LTD_G_SUM[i]! }
     }
   }
-  return { group: 0, adjustedVal: pairVal };
+  return { group: 0, adjustedVal: pairVal }
 }
 
 /**
@@ -423,28 +423,28 @@ function ltdGroup(pairVal: number): { group: number; adjustedVal: number } {
  * @returns Array of bar widths (47 elements)
  */
 export function encodeGS1DataBarLimited(gtin: string): number[] {
-  const digits13 = parseGTIN(gtin, "Limited");
+  const digits13 = parseGTIN(gtin, "Limited")
 
   if (digits13[0] !== "0" && digits13[0] !== "1") {
-    throw new InvalidInputError("GS1 DataBar Limited: GTIN must start with 0 or 1");
+    throw new InvalidInputError("GS1 DataBar Limited: GTIN must start with 0 or 1")
   }
 
   // Convert to numeric value
-  let val = 0n;
+  let val = 0n
   for (let i = 0; i < 13; i++) {
-    val = val * 10n + BigInt(digits13.charCodeAt(i) - 48);
+    val = val * 10n + BigInt(digits13.charCodeAt(i) - 48)
   }
 
   // Split into left and right pair values
-  const pairVals = [Number(val / 2013571n), Number(val % 2013571n)];
+  const pairVals = [Number(val / 2013571n), Number(val % 2013571n)]
 
   // Encode each pair using 7 elements (interleaved odd/even)
-  const pairWidths: number[][] = [];
+  const pairWidths: number[][] = []
 
   for (let i = 0; i < 2; i++) {
-    const { group, adjustedVal } = ltdGroup(pairVals[i]!);
-    const odd = Math.trunc(adjustedVal / LTD_T_EVEN[group]!);
-    const even = adjustedVal % LTD_T_EVEN[group]!;
+    const { group, adjustedVal } = ltdGroup(pairVals[i]!)
+    const odd = Math.trunc(adjustedVal / LTD_T_EVEN[group]!)
+    const even = adjustedVal % LTD_T_EVEN[group]!
 
     pairWidths.push(
       interleaveWidths(
@@ -456,52 +456,52 @@ export function encodeGS1DataBarLimited(gtin: string): number[] {
         LTD_WIDEST[group]!,
         false,
       ),
-    );
+    )
   }
 
   // Calculate checksum
-  let checksum = 0;
+  let checksum = 0
   for (let i = 0; i < 14; i++) {
-    checksum += LTD_CHECKSUM_WEIGHT[0]![i]! * pairWidths[0]![i]!;
-    checksum += LTD_CHECKSUM_WEIGHT[1]![i]! * pairWidths[1]![i]!;
+    checksum += LTD_CHECKSUM_WEIGHT[0]![i]! * pairWidths[0]![i]!
+    checksum += LTD_CHECKSUM_WEIGHT[1]![i]! * pairWidths[1]![i]!
   }
-  checksum %= 89;
+  checksum %= 89
 
-  const checksumFinderPattern = LTD_FINDER_PATTERN[checksum]!;
+  const checksumFinderPattern = LTD_FINDER_PATTERN[checksum]!
 
   // Assemble 47-element total width array
-  const total: number[] = Array.from<number>({ length: 47 });
+  const total: number[] = Array.from<number>({ length: 47 })
 
   // Guards
-  total[0] = 1; // Left guard bar
-  total[1] = 1; // Left guard space
-  total[44] = 1; // Right guard space
-  total[45] = 1; // Right guard bar
-  total[46] = 5; // Right padding (5-module termination bar)
+  total[0] = 1 // Left guard bar
+  total[1] = 1 // Left guard space
+  total[44] = 1 // Right guard space
+  total[45] = 1 // Right guard bar
+  total[46] = 5 // Right padding (5-module termination bar)
 
   // Data and finder
   for (let i = 0; i < 14; i++) {
-    total[i + 2] = pairWidths[0]![i]!;
-    total[i + 16] = checksumFinderPattern[i]!;
-    total[i + 30] = pairWidths[1]![i]!;
+    total[i + 2] = pairWidths[0]![i]!
+    total[i + 16] = checksumFinderPattern[i]!
+    total[i + 30] = pairWidths[1]![i]!
   }
 
-  return total;
+  return total
 }
 
 // ─── DataBar Expanded ───────────────────────────────────────────────────────
 
 // Table 8: Group sum boundaries for Expanded
-const EXP_G_SUM = [0, 348, 1388, 2948, 3988];
+const EXP_G_SUM = [0, 348, 1388, 2948, 3988]
 
 // T_even values per group
-const EXP_T_EVEN = [4, 20, 52, 104, 204];
+const EXP_T_EVEN = [4, 20, 52, 104, 204]
 
 // Modules per group (odd); even = 17 - odd
-const EXP_MODULES = [12, 10, 8, 6, 4];
+const EXP_MODULES = [12, 10, 8, 6, 4]
 
 // Widest element per group (odd); even = 9 - odd
-const EXP_WIDEST = [7, 5, 4, 3, 1];
+const EXP_WIDEST = [7, 5, 4, 3, 1]
 
 // Table 14: Checksum weights (23 rows x 8 element widths)
 // prettier-ignore
@@ -534,7 +534,7 @@ const EXP_FINDER_PATTERN = [
   [1, 1, 5, 6, 2],
   [2, 2, 9, 1, 1],
   [1, 1, 9, 2, 2],
-];
+]
 
 // Table 16: Finder pattern sequence per number of codeblocks
 // Index = (symbol_chars - 1) / 2 - 1; values are 1-based finder indices
@@ -549,7 +549,7 @@ const EXP_FINDER_SEQUENCE: number[][] = [
   [1, 2, 3, 4, 5, 6, 7, 10, 9],
   [1, 2, 3, 4, 5, 6, 7, 10, 11, 12],
   [1, 2, 3, 4, 5, 8, 7, 10, 9, 12, 11],
-];
+]
 
 // Weight row indices for checksum calculation
 // prettier-ignore
@@ -570,10 +570,10 @@ const EXP_WEIGHT_ROWS: number[][] = [
 function expGroup(val: number): number {
   for (let i = 0; i < EXP_G_SUM.length - 1; i++) {
     if (val < EXP_G_SUM[i + 1]!) {
-      return i;
+      return i
     }
   }
-  return EXP_G_SUM.length - 1;
+  return EXP_G_SUM.length - 1
 }
 
 /**
@@ -582,7 +582,7 @@ function expGroup(val: number): number {
  */
 function appendBits(binary: number[], val: number, count: number): void {
   for (let i = count - 1; i >= 0; i--) {
-    binary.push((val >> i) & 1);
+    binary.push((val >> i) & 1)
   }
 }
 
@@ -592,159 +592,159 @@ function appendBits(binary: number[], val: number, count: number): void {
  * For simplicity, methods 3-14 (compressed weight/date) are encoded using method 1 or 2.
  */
 function expBinaryString(data: string): number[] {
-  const binary: number[] = [];
+  const binary: number[] = []
 
   // Linkage flag (0 = standalone, no composite)
-  binary.push(0);
+  binary.push(0)
 
   // Check if data starts with "01" (AI 01) and has at least 16 chars
   if (data.length >= 16 && data[0] === "0" && data[1] === "1") {
     // Method 1: (01) and possibly other AIs
     // Header: "1"
-    appendBits(binary, 1, 1);
+    appendBits(binary, 1, 1)
 
     // Leading digit (position 2)
-    appendBits(binary, data.charCodeAt(2) - 48, 4);
+    appendBits(binary, data.charCodeAt(2) - 48, 4)
 
     // Next 12 digits (positions 3-14), 3 at a time -> 10 bits
     for (let i = 3; i < 15; i += 3) {
       const triplet =
         (data.charCodeAt(i) - 48) * 100 +
         (data.charCodeAt(i + 1) - 48) * 10 +
-        (data.charCodeAt(i + 2) - 48);
-      appendBits(binary, triplet, 10);
+        (data.charCodeAt(i + 2) - 48)
+      appendBits(binary, triplet, 10)
     }
 
     // Variable length bit field placeholder
     // bit1: symbolChars odd? bit2: symbolChars > 14?
     // We'll patch these after we know the symbol size
-    const patchIdx = binary.length;
-    binary.push(0, 0); // placeholder
+    const patchIdx = binary.length
+    binary.push(0, 0) // placeholder
 
     // Remaining data (after position 16) goes into general field
     if (data.length > 16) {
-      encodeGeneralField(data, 16, binary);
+      encodeGeneralField(data, 16, binary)
     }
 
     // Padding and patching
-    padAndPatch(binary, patchIdx);
+    padAndPatch(binary, patchIdx)
   } else {
     // Method 2: general data
     // Header: "00"
-    appendBits(binary, 0, 2);
+    appendBits(binary, 0, 2)
 
     // Variable length bit field placeholder
-    const patchIdx = binary.length;
-    binary.push(0, 0); // placeholder
+    const patchIdx = binary.length
+    binary.push(0, 0) // placeholder
 
     // Encode all data into general field
-    encodeGeneralField(data, 0, binary);
+    encodeGeneralField(data, 0, binary)
 
     // Padding and patching
-    padAndPatch(binary, patchIdx);
+    padAndPatch(binary, patchIdx)
   }
 
-  return binary;
+  return binary
 }
 
 /** Encode general field data using numeric, alphanumeric, and ISO 646 modes */
 function encodeGeneralField(data: string, start: number, binary: number[]): void {
   // Use numeric mode for all-numeric data, else alphanumeric
-  let i = start;
-  let mode: "numeric" | "alpha" | "iso646" = "numeric";
+  let i = start
+  let mode: "numeric" | "alpha" | "iso646" = "numeric"
 
   while (i < data.length) {
     if (data[i] === "\x1D") {
       // FNC1 separator
       if (mode === "numeric") {
-        appendBits(binary, 0x0f, 4); // FNC1 in numeric mode
+        appendBits(binary, 0x0f, 4) // FNC1 in numeric mode
       } else if (mode === "alpha") {
-        appendBits(binary, 0x0f, 5); // FNC1 in alphanumeric
+        appendBits(binary, 0x0f, 5) // FNC1 in alphanumeric
       } else {
-        appendBits(binary, 0x0f, 5); // FNC1 in ISO 646
+        appendBits(binary, 0x0f, 5) // FNC1 in ISO 646
       }
-      i++;
-      continue;
+      i++
+      continue
     }
 
-    const ch = data.charCodeAt(i);
+    const ch = data.charCodeAt(i)
 
     if (mode === "numeric") {
       if (ch >= 48 && ch <= 57) {
         // Check if we have a pair of digits
         if (i + 1 < data.length && data.charCodeAt(i + 1) >= 48 && data.charCodeAt(i + 1) <= 57) {
-          const pair = (ch - 48) * 11 + (data.charCodeAt(i + 1) - 48) + 8;
-          appendBits(binary, pair, 7);
-          i += 2;
+          const pair = (ch - 48) * 11 + (data.charCodeAt(i + 1) - 48) + 8
+          appendBits(binary, pair, 7)
+          i += 2
         } else {
           // Last odd digit
-          appendBits(binary, ch - 48 + 1, 4);
-          i++;
+          appendBits(binary, ch - 48 + 1, 4)
+          i++
         }
       } else {
         // Switch to alphanumeric
-        appendBits(binary, 0, 4); // Latch to alpha
-        mode = "alpha";
+        appendBits(binary, 0, 4) // Latch to alpha
+        mode = "alpha"
       }
     } else if (mode === "alpha") {
       if (ch >= 48 && ch <= 57) {
         // Check if next two are digits - maybe switch to numeric
         if (i + 1 < data.length && data.charCodeAt(i + 1) >= 48 && data.charCodeAt(i + 1) <= 57) {
-          appendBits(binary, 0, 3); // Latch to numeric "000"
-          mode = "numeric";
+          appendBits(binary, 0, 3) // Latch to numeric "000"
+          mode = "numeric"
           // Don't advance i, re-encode in numeric mode
         } else {
-          appendBits(binary, ch - 43, 5); // Digits 0-9 -> 5-14
-          i++;
+          appendBits(binary, ch - 43, 5) // Digits 0-9 -> 5-14
+          i++
         }
       } else if (ch >= 65 && ch <= 90) {
-        appendBits(binary, ch - 65 + 15, 5); // A=15, B=16, ..., Z=40
-        i++;
+        appendBits(binary, ch - 65 + 15, 5) // A=15, B=16, ..., Z=40
+        i++
       } else if (ch === 42) {
         // '*'
-        appendBits(binary, 41, 5);
-        i++;
+        appendBits(binary, 41, 5)
+        i++
       } else if (ch === 44) {
         // ','
-        appendBits(binary, 42, 5);
-        i++;
+        appendBits(binary, 42, 5)
+        i++
       } else if (ch === 45) {
         // '-'
-        appendBits(binary, 43, 5);
-        i++;
+        appendBits(binary, 43, 5)
+        i++
       } else if (ch === 46) {
         // '.'
-        appendBits(binary, 44, 5);
-        i++;
+        appendBits(binary, 44, 5)
+        i++
       } else if (ch === 47) {
         // '/'
-        appendBits(binary, 45, 5);
-        i++;
+        appendBits(binary, 45, 5)
+        i++
       } else {
         // Switch to ISO 646 for other characters
-        appendBits(binary, 4, 5); // Latch to ISO 646
-        mode = "iso646";
+        appendBits(binary, 4, 5) // Latch to ISO 646
+        mode = "iso646"
       }
     } else {
       // iso646 mode - 5, 7, or 8 bits per character
       if (ch >= 48 && ch <= 57) {
         if (i + 1 < data.length && data.charCodeAt(i + 1) >= 48 && data.charCodeAt(i + 1) <= 57) {
-          appendBits(binary, 0, 3); // Latch to numeric
-          mode = "numeric";
+          appendBits(binary, 0, 3) // Latch to numeric
+          mode = "numeric"
         } else {
-          appendBits(binary, ch - 43, 5); // Digits: 5-14
-          i++;
+          appendBits(binary, ch - 43, 5) // Digits: 5-14
+          i++
         }
       } else if (ch >= 65 && ch <= 90) {
-        appendBits(binary, ch - 65 + 15, 7); // A-Z in ISO 646
-        i++;
+        appendBits(binary, ch - 65 + 15, 7) // A-Z in ISO 646
+        i++
       } else if (ch >= 97 && ch <= 122) {
-        appendBits(binary, ch - 97 + 41, 7); // a-z
-        i++;
+        appendBits(binary, ch - 97 + 41, 7) // a-z
+        i++
       } else {
         // Other characters as 8-bit values
-        appendBits(binary, ch, 8);
-        i++;
+        appendBits(binary, ch, 8)
+        i++
       }
     }
   }
@@ -753,29 +753,29 @@ function encodeGeneralField(data: string, start: number, binary: number[]): void
 /** Pad binary data and patch variable-length bit field */
 function padAndPatch(binary: number[], patchIdx: number): void {
   // Calculate symbol characters needed
-  let remainder = 12 - (binary.length % 12);
-  if (remainder === 12) remainder = 0;
-  let symbolChars = Math.trunc((binary.length + remainder) / 12) + 1;
+  let remainder = 12 - (binary.length % 12)
+  if (remainder === 12) remainder = 0
+  let symbolChars = Math.trunc((binary.length + remainder) / 12) + 1
 
-  if (symbolChars < 4) symbolChars = 4;
+  if (symbolChars < 4) symbolChars = 4
 
-  remainder = 12 * (symbolChars - 1) - binary.length;
+  remainder = 12 * (symbolChars - 1) - binary.length
 
   // Add padding
   if (remainder > 0) {
     // First pad with 0000 if in numeric mode end
-    appendBits(binary, 0, Math.min(4, remainder));
-    remainder -= Math.min(4, remainder);
+    appendBits(binary, 0, Math.min(4, remainder))
+    remainder -= Math.min(4, remainder)
     // Then pad with 00100 patterns
     while (remainder > 0) {
-      appendBits(binary, 4, Math.min(5, remainder));
-      remainder -= Math.min(5, remainder);
+      appendBits(binary, 4, Math.min(5, remainder))
+      remainder -= Math.min(5, remainder)
     }
   }
 
   // Patch variable-length symbol bit field
-  binary[patchIdx] = symbolChars & 1 ? 1 : 0;
-  binary[patchIdx + 1] = symbolChars > 14 ? 1 : 0;
+  binary[patchIdx] = symbolChars & 1 ? 1 : 0
+  binary[patchIdx + 1] = symbolChars > 14 ? 1 : 0
 }
 
 /**
@@ -786,36 +786,36 @@ function padAndPatch(binary: number[], patchIdx: number): void {
  */
 export function encodeGS1DataBarExpanded(data: string): number[] {
   if (data.length === 0) {
-    throw new InvalidInputError("GS1 DataBar Expanded: data must not be empty");
+    throw new InvalidInputError("GS1 DataBar Expanded: data must not be empty")
   }
 
   // Parse AI-formatted input -- strip parentheses and validate AI structure
-  let payload = data;
+  let payload = data
   if (data.startsWith("(")) {
-    const fields = parseAIString(data); // throws on invalid AI syntax
-    payload = fields.map((f) => f.ai + f.data).join("");
+    const fields = parseAIString(data) // throws on invalid AI syntax
+    payload = fields.map((f) => f.ai + f.data).join("")
   }
 
   // Generate binary string
-  const binary = expBinaryString(payload);
+  const binary = expBinaryString(payload)
 
   // Calculate data characters from binary
-  const dataChars = Math.trunc(binary.length / 12);
-  const symbolChars = dataChars + 1; // Plus check char
+  const dataChars = Math.trunc(binary.length / 12)
+  const symbolChars = dataChars + 1 // Plus check char
 
   // Encode each 12-bit segment to element widths
-  const charWidths: number[][] = [];
+  const charWidths: number[][] = []
   for (let i = 0; i < dataChars; i++) {
-    let vs = 0;
+    let vs = 0
     for (let j = 0; j < 12; j++) {
       if (binary[i * 12 + j]) {
-        vs |= 0x800 >> j;
+        vs |= 0x800 >> j
       }
     }
 
-    const group = expGroup(vs);
-    const odd = Math.trunc((vs - EXP_G_SUM[group]!) / EXP_T_EVEN[group]!);
-    const even = (vs - EXP_G_SUM[group]!) % EXP_T_EVEN[group]!;
+    const group = expGroup(vs)
+    const odd = Math.trunc((vs - EXP_G_SUM[group]!) / EXP_T_EVEN[group]!)
+    const even = (vs - EXP_G_SUM[group]!) % EXP_T_EVEN[group]!
 
     charWidths.push(
       interleaveWidths(
@@ -827,25 +827,25 @@ export function encodeGS1DataBarExpanded(data: string): number[] {
         EXP_WIDEST[group]!,
         true,
       ),
-    );
+    )
   }
 
   // Calculate checksum (7.2.6)
-  let checksum = 0;
-  const weightRowIdx = Math.trunc((dataChars - 2) / 2);
+  let checksum = 0
+  const weightRowIdx = Math.trunc((dataChars - 2) / 2)
 
   for (let i = 0; i < dataChars; i++) {
-    const row = EXP_WEIGHT_ROWS[weightRowIdx]![i]!;
+    const row = EXP_WEIGHT_ROWS[weightRowIdx]![i]!
     for (let j = 0; j < 8; j++) {
-      checksum += charWidths[i]![j]! * EXP_CHECKSUM_WEIGHT[row]![j]!;
+      checksum += charWidths[i]![j]! * EXP_CHECKSUM_WEIGHT[row]![j]!
     }
   }
 
-  const checkChar = 211 * (symbolChars - 4) + (checksum % 211);
+  const checkChar = 211 * (symbolChars - 4) + (checksum % 211)
 
-  const checkGroup = expGroup(checkChar);
-  const checkOdd = Math.trunc((checkChar - EXP_G_SUM[checkGroup]!) / EXP_T_EVEN[checkGroup]!);
-  const checkEven = (checkChar - EXP_G_SUM[checkGroup]!) % EXP_T_EVEN[checkGroup]!;
+  const checkGroup = expGroup(checkChar)
+  const checkOdd = Math.trunc((checkChar - EXP_G_SUM[checkGroup]!) / EXP_T_EVEN[checkGroup]!)
+  const checkEven = (checkChar - EXP_G_SUM[checkGroup]!) % EXP_T_EVEN[checkGroup]!
 
   const checkWidths = interleaveWidths(
     checkOdd,
@@ -855,48 +855,48 @@ export function encodeGS1DataBarExpanded(data: string): number[] {
     4,
     EXP_WIDEST[checkGroup]!,
     true,
-  );
+  )
 
   // Assemble element array
-  const codeblocks = Math.trunc((symbolChars + 1) / 2);
-  const patternWidth = codeblocks * 5 + symbolChars * 8 + 4;
-  const elements: number[] = Array.from<number>({ length: patternWidth }).fill(0);
+  const codeblocks = Math.trunc((symbolChars + 1) / 2)
+  const patternWidth = codeblocks * 5 + symbolChars * 8 + 4
+  const elements: number[] = Array.from<number>({ length: patternWidth }).fill(0)
 
   // Put finder patterns in element array
-  const p = Math.trunc((symbolChars - 1) / 2) - 1;
+  const p = Math.trunc((symbolChars - 1) / 2) - 1
   for (let i = 0; i < codeblocks; i++) {
-    const k = EXP_FINDER_SEQUENCE[p]![i]! - 1;
+    const k = EXP_FINDER_SEQUENCE[p]![i]! - 1
     for (let j = 0; j < 5; j++) {
-      elements[21 * i + j + 10] = EXP_FINDER_PATTERN[k]![j]!;
+      elements[21 * i + j + 10] = EXP_FINDER_PATTERN[k]![j]!
     }
   }
 
   // Put check character in element array
   for (let i = 0; i < 8; i++) {
-    elements[i + 2] = checkWidths[i]!;
+    elements[i + 2] = checkWidths[i]!
   }
 
   // Put forward reading data characters (odd-indexed: 1, 3, 5, ...)
   for (let i = 1; i < dataChars; i += 2) {
-    const k = Math.trunc((i - 1) / 2) * 21 + 23;
+    const k = Math.trunc((i - 1) / 2) * 21 + 23
     for (let j = 0; j < 8; j++) {
-      elements[k + j] = charWidths[i]![j]!;
+      elements[k + j] = charWidths[i]![j]!
     }
   }
 
   // Put reversed data characters (even-indexed: 0, 2, 4, ...)
   for (let i = 0; i < dataChars; i += 2) {
-    const k = Math.trunc(i / 2) * 21 + 15;
+    const k = Math.trunc(i / 2) * 21 + 15
     for (let j = 0; j < 8; j++) {
-      elements[k + j] = charWidths[i]![7 - j]!;
+      elements[k + j] = charWidths[i]![7 - j]!
     }
   }
 
   // Set guards
-  elements[0] = 1;
-  elements[1] = 1;
-  elements[patternWidth - 2] = 1;
-  elements[patternWidth - 1] = 1;
+  elements[0] = 1
+  elements[1] = 1
+  elements[patternWidth - 2] = 1
+  elements[patternWidth - 1] = 1
 
-  return elements;
+  return elements
 }

--- a/src/encoders/hanxin.ts
+++ b/src/encoders/hanxin.ts
@@ -9,67 +9,67 @@
  * - Finder patterns at all 4 corners (unlike QR's 3)
  */
 
-import { InvalidInputError, CapacityError } from "../errors";
+import { InvalidInputError, CapacityError } from "../errors"
 
 // ---------------------------------------------------------------------------
 // Han Xin mode indicators (4 bits each)
 // ---------------------------------------------------------------------------
-const MODE_NUMERIC = 0b0001;
-const MODE_TEXT = 0b0010;
-const MODE_BINARY = 0b0011;
+const MODE_NUMERIC = 0b0001
+const MODE_TEXT = 0b0010
+const MODE_BINARY = 0b0011
 // const MODE_CHINESE = 0b0100; // GB 18030 — reserved for future use
 
 // ---------------------------------------------------------------------------
 // GF(256) arithmetic with Han Xin primitive polynomial 0x163
 // (x^8 + x^6 + x^5 + x + 1) — different from QR's 0x11D and DM's 0x12D
 // ---------------------------------------------------------------------------
-const HX_GF_EXP = new Uint8Array(512);
-const HX_GF_LOG = new Uint8Array(256);
+const HX_GF_EXP = new Uint8Array(512)
+const HX_GF_LOG = new Uint8Array(256)
 
-(function initHanXinGF() {
-  let x = 1;
+;(function initHanXinGF() {
+  let x = 1
   for (let i = 0; i < 255; i++) {
-    HX_GF_EXP[i] = x;
-    HX_GF_LOG[x] = i;
-    x = x << 1;
-    if (x >= 256) x ^= 0x163;
+    HX_GF_EXP[i] = x
+    HX_GF_LOG[x] = i
+    x = x << 1
+    if (x >= 256) x ^= 0x163
   }
   // Extend exp table for easier modular arithmetic
   for (let i = 255; i < 512; i++) {
-    HX_GF_EXP[i] = HX_GF_EXP[i - 255]!;
+    HX_GF_EXP[i] = HX_GF_EXP[i - 255]!
   }
-})();
+})()
 
 /** Multiply two GF(256) elements using Han Xin polynomial */
 function gfMultiply(a: number, b: number): number {
-  if (a === 0 || b === 0) return 0;
-  return HX_GF_EXP[(HX_GF_LOG[a]! + HX_GF_LOG[b]!) % 255]!;
+  if (a === 0 || b === 0) return 0
+  return HX_GF_EXP[(HX_GF_LOG[a]! + HX_GF_LOG[b]!) % 255]!
 }
 
 /** Generate Reed-Solomon EC codewords for Han Xin over GF(256)/0x163 */
 function hanxinGenerateEC(data: number[], ecCount: number): number[] {
   // Build generator polynomial: g(x) = (x - a^0)(x - a^1)...(x - a^(ecCount-1))
-  const gen: number[] = Array.from({ length: ecCount + 1 }, () => 0);
-  gen[0] = 1;
+  const gen: number[] = Array.from({ length: ecCount + 1 }, () => 0)
+  gen[0] = 1
 
   for (let i = 0; i < ecCount; i++) {
     for (let j = gen.length - 1; j >= 1; j--) {
-      gen[j] = gen[j - 1]! ^ gfMultiply(gen[j]!, HX_GF_EXP[i]!);
+      gen[j] = gen[j - 1]! ^ gfMultiply(gen[j]!, HX_GF_EXP[i]!)
     }
-    gen[0] = gfMultiply(gen[0]!, HX_GF_EXP[i]!);
+    gen[0] = gfMultiply(gen[0]!, HX_GF_EXP[i]!)
   }
 
   // Polynomial long division: data polynomial / generator polynomial
-  const result = Array.from({ length: ecCount }, () => 0);
+  const result = Array.from({ length: ecCount }, () => 0)
   for (const byte of data) {
-    const lead = byte ^ result[0]!;
+    const lead = byte ^ result[0]!
     for (let j = 0; j < ecCount - 1; j++) {
-      result[j] = result[j + 1]! ^ gfMultiply(lead, gen[j + 1]!);
+      result[j] = result[j + 1]! ^ gfMultiply(lead, gen[j + 1]!)
     }
-    result[ecCount - 1] = gfMultiply(lead, gen[ecCount]!);
+    result[ecCount - 1] = gfMultiply(lead, gen[ecCount]!)
   }
 
-  return result;
+  return result
 }
 
 // ---------------------------------------------------------------------------
@@ -79,7 +79,7 @@ function hanxinGenerateEC(data: number[], ecCount: number): number[] {
 /** Push `count` bits of `value` (MSB first) into a bit array */
 function pushBits(arr: number[], value: number, count: number): void {
   for (let i = count - 1; i >= 0; i--) {
-    arr.push((value >> i) & 1);
+    arr.push((value >> i) & 1)
   }
 }
 
@@ -89,7 +89,7 @@ function pushBits(arr: number[], value: number, count: number): void {
 
 // Han Xin version sizes: version v → (v*2 + 21) modules per side
 function hanxinSize(version: number): number {
-  return version * 2 + 21;
+  return version * 2 + 21
 }
 
 /**
@@ -104,30 +104,30 @@ function hanxinSize(version: number): number {
  * before applying EC overhead.
  */
 function hanxinTotalCodewords(version: number): number {
-  const size = hanxinSize(version);
-  const totalModules = size * size;
+  const size = hanxinSize(version)
+  const totalModules = size * size
 
   // 4 finder patterns — 7×7 each
-  const finderModules = 4 * 7 * 7;
+  const finderModules = 4 * 7 * 7
 
   // Separator bands around finders: 4 L-shaped bands, ~8 modules each
-  const separatorModules = 4 * (8 + 7);
+  const separatorModules = 4 * (8 + 7)
 
   // Format/version info regions around finders
-  const formatModules = Math.min(36 + version * 2, size * 4);
+  const formatModules = Math.min(36 + version * 2, size * 4)
 
-  const usableModules = totalModules - finderModules - separatorModules - formatModules;
+  const usableModules = totalModules - finderModules - separatorModules - formatModules
 
-  return Math.floor(usableModules / 8);
+  return Math.floor(usableModules / 8)
 }
 
 /**
  * Get data codeword capacity for a version at a given EC ratio.
  */
 function hanxinDataCapacity(version: number, ecRatio: number): number {
-  const total = hanxinTotalCodewords(version);
-  const ecBytes = Math.ceil(total * ecRatio);
-  return total - ecBytes;
+  const total = hanxinTotalCodewords(version)
+  const ecBytes = Math.ceil(total * ecRatio)
+  return total - ecBytes
 }
 
 // ---------------------------------------------------------------------------
@@ -137,25 +137,25 @@ function hanxinDataCapacity(version: number, ecRatio: number): number {
 /** Check if entire input is digits */
 function isNumeric(text: string): boolean {
   for (let i = 0; i < text.length; i++) {
-    const c = text.charCodeAt(i);
-    if (c < 0x30 || c > 0x39) return false;
+    const c = text.charCodeAt(i)
+    if (c < 0x30 || c > 0x39) return false
   }
-  return true;
+  return true
 }
 
 /** Check if entire input is in the Han Xin text mode character set */
 function isText(text: string): boolean {
   for (let i = 0; i < text.length; i++) {
-    const c = text.charCodeAt(i);
+    const c = text.charCodeAt(i)
     // Han Xin text mode covers ASCII 0x20-0x7E
-    if (c < 0x20 || c > 0x7e) return false;
+    if (c < 0x20 || c > 0x7e) return false
   }
-  return true;
+  return true
 }
 
 export interface HanXinOptions {
-  ecLevel?: 1 | 2 | 3 | 4; // L1(~8%), L2(~15%), L3(~23%), L4(~30%)
-  version?: number; // 1-84
+  ecLevel?: 1 | 2 | 3 | 4 // L1(~8%), L2(~15%), L3(~23%), L4(~30%)
+  version?: number // 1-84
 }
 
 /**
@@ -164,161 +164,161 @@ export interface HanXinOptions {
  */
 export function encodeHanXin(text: string, options: HanXinOptions = {}): boolean[][] {
   if (text.length === 0) {
-    throw new InvalidInputError("Han Xin Code input must not be empty");
+    throw new InvalidInputError("Han Xin Code input must not be empty")
   }
 
-  const ecLevel = options.ecLevel ?? 1;
-  const ecRatio = [0, 0.08, 0.15, 0.23, 0.3][ecLevel];
+  const ecLevel = options.ecLevel ?? 1
+  const ecRatio = [0, 0.08, 0.15, 0.23, 0.3][ecLevel]
   if (ecRatio === undefined) {
     // Without this guard an out-of-range level yields NaN capacities and
     // surfaces as a misleading "data too long" error.
-    throw new InvalidInputError(`Han Xin EC level must be 1, 2, 3 or 4 (got ${String(ecLevel)})`);
+    throw new InvalidInputError(`Han Xin EC level must be 1, 2, 3 or 4 (got ${String(ecLevel)})`)
   }
 
   // Build data bits with Han Xin mode indicators
-  const bits: number[] = [];
+  const bits: number[] = []
 
   if (isNumeric(text)) {
     // Numeric mode: groups of 3 digits → 10 bits
-    pushBits(bits, MODE_NUMERIC, 4);
-    pushBits(bits, text.length, 13);
+    pushBits(bits, MODE_NUMERIC, 4)
+    pushBits(bits, text.length, 13)
     for (let i = 0; i < text.length; i += 3) {
-      const group = text.substring(i, Math.min(i + 3, text.length));
-      const val = Number.parseInt(group, 10);
+      const group = text.substring(i, Math.min(i + 3, text.length))
+      const val = Number.parseInt(group, 10)
       if (group.length === 3) {
-        pushBits(bits, val, 10);
+        pushBits(bits, val, 10)
       } else if (group.length === 2) {
-        pushBits(bits, val, 7);
+        pushBits(bits, val, 7)
       } else {
-        pushBits(bits, val, 4);
+        pushBits(bits, val, 4)
       }
     }
   } else if (isText(text)) {
     // Text mode: 6 bits per character
-    pushBits(bits, MODE_TEXT, 4);
-    pushBits(bits, text.length, 13);
+    pushBits(bits, MODE_TEXT, 4)
+    pushBits(bits, text.length, 13)
     for (let i = 0; i < text.length; i++) {
       // Map ASCII 0x20-0x7E to 0-94
-      pushBits(bits, text.charCodeAt(i) - 0x20, 7);
+      pushBits(bits, text.charCodeAt(i) - 0x20, 7)
     }
   } else {
     // Binary mode: raw bytes
-    const data = new TextEncoder().encode(text);
-    pushBits(bits, MODE_BINARY, 4);
-    pushBits(bits, data.length, 13);
+    const data = new TextEncoder().encode(text)
+    pushBits(bits, MODE_BINARY, 4)
+    pushBits(bits, data.length, 13)
     for (const byte of data) {
-      pushBits(bits, byte, 8);
+      pushBits(bits, byte, 8)
     }
   }
 
   // Select version
-  const dataBitCount = bits.length;
-  let version = options.version ?? 0;
+  const dataBitCount = bits.length
+  let version = options.version ?? 0
 
   if (options.version === undefined) {
     for (let v = 1; v <= 84; v++) {
-      const dataCap = hanxinDataCapacity(v, ecRatio);
-      const neededBytes = Math.ceil(dataBitCount / 8);
+      const dataCap = hanxinDataCapacity(v, ecRatio)
+      const neededBytes = Math.ceil(dataBitCount / 8)
       if (neededBytes <= dataCap) {
-        version = v;
-        break;
+        version = v
+        break
       }
     }
     if (version === 0) {
-      throw new CapacityError("Data too long for any Han Xin Code version");
+      throw new CapacityError("Data too long for any Han Xin Code version")
     }
   } else if (!Number.isInteger(version) || version < 1 || version > 84) {
-    throw new InvalidInputError(`Han Xin version must be an integer 1-84 (got ${String(version)})`);
+    throw new InvalidInputError(`Han Xin version must be an integer 1-84 (got ${String(version)})`)
   }
 
-  const size = hanxinSize(version);
+  const size = hanxinSize(version)
 
   // Pad bits to fill data capacity
-  const totalCW = hanxinTotalCodewords(version);
-  const ecBytes = Math.ceil(totalCW * ecRatio);
-  const dataBytes = totalCW - ecBytes;
-  const totalDataBits = dataBytes * 8;
+  const totalCW = hanxinTotalCodewords(version)
+  const ecBytes = Math.ceil(totalCW * ecRatio)
+  const dataBytes = totalCW - ecBytes
+  const totalDataBits = dataBytes * 8
 
   // Terminator: up to 4 zero bits
-  const termLen = Math.min(4, totalDataBits - bits.length);
-  pushBits(bits, 0, termLen);
+  const termLen = Math.min(4, totalDataBits - bits.length)
+  pushBits(bits, 0, termLen)
 
   // Byte-align
-  while (bits.length % 8 !== 0) bits.push(0);
+  while (bits.length % 8 !== 0) bits.push(0)
 
   // Pad with 0x55 (Han Xin padding byte, alternating bits)
   while (bits.length < totalDataBits) {
-    pushBits(bits, 0x55, 8);
+    pushBits(bits, 0x55, 8)
   }
   // Trim to exact length
-  bits.length = totalDataBits;
+  bits.length = totalDataBits
 
   // Convert bits to bytes
-  const dataArr: number[] = [];
+  const dataArr: number[] = []
   for (let i = 0; i < bits.length; i += 8) {
-    let byte = 0;
+    let byte = 0
     for (let j = 0; j < 8 && i + j < bits.length; j++) {
-      byte = (byte << 1) | bits[i + j]!;
+      byte = (byte << 1) | bits[i + j]!
     }
-    dataArr.push(byte);
+    dataArr.push(byte)
   }
 
   // Generate EC with Han Xin RS over GF(256)/0x163
   // Split into blocks if ecBytes > 255 (RS block limit)
-  let allBytes: number[];
+  let allBytes: number[]
   if (ecBytes === 0) {
-    allBytes = dataArr;
+    allBytes = dataArr
   } else if (ecBytes <= 255) {
-    const ec = hanxinGenerateEC(dataArr, ecBytes);
-    allBytes = [...dataArr, ...ec];
+    const ec = hanxinGenerateEC(dataArr, ecBytes)
+    allBytes = [...dataArr, ...ec]
   } else {
     // Split into multiple RS blocks
-    const numBlocks = Math.ceil(ecBytes / 255);
-    const ecPerBlock = Math.ceil(ecBytes / numBlocks);
-    const baseDataPerBlock = Math.floor(dataArr.length / numBlocks);
-    const extraDataBlocks = dataArr.length % numBlocks;
+    const numBlocks = Math.ceil(ecBytes / 255)
+    const ecPerBlock = Math.ceil(ecBytes / numBlocks)
+    const baseDataPerBlock = Math.floor(dataArr.length / numBlocks)
+    const extraDataBlocks = dataArr.length % numBlocks
 
-    const interleavedData: number[] = [];
-    const interleavedEC: number[] = [];
-    const blocks: number[][] = [];
-    let pos = 0;
+    const interleavedData: number[] = []
+    const interleavedEC: number[] = []
+    const blocks: number[][] = []
+    let pos = 0
 
     for (let b = 0; b < numBlocks; b++) {
-      const blockSize = baseDataPerBlock + (b < extraDataBlocks ? 1 : 0);
-      const block = dataArr.slice(pos, pos + blockSize);
-      blocks.push(block);
-      pos += blockSize;
+      const blockSize = baseDataPerBlock + (b < extraDataBlocks ? 1 : 0)
+      const block = dataArr.slice(pos, pos + blockSize)
+      blocks.push(block)
+      pos += blockSize
     }
 
     // Generate EC per block
-    const ecBlocks: number[][] = [];
+    const ecBlocks: number[][] = []
     for (const block of blocks) {
-      ecBlocks.push(hanxinGenerateEC(block, Math.min(ecPerBlock, 255)));
+      ecBlocks.push(hanxinGenerateEC(block, Math.min(ecPerBlock, 255)))
     }
 
     // Interleave data
-    const maxDataLen = Math.max(...blocks.map((b) => b.length));
+    const maxDataLen = Math.max(...blocks.map((b) => b.length))
     for (let i = 0; i < maxDataLen; i++) {
       for (const block of blocks) {
-        if (i < block.length) interleavedData.push(block[i]!);
+        if (i < block.length) interleavedData.push(block[i]!)
       }
     }
 
     // Interleave EC
-    const maxECLen = Math.max(...ecBlocks.map((b) => b.length));
+    const maxECLen = Math.max(...ecBlocks.map((b) => b.length))
     for (let i = 0; i < maxECLen; i++) {
       for (const ec of ecBlocks) {
-        if (i < ec.length) interleavedEC.push(ec[i]!);
+        if (i < ec.length) interleavedEC.push(ec[i]!)
       }
     }
 
-    allBytes = [...interleavedData, ...interleavedEC];
+    allBytes = [...interleavedData, ...interleavedEC]
   }
 
   // Build matrix
   const matrix: (boolean | null)[][] = Array.from({ length: size }, () =>
     Array.from<boolean | null>({ length: size }).fill(null),
-  );
+  )
 
   // Place 4 finder patterns (all corners — Han Xin has 4, not 3 like QR)
   // Han Xin 4 rotationally-distinct chevron-shaped finder patterns (from Zint/bwip-js)
@@ -331,62 +331,62 @@ export function encodeHanXin(text: string, options: HanXinOptions = {}): boolean
   // prettier-ignore
   const FINDER_BR = [0x75,0x75,0x75,0x05,0x7d,0x01,0x7f]; // TR reversed
 
-  placeFinderHX(matrix, 0, 0, FINDER_TL, size);
-  placeFinderHX(matrix, 0, size - 7, FINDER_TR, size);
-  placeFinderHX(matrix, size - 7, 0, FINDER_BL, size);
-  placeFinderHX(matrix, size - 7, size - 7, FINDER_BR, size);
+  placeFinderHX(matrix, 0, 0, FINDER_TL, size)
+  placeFinderHX(matrix, 0, size - 7, FINDER_TR, size)
+  placeFinderHX(matrix, size - 7, 0, FINDER_BL, size)
+  placeFinderHX(matrix, size - 7, size - 7, FINDER_BR, size)
 
   // Separator: 8-module white border around each finder (row/col 7 and symmetric)
   for (let i = 0; i < 8; i++) {
     // Top-left separator
-    matrix[7]![i] = false;
-    matrix[i]![7] = false;
+    matrix[7]![i] = false
+    matrix[i]![7] = false
     // Top-right separator
-    matrix[7]![size - 1 - i] = false;
-    matrix[i]![size - 8] = false;
+    matrix[7]![size - 1 - i] = false
+    matrix[i]![size - 8] = false
     // Bottom-left separator
-    matrix[size - 8]![i] = false;
-    matrix[size - 1 - i]![7] = false;
+    matrix[size - 8]![i] = false
+    matrix[size - 1 - i]![7] = false
     // Bottom-right separator
-    matrix[size - 8]![size - 1 - i] = false;
-    matrix[size - 1 - i]![size - 8] = false;
+    matrix[size - 8]![size - 1 - i] = false
+    matrix[size - 1 - i]![size - 8] = false
   }
 
   // Function information region: 9-module reserved area (row/col 8 and symmetric)
   for (let i = 0; i < 9; i++) {
     // Top-left
-    if (matrix[8]![i] === null) matrix[8]![i] = false;
-    if (matrix[i]![8] === null) matrix[i]![8] = false;
+    if (matrix[8]![i] === null) matrix[8]![i] = false
+    if (matrix[i]![8] === null) matrix[i]![8] = false
     // Top-right
-    if (matrix[8]![size - 1 - i] === null) matrix[8]![size - 1 - i] = false;
-    if (matrix[i]![size - 9] === null) matrix[i]![size - 9] = false;
+    if (matrix[8]![size - 1 - i] === null) matrix[8]![size - 1 - i] = false
+    if (matrix[i]![size - 9] === null) matrix[i]![size - 9] = false
     // Bottom-left
-    if (matrix[size - 9]![i] === null) matrix[size - 9]![i] = false;
-    if (matrix[size - 1 - i]![8] === null) matrix[size - 1 - i]![8] = false;
+    if (matrix[size - 9]![i] === null) matrix[size - 9]![i] = false
+    if (matrix[size - 1 - i]![8] === null) matrix[size - 1 - i]![8] = false
     // Bottom-right
-    if (matrix[size - 9]![size - 1 - i] === null) matrix[size - 9]![size - 1 - i] = false;
-    if (matrix[size - 1 - i]![size - 9] === null) matrix[size - 1 - i]![size - 9] = false;
+    if (matrix[size - 9]![size - 1 - i] === null) matrix[size - 9]![size - 1 - i] = false
+    if (matrix[size - 1 - i]![size - 9] === null) matrix[size - 1 - i]![size - 9] = false
   }
 
   // Place data bits into available modules
-  const allBits: number[] = [];
+  const allBits: number[] = []
   for (const byte of allBytes) {
-    pushBits(allBits, byte, 8);
+    pushBits(allBits, byte, 8)
   }
 
-  let bitIdx = 0;
+  let bitIdx = 0
   for (let c = size - 2; c >= 1; c -= 2) {
     for (let r = 1; r < size - 1; r++) {
       for (const cc of [c, c - 1]) {
         if (cc >= 0 && cc < size && matrix[r]![cc] === null) {
-          matrix[r]![cc] = bitIdx < allBits.length ? allBits[bitIdx]! === 1 : false;
-          bitIdx++;
+          matrix[r]![cc] = bitIdx < allBits.length ? allBits[bitIdx]! === 1 : false
+          bitIdx++
         }
       }
     }
   }
 
-  return matrix.map((row) => row.map((cell) => cell === true));
+  return matrix.map((row) => row.map((cell) => cell === true))
 }
 
 function placeFinderHX(
@@ -398,10 +398,10 @@ function placeFinderHX(
 ): void {
   for (let r = 0; r < 7; r++) {
     for (let c = 0; c < 7; c++) {
-      const rr = row + r;
-      const cc = col + c;
-      if (rr < 0 || rr >= size || cc < 0 || cc >= size) continue;
-      matrix[rr]![cc] = ((pattern[r]! >> (6 - c)) & 1) === 1;
+      const rr = row + r
+      const cc = col + c
+      if (rr < 0 || rr >= size || cc < 0 || cc >= size) continue
+      matrix[rr]![cc] = ((pattern[r]! >> (6 - c)) & 1) === 1
     }
   }
 }

--- a/src/encoders/hibc.ts
+++ b/src/encoders/hibc.ts
@@ -6,19 +6,19 @@
  * HIBC Secondary: +$$ ExpiryDate LotNumber CheckDigit
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
-const HIBC_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%";
+const HIBC_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%"
 
 /** Calculate HIBC mod 43 check digit */
 function hibcCheckDigit(data: string): string {
-  let sum = 0;
+  let sum = 0
   for (const ch of data) {
-    const idx = HIBC_CHARS.indexOf(ch);
-    if (idx === -1) throw new InvalidInputError(`Invalid HIBC character: "${ch}"`);
-    sum += idx;
+    const idx = HIBC_CHARS.indexOf(ch)
+    if (idx === -1) throw new InvalidInputError(`Invalid HIBC character: "${ch}"`)
+    sum += idx
   }
-  return HIBC_CHARS[sum % 43]!;
+  return HIBC_CHARS[sum % 43]!
 }
 
 /**
@@ -31,23 +31,23 @@ function hibcCheckDigit(data: string): string {
  */
 export function encodeHIBCPrimary(lic: string, product: string, unitOfMeasure = 0): string {
   if (!/^[A-Z][A-Z0-9]{3}$/.test(lic)) {
-    throw new InvalidInputError("HIBC LIC must be 4 characters: letter + 3 alphanumeric");
+    throw new InvalidInputError("HIBC LIC must be 4 characters: letter + 3 alphanumeric")
   }
   if (product.length < 1 || product.length > 18) {
-    throw new InvalidInputError("HIBC product number must be 1-18 characters");
+    throw new InvalidInputError("HIBC product number must be 1-18 characters")
   }
   if (!/^[0-9A-Z\-. $/+%]+$/.test(product)) {
     throw new InvalidInputError(
       "HIBC product number contains invalid characters (must be uppercase alphanumeric or - . $ / + %)",
-    );
+    )
   }
   if (unitOfMeasure < 0 || unitOfMeasure > 9) {
-    throw new InvalidInputError("HIBC unit of measure must be 0-9");
+    throw new InvalidInputError("HIBC unit of measure must be 0-9")
   }
 
-  const data = `+${lic}${product}${unitOfMeasure}`;
-  const check = hibcCheckDigit(data);
-  return `${data}${check}`;
+  const data = `+${lic}${product}${unitOfMeasure}`
+  const check = hibcCheckDigit(data)
+  return `${data}${check}`
 }
 
 /**
@@ -59,37 +59,37 @@ export function encodeHIBCPrimary(lic: string, product: string, unitOfMeasure = 
  */
 export function encodeHIBCSecondary(expiry?: string, lot?: string): string {
   if (!expiry && !lot) {
-    throw new InvalidInputError("HIBC Secondary requires at least expiry or lot");
+    throw new InvalidInputError("HIBC Secondary requires at least expiry or lot")
   }
   if (lot && !/^[0-9A-Z\-. $/+%]+$/.test(lot)) {
     throw new InvalidInputError(
       "HIBC lot number contains invalid characters (must be uppercase alphanumeric or - . $ / + %)",
-    );
+    )
   }
-  let data = "+$$";
+  let data = "+$$"
 
   if (expiry) {
     // Date format indicator + date
     if (expiry.length === 4) {
       // YYMM
-      data += `2${expiry}`;
+      data += `2${expiry}`
     } else if (expiry.length === 6) {
       // YYMMDD
-      data += `3${expiry}`;
+      data += `3${expiry}`
     } else if (expiry.length === 8) {
       // YYYYMMDD
-      data += `4${expiry}`;
+      data += `4${expiry}`
     } else {
-      throw new InvalidInputError("HIBC expiry must be YYMM, YYMMDD, or YYYYMMDD");
+      throw new InvalidInputError("HIBC expiry must be YYMM, YYMMDD, or YYYYMMDD")
     }
   }
 
   if (lot) {
-    data += lot;
+    data += lot
   }
 
-  const check = hibcCheckDigit(data);
-  return `${data}${check}`;
+  const check = hibcCheckDigit(data)
+  return `${data}${check}`
 }
 
 /**
@@ -100,18 +100,18 @@ export function encodeHIBCConcatenated(
   product: string,
   options?: { unitOfMeasure?: number; expiry?: string; lot?: string },
 ): string {
-  const primary = encodeHIBCPrimary(lic, product, options?.unitOfMeasure);
+  const primary = encodeHIBCPrimary(lic, product, options?.unitOfMeasure)
   // Remove check digit from primary for concatenation
-  const primaryData = primary.slice(0, -1);
+  const primaryData = primary.slice(0, -1)
 
-  let secondary = "";
+  let secondary = ""
   if (options?.expiry || options?.lot) {
-    const sec = encodeHIBCSecondary(options.expiry, options.lot);
+    const sec = encodeHIBCSecondary(options.expiry, options.lot)
     // Remove "+$$" prefix and check digit for concatenation
-    secondary = "/" + sec.slice(3, -1);
+    secondary = "/" + sec.slice(3, -1)
   }
 
-  const combined = `${primaryData}${secondary}`;
-  const check = hibcCheckDigit(combined);
-  return `${combined}${check}`;
+  const combined = `${primaryData}${secondary}`
+  const check = hibcCheckDigit(combined)
+  return `${combined}${check}`
 }

--- a/src/encoders/imb.ts
+++ b/src/encoders/imb.ts
@@ -6,8 +6,8 @@
  * Output: Array of 65 bar states (FourState: T/A/D/F)
  */
 
-import { InvalidInputError } from "../errors";
-import type { FourState } from "./fourstate";
+import { InvalidInputError } from "../errors"
+import type { FourState } from "./fourstate"
 
 /**
  * Bar construction table from USPS-B-3200 Appendix (Table 22)
@@ -92,50 +92,50 @@ const BAR_TABLE: [number, number, number, number][] = [
  * pairs go at the beginning (forward, then reverse).
  */
 function initNOf13Table(n: number, tableLength: number): number[] {
-  const table: number[] = Array.from({ length: tableLength });
-  let lo = 0;
-  let hi = tableLength - 1;
+  const table: number[] = Array.from({ length: tableLength })
+  let lo = 0
+  let hi = tableLength - 1
 
   for (let i = 0; i < 8192; i++) {
     // Count number of 1-bits
-    let bitCount = 0;
-    let tmp = i;
+    let bitCount = 0
+    let tmp = i
     while (tmp) {
-      bitCount += tmp & 1;
-      tmp >>>= 1;
+      bitCount += tmp & 1
+      tmp >>>= 1
     }
-    if (bitCount !== n) continue;
+    if (bitCount !== n) continue
 
     // Compute 13-bit reversal
-    let rev = 0;
-    tmp = i;
+    let rev = 0
+    tmp = i
     for (let b = 0; b < 13; b++) {
-      rev = (rev << 1) | (tmp & 1);
-      tmp >>>= 1;
+      rev = (rev << 1) | (tmp & 1)
+      tmp >>>= 1
     }
 
     // Skip if we already visited this pair (reverse < forward)
-    if (rev < i) continue;
+    if (rev < i) continue
 
     if (i === rev) {
       // Palindromic: place at end
-      table[hi] = i;
-      hi--;
+      table[hi] = i
+      hi--
     } else {
       // Non-palindromic: place forward then reverse
-      table[lo] = i;
-      lo++;
-      table[lo] = rev;
-      lo++;
+      table[lo] = i
+      lo++
+      table[lo] = rev
+      lo++
     }
   }
 
-  return table;
+  return table
 }
 
 // Pre-compute the character lookup tables
-const TABLE_5_OF_13 = initNOf13Table(5, 1287);
-const TABLE_2_OF_13 = initNOf13Table(2, 78);
+const TABLE_5_OF_13 = initNOf13Table(5, 1287)
+const TABLE_2_OF_13 = initNOf13Table(2, 78)
 
 /**
  * Encode USPS Intelligent Mail barcode
@@ -145,93 +145,93 @@ const TABLE_2_OF_13 = initNOf13Table(2, 78);
  * @returns Array of 65 FourState values
  */
 export function encodeIMb(trackingCode: string, routingCode: string = ""): FourState[] {
-  const track = trackingCode.replace(/\s/g, "");
-  const route = routingCode.replace(/[\s-]/g, "");
+  const track = trackingCode.replace(/\s/g, "")
+  const route = routingCode.replace(/[\s-]/g, "")
 
   if (!/^\d{20}$/.test(track)) {
-    throw new InvalidInputError("IMb tracking code must be exactly 20 digits");
+    throw new InvalidInputError("IMb tracking code must be exactly 20 digits")
   }
   if (route.length !== 0 && route.length !== 5 && route.length !== 9 && route.length !== 11) {
-    throw new InvalidInputError("IMb routing code must be 0, 5, 9, or 11 digits");
+    throw new InvalidInputError("IMb routing code must be 0, 5, 9, or 11 digits")
   }
   if (route.length > 0 && !/^\d+$/.test(route)) {
-    throw new InvalidInputError("IMb routing code must contain only digits");
+    throw new InvalidInputError("IMb routing code must contain only digits")
   }
 
   // Step 1: Convert routing code + tracking code to binary value
-  let binary = convertRoutingCode(route);
-  binary = convertTrackingCode(binary, track);
+  let binary = convertRoutingCode(route)
+  binary = convertTrackingCode(binary, track)
 
   // Step 2: CRC-11 Frame Check Sequence
-  const fcs = crc11(binary);
+  const fcs = crc11(binary)
 
   // Step 3: Convert to 10 codewords
-  const codewords = binaryToCodewords(binary);
+  const codewords = binaryToCodewords(binary)
 
   // Step 4: Integrate FCS into codewords
   // Double cw[9] for orientation detection
-  codewords[9]! *= 2;
+  codewords[9]! *= 2
   // If FCS bit 10 is set, add 659 to cw[0]
   if (fcs & (1 << 10)) {
-    codewords[0]! += 659;
+    codewords[0]! += 659
   }
 
   // Step 5: Convert codewords to 13-bit characters using lookup tables
-  const characters: number[] = Array.from({ length: 10 });
+  const characters: number[] = Array.from({ length: 10 })
   for (let i = 0; i < 10; i++) {
-    const cw = codewords[i]!;
+    const cw = codewords[i]!
     if (cw <= 1286) {
-      characters[i] = TABLE_5_OF_13[cw]!;
+      characters[i] = TABLE_5_OF_13[cw]!
     } else {
-      characters[i] = TABLE_2_OF_13[cw - 1287]!;
+      characters[i] = TABLE_2_OF_13[cw - 1287]!
     }
   }
 
   // Step 6: Apply FCS bits to flip characters (XOR with 0x1FFF)
   for (let i = 0; i < 10; i++) {
     if (fcs & (1 << i)) {
-      characters[i]! ^= 0x1fff;
+      characters[i]! ^= 0x1fff
     }
   }
 
   // Step 7: Map characters to 65 bars using bar construction table
-  const bars: FourState[] = Array.from({ length: 65 });
+  const bars: FourState[] = Array.from({ length: 65 })
   for (let i = 0; i < 65; i++) {
-    const [descChar, descBit, ascChar, ascBit] = BAR_TABLE[i]!;
-    const ascend = (characters[ascChar]! & (1 << ascBit)) !== 0;
-    const descend = (characters[descChar]! & (1 << descBit)) !== 0;
+    const [descChar, descBit, ascChar, ascBit] = BAR_TABLE[i]!
+    const ascend = (characters[ascChar]! & (1 << ascBit)) !== 0
+    const descend = (characters[descChar]! & (1 << descBit)) !== 0
 
     if (ascend && descend) {
-      bars[i] = "F";
+      bars[i] = "F"
     } else if (ascend) {
-      bars[i] = "A";
+      bars[i] = "A"
     } else if (descend) {
-      bars[i] = "D";
+      bars[i] = "D"
     } else {
-      bars[i] = "T";
+      bars[i] = "T"
     }
   }
 
-  return bars;
+  return bars
 }
 
 /** Convert routing code to initial binary value per USPS-B-3200 */
 function convertRoutingCode(route: string): bigint {
-  if (route.length === 0) return 0n;
-  if (route.length === 5) return BigInt(route) + 1n;
-  if (route.length === 9) return BigInt(route) + 100001n;
+  if (route.length === 0) return 0n
+  if (route.length === 5) return BigInt(route) + 1n
+  if (route.length === 9) return BigInt(route) + 100001n
   // route.length === 11
-  return BigInt(route) + 1000100001n;
+  return BigInt(route) + 1000100001n
 }
 
 /** Encode tracking code into binary value digit by digit per USPS-B-3200 */
 function convertTrackingCode(binary: bigint, track: string): bigint {
-  binary = binary * 10n + BigInt(track[0]!);
-  binary = binary * 5n + BigInt(track[1]!);
+  binary = binary * 10n + BigInt(track[0]!)
+  binary = binary * 5n + BigInt(track[1]!)
   for (let i = 2; i < 20; i++) {
-    binary = binary * 10n + BigInt(track[i]!);
+    binary = binary * 10n + BigInt(track[i]!)
   }
-  return binary;
+  return binary
 }
 
 /**
@@ -241,60 +241,60 @@ function convertTrackingCode(binary: bigint, track: string): bigint {
  */
 function crc11(value: bigint): number {
   // Convert to 13 bytes (big-endian)
-  const bytes: number[] = Array.from({ length: 13 });
-  let v = value;
+  const bytes: number[] = Array.from({ length: 13 })
+  let v = value
   for (let i = 12; i >= 0; i--) {
-    bytes[i] = Number(v & 0xffn);
-    v >>= 8n;
+    bytes[i] = Number(v & 0xffn)
+    v >>= 8n
   }
 
-  const genPoly = 0x0f35;
-  let fcs = 0x07ff; // initial value: all 11 bits set
+  const genPoly = 0x0f35
+  let fcs = 0x07ff // initial value: all 11 bits set
 
   // Process first byte: skip the 2 most significant bits (only 6 bits used)
-  let data = bytes[0]! << 5;
+  let data = bytes[0]! << 5
   for (let bit = 2; bit < 8; bit++) {
     if ((fcs ^ data) & 0x400) {
-      fcs = (fcs << 1) ^ genPoly;
+      fcs = (fcs << 1) ^ genPoly
     } else {
-      fcs = fcs << 1;
+      fcs = fcs << 1
     }
-    fcs &= 0x7ff;
-    data <<= 1;
+    fcs &= 0x7ff
+    data <<= 1
   }
 
   // Process remaining 12 bytes (all 8 bits each)
   for (let byteIdx = 1; byteIdx < 13; byteIdx++) {
-    data = bytes[byteIdx]! << 3;
+    data = bytes[byteIdx]! << 3
     for (let bit = 0; bit < 8; bit++) {
       if ((fcs ^ data) & 0x400) {
-        fcs = (fcs << 1) ^ genPoly;
+        fcs = (fcs << 1) ^ genPoly
       } else {
-        fcs = fcs << 1;
+        fcs = fcs << 1
       }
-      fcs &= 0x7ff;
-      data <<= 1;
+      fcs &= 0x7ff
+      data <<= 1
     }
   }
 
-  return fcs;
+  return fcs
 }
 
 /** Convert binary value to 10 codewords per USPS-B-3200 */
 function binaryToCodewords(value: bigint): number[] {
-  const codewords: number[] = Array.from({ length: 10 });
-  let remaining = value;
+  const codewords: number[] = Array.from({ length: 10 })
+  let remaining = value
 
   // Extract from LSB: cw[9] is base 636, cw[8..1] are base 1365, cw[0] is remainder
-  codewords[9] = Number(remaining % 636n);
-  remaining = remaining / 636n;
+  codewords[9] = Number(remaining % 636n)
+  remaining = remaining / 636n
 
   for (let i = 8; i >= 1; i--) {
-    codewords[i] = Number(remaining % 1365n);
-    remaining = remaining / 1365n;
+    codewords[i] = Number(remaining % 1365n)
+    remaining = remaining / 1365n
   }
 
-  codewords[0] = Number(remaining);
+  codewords[0] = Number(remaining)
 
-  return codewords;
+  return codewords
 }

--- a/src/encoders/isbt128.ts
+++ b/src/encoders/isbt128.ts
@@ -6,12 +6,12 @@
  * for donation identification, blood components, expiry dates, etc.
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 /**
  * ISO/IEC 7064 Mod 37-2 check character set: 0-9 (values 0-9), A-Z (values 10-35), * (value 36)
  */
-const MOD37_CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*";
+const MOD37_CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*"
 
 /**
  * Compute ISO/IEC 7064 Modulo 37-2 check character
@@ -26,18 +26,18 @@ const MOD37_CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*";
  * @returns Single check character
  */
 export function iso7064Mod37_2(data: string): string {
-  let sum = 0;
+  let sum = 0
   for (let i = 0; i < data.length; i++) {
-    const idx = MOD37_CHARSET.indexOf(data[i]);
+    const idx = MOD37_CHARSET.indexOf(data[i])
     if (idx === -1) {
       throw new InvalidInputError(
         `Invalid character '${data[i]}' for ISO 7064 Mod 37-2 check character computation`,
-      );
+      )
     }
-    sum = ((sum + idx) * 2) % 37;
+    sum = ((sum + idx) * 2) % 37
   }
-  const check = (37 - sum) % 37;
-  return MOD37_CHARSET[check];
+  const check = (37 - sum) % 37
+  return MOD37_CHARSET[check]
 }
 
 /**
@@ -62,27 +62,27 @@ export function encodeISBT128DIN(
   donationNumber: string,
 ): string {
   if (!/^[A-Z]{2}$/.test(countryCode)) {
-    throw new InvalidInputError("ISBT 128 country code must be 2 uppercase letters");
+    throw new InvalidInputError("ISBT 128 country code must be 2 uppercase letters")
   }
   if (facilityNumber.length > 5) {
-    throw new InvalidInputError("ISBT 128 facility number must be max 5 characters");
+    throw new InvalidInputError("ISBT 128 facility number must be max 5 characters")
   }
   if (!/^\d{2}$/.test(year)) {
-    throw new InvalidInputError("ISBT 128 year must be exactly 2 digits");
+    throw new InvalidInputError("ISBT 128 year must be exactly 2 digits")
   }
   if (
     donationNumber.length < 1 ||
     donationNumber.length > 6 ||
     !/^[A-Z0-9]+$/.test(donationNumber)
   ) {
-    throw new InvalidInputError("ISBT 128 donation number must be 1-6 alphanumeric characters");
+    throw new InvalidInputError("ISBT 128 donation number must be 1-6 alphanumeric characters")
   }
 
-  const facility = facilityNumber.padStart(5, "0");
-  const donation = donationNumber.padStart(6, "0");
-  const din = `${countryCode}${facility}${year}${donation}`;
-  const check = iso7064Mod37_2(din);
-  return `=${din}${check}`;
+  const facility = facilityNumber.padStart(5, "0")
+  const donation = donationNumber.padStart(6, "0")
+  const din = `${countryCode}${facility}${year}${donation}`
+  const check = iso7064Mod37_2(din)
+  return `=${din}${check}`
 }
 
 /**
@@ -94,9 +94,9 @@ export function encodeISBT128DIN(
  */
 export function encodeISBT128Component(productCode: string): string {
   if (productCode.length !== 5) {
-    throw new InvalidInputError("ISBT 128 product code must be exactly 5 characters");
+    throw new InvalidInputError("ISBT 128 product code must be exactly 5 characters")
   }
-  return `=${productCode}`;
+  return `=${productCode}`
 }
 
 /**
@@ -108,9 +108,9 @@ export function encodeISBT128Component(productCode: string): string {
  */
 export function encodeISBT128Expiry(date: string): string {
   if (!/^\d{6}$/.test(date)) {
-    throw new InvalidInputError("ISBT 128 expiry date must be 6 digits (YYMMDD)");
+    throw new InvalidInputError("ISBT 128 expiry date must be 6 digits (YYMMDD)")
   }
-  return `&${date}`;
+  return `&${date}`
 }
 
 /**
@@ -122,7 +122,7 @@ export function encodeISBT128Expiry(date: string): string {
  */
 export function encodeISBT128BloodGroup(bloodGroup: string): string {
   if (bloodGroup.length < 1 || bloodGroup.length > 5) {
-    throw new InvalidInputError("ISBT 128 blood group code must be 1-5 characters");
+    throw new InvalidInputError("ISBT 128 blood group code must be 1-5 characters")
   }
-  return `%${bloodGroup}`;
+  return `%${bloodGroup}`
 }

--- a/src/encoders/itf.ts
+++ b/src/encoders/itf.ts
@@ -2,7 +2,7 @@
  * Interleaved 2 of 5 (ITF) and ITF-14 barcode encoder
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Digit patterns: 5 elements each (N=1 narrow, W=3 wide)
 const DIGIT_PATTERNS: number[][] = [
@@ -16,17 +16,17 @@ const DIGIT_PATTERNS: number[][] = [
   [1, 1, 1, 3, 3], // 7: N N N W W
   [3, 1, 1, 3, 1], // 8: W N N W N
   [1, 3, 1, 3, 1], // 9: N W N W N
-];
+]
 
-const START_PATTERN = [1, 1, 1, 1]; // narrow bar, narrow space, narrow bar, narrow space
-const STOP_PATTERN = [3, 1, 1]; // wide bar, narrow space, narrow bar
+const START_PATTERN = [1, 1, 1, 1] // narrow bar, narrow space, narrow bar, narrow space
+const STOP_PATTERN = [3, 1, 1] // wide bar, narrow space, narrow bar
 
 /**
  * Validate that a string contains only digits
  */
 function validateDigitsOnly(text: string): void {
   if (!/^\d+$/.test(text)) {
-    throw new InvalidInputError("ITF barcode requires digits only (0-9)");
+    throw new InvalidInputError("ITF barcode requires digits only (0-9)")
   }
 }
 
@@ -34,13 +34,13 @@ function validateDigitsOnly(text: string): void {
  * Calculate ITF-14 / EAN modulo 10 check digit
  */
 function calculateCheckDigit(digits: number[]): number {
-  let sum = 0;
+  let sum = 0
   for (let i = 0; i < digits.length; i++) {
     // ITF-14 uses the same weighting as EAN: alternating 3 and 1 from the right
     // For a 13-digit input, position 0 gets weight 3, position 1 gets weight 1, etc.
-    sum += digits[i]! * (i % 2 === 0 ? 3 : 1);
+    sum += digits[i]! * (i % 2 === 0 ? 3 : 1)
   }
-  return (10 - (sum % 10)) % 10;
+  return (10 - (sum % 10)) % 10
 }
 
 /**
@@ -49,16 +49,16 @@ function calculateCheckDigit(digits: number[]): number {
  * Returns 10 elements: bar, space, bar, space, bar, space, bar, space, bar, space
  */
 function encodePair(d1: number, d2: number): number[] {
-  const pattern1 = DIGIT_PATTERNS[d1]!;
-  const pattern2 = DIGIT_PATTERNS[d2]!;
-  const result: number[] = [];
+  const pattern1 = DIGIT_PATTERNS[d1]!
+  const pattern2 = DIGIT_PATTERNS[d2]!
+  const result: number[] = []
 
   for (let i = 0; i < 5; i++) {
-    result.push(pattern1[i]!); // bar width from first digit
-    result.push(pattern2[i]!); // space width from second digit
+    result.push(pattern1[i]!) // bar width from first digit
+    result.push(pattern2[i]!) // space width from second digit
   }
 
-  return result;
+  return result
 }
 
 /**
@@ -68,37 +68,37 @@ function encodePair(d1: number, d2: number): number[] {
  * Returns: array of bar widths (alternating bar/space)
  */
 export function encodeITF(text: string): number[] {
-  validateDigitsOnly(text);
+  validateDigitsOnly(text)
 
   // Prepend 0 if odd number of digits
-  let digits = text;
+  let digits = text
   if (digits.length % 2 !== 0) {
-    digits = "0" + digits;
+    digits = "0" + digits
   }
 
-  const bars: number[] = [];
+  const bars: number[] = []
 
   // Start pattern
   for (const w of START_PATTERN) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Encode digit pairs
   for (let i = 0; i < digits.length; i += 2) {
-    const d1 = digits.charCodeAt(i) - 48;
-    const d2 = digits.charCodeAt(i + 1) - 48;
-    const pair = encodePair(d1, d2);
+    const d1 = digits.charCodeAt(i) - 48
+    const d2 = digits.charCodeAt(i + 1) - 48
+    const pair = encodePair(d1, d2)
     for (const w of pair) {
-      bars.push(w);
+      bars.push(w)
     }
   }
 
   // Stop pattern
   for (const w of STOP_PATTERN) {
-    bars.push(w);
+    bars.push(w)
   }
 
-  return bars;
+  return bars
 }
 
 /**
@@ -108,29 +108,29 @@ export function encodeITF(text: string): number[] {
  * Returns: array of bar widths (alternating bar/space)
  */
 export function encodeITF14(text: string): number[] {
-  validateDigitsOnly(text);
+  validateDigitsOnly(text)
 
-  let digits: string;
+  let digits: string
 
   if (text.length === 13) {
     // Auto-calculate check digit
-    const nums = text.split("").map(Number);
-    const check = calculateCheckDigit(nums);
-    digits = text + String(check);
+    const nums = text.split("").map(Number)
+    const check = calculateCheckDigit(nums)
+    digits = text + String(check)
   } else if (text.length === 14) {
-    const nums = text.slice(0, 13).split("").map(Number);
-    const expected = calculateCheckDigit(nums);
-    const provided = Number(text[13]);
+    const nums = text.slice(0, 13).split("").map(Number)
+    const expected = calculateCheckDigit(nums)
+    const provided = Number(text[13])
     if (provided !== expected) {
       throw new InvalidInputError(
         `ITF-14 check digit mismatch: expected ${expected}, got ${provided}`,
-      );
+      )
     }
-    digits = text;
+    digits = text
   } else {
-    throw new InvalidInputError("ITF-14 requires 13 or 14 digits");
+    throw new InvalidInputError("ITF-14 requires 13 or 14 digits")
   }
 
   // Encode using standard ITF (14 digits is already even)
-  return encodeITF(digits);
+  return encodeITF(digits)
 }

--- a/src/encoders/jabcode.ts
+++ b/src/encoders/jabcode.ts
@@ -12,10 +12,10 @@
  * Each cell has a color index (0-3 for 4-color, 0-7 for 8-color).
  */
 
-import { InvalidInputError, CapacityError } from "../errors";
+import { InvalidInputError, CapacityError } from "../errors"
 
 /** JAB Code color palette — 4-color default */
-export const JAB_COLORS_4 = ["#000000", "#FF0000", "#00FF00", "#0000FF"] as const;
+export const JAB_COLORS_4 = ["#000000", "#FF0000", "#00FF00", "#0000FF"] as const
 /** 8-color palette */
 export const JAB_COLORS_8 = [
   "#000000",
@@ -26,24 +26,24 @@ export const JAB_COLORS_8 = [
   "#FF00FF",
   "#00FFFF",
   "#FFFFFF",
-] as const;
+] as const
 
 export interface JABCodeOptions {
   /** Number of colors: 4 or 8 (default 4) */
-  colors?: 4 | 8;
+  colors?: 4 | 8
   /** EC percentage (default 20) */
-  ecPercent?: number;
+  ecPercent?: number
 }
 
 export interface JABCodeResult {
   /** 2D matrix of color indices (0 to colors-1) */
-  matrix: number[][];
+  matrix: number[][]
   /** Number of rows */
-  rows: number;
+  rows: number
   /** Number of columns */
-  cols: number;
+  cols: number
   /** Color palette */
-  palette: readonly string[];
+  palette: readonly string[]
 }
 
 // ---------------------------------------------------------------------------
@@ -55,13 +55,13 @@ export interface JABCodeResult {
  * Returns values in [0, 2^32).
  */
 function xorshift32(state: number): [number, number] {
-  let s = state | 0;
-  s ^= s << 13;
-  s ^= s >>> 17;
-  s ^= s << 5;
+  let s = state | 0
+  s ^= s << 13
+  s ^= s >>> 17
+  s ^= s << 5
   // Ensure unsigned 32-bit
-  s = s >>> 0;
-  return [s, s];
+  s = s >>> 0
+  return [s, s]
 }
 
 /**
@@ -80,39 +80,39 @@ function xorshift32(state: number): [number, number] {
  * @returns Array of parity bits (0 or 1)
  */
 function computeLDPCParityBits(dataBits: number[], numParityBits: number): number[] {
-  const n = dataBits.length;
-  if (n === 0) return [];
+  const n = dataBits.length
+  if (n === 0) return []
 
   // Each parity bit checks a subset of data bits.
   // Use ~sqrt(n) checks per parity for good sparsity, minimum 3.
-  const checksPerParity = Math.max(3, Math.min(n, Math.ceil(Math.sqrt(n))));
+  const checksPerParity = Math.max(3, Math.min(n, Math.ceil(Math.sqrt(n))))
 
-  const parityBits: number[] = [];
+  const parityBits: number[] = []
 
   for (let p = 0; p < numParityBits; p++) {
     // Seed the PRNG with a value derived from the parity bit index
     // Use a large prime multiplier for good distribution
-    let prngState = ((p + 1) * 2654435761) >>> 0;
+    let prngState = ((p + 1) * 2654435761) >>> 0
 
     // Select `checksPerParity` distinct data bit indices
-    const indices = new Set<number>();
-    let iterations = 0;
+    const indices = new Set<number>()
+    let iterations = 0
     while (indices.size < checksPerParity && iterations < checksPerParity * 10) {
-      const [nextState, val] = xorshift32(prngState);
-      prngState = nextState;
-      indices.add(val % n);
-      iterations++;
+      const [nextState, val] = xorshift32(prngState)
+      prngState = nextState
+      indices.add(val % n)
+      iterations++
     }
 
     // Compute parity as XOR of selected data bits
-    let parity = 0;
+    let parity = 0
     for (const idx of indices) {
-      parity ^= dataBits[idx]!;
+      parity ^= dataBits[idx]!
     }
-    parityBits.push(parity);
+    parityBits.push(parity)
   }
 
-  return parityBits;
+  return parityBits
 }
 
 // ---------------------------------------------------------------------------
@@ -130,24 +130,24 @@ function computeLDPCParityBits(dataBits: number[], numParityBits: number): numbe
  *  - Bits 6-15: data byte length (0-1023)
  */
 function encodeMetadata(numColors: number, ecPercent: number, dataLength: number): number[] {
-  const bits: number[] = [];
+  const bits: number[] = []
 
   // Bit 0: palette flag
-  bits.push(numColors === 8 ? 1 : 0);
+  bits.push(numColors === 8 ? 1 : 0)
 
   // Bits 1-5: EC percent (quantized to 5 bits)
-  const ecQuantized = Math.min(31, Math.floor(ecPercent / 4));
+  const ecQuantized = Math.min(31, Math.floor(ecPercent / 4))
   for (let i = 4; i >= 0; i--) {
-    bits.push((ecQuantized >> i) & 1);
+    bits.push((ecQuantized >> i) & 1)
   }
 
   // Bits 6-15: data byte length (10 bits, max 1023)
-  const len = Math.min(1023, dataLength);
+  const len = Math.min(1023, dataLength)
   for (let i = 9; i >= 0; i--) {
-    bits.push((len >> i) & 1);
+    bits.push((len >> i) & 1)
   }
 
-  return bits;
+  return bits
 }
 
 // ---------------------------------------------------------------------------
@@ -171,51 +171,51 @@ function placeJABFinder(
   cornerIndex: number,
   numColors: number,
 ): void {
-  const maxR = matrix.length;
-  const maxC = matrix[0]!.length;
+  const maxR = matrix.length
+  const maxC = matrix[0]!.length
 
   // Inner color varies by corner for orientation detection
   // Corner 0 (TL)=0, 1 (TR)=1, 2 (BL)=2, 3 (BR)=3
-  const innerColor = cornerIndex % numColors;
+  const innerColor = cornerIndex % numColors
 
   // Middle ring color
-  const midColor = 1 % numColors;
+  const midColor = 1 % numColors
 
   for (let r = 0; r < 7; r++) {
     for (let c = 0; c < 7; c++) {
-      const rr = row + r;
-      const cc = col + c;
-      if (rr >= maxR || cc >= maxC) continue;
+      const rr = row + r
+      const cc = col + c
+      if (rr >= maxR || cc >= maxC) continue
 
       // Determine which ring this cell belongs to
-      const isOuterEdge = r === 0 || r === 6 || c === 0 || c === 6;
-      const isInner = r >= 2 && r <= 4 && c >= 2 && c <= 4;
+      const isOuterEdge = r === 0 || r === 6 || c === 0 || c === 6
+      const isInner = r >= 2 && r <= 4 && c >= 2 && c <= 4
 
       if (isInner) {
         // Inner 3x3 block — corner-specific color
-        matrix[rr]![cc] = innerColor;
+        matrix[rr]![cc] = innerColor
       } else if (isOuterEdge) {
         // Outer ring — alternating colors 0 and 2
-        const alt = (r + c) % 2;
-        matrix[rr]![cc] = alt === 0 ? 0 : 2 % numColors;
+        const alt = (r + c) % 2
+        matrix[rr]![cc] = alt === 0 ? 0 : 2 % numColors
       } else {
         // Middle ring
-        matrix[rr]![cc] = midColor;
+        matrix[rr]![cc] = midColor
       }
     }
   }
 
   // Separator (color 0) — one cell border around the finder
   for (let i = -1; i <= 7; i++) {
-    const rr = row + 7;
-    const cc = col + i;
+    const rr = row + 7
+    const cc = col + i
     if (rr >= 0 && rr < maxR && cc >= 0 && cc < maxC) {
-      matrix[rr]![cc] = 0;
+      matrix[rr]![cc] = 0
     }
-    const rr2 = row + i;
-    const cc2 = col + 7;
+    const rr2 = row + i
+    const cc2 = col + 7
     if (rr2 >= 0 && rr2 < maxR && cc2 >= 0 && cc2 < maxC) {
-      matrix[rr2]![cc2] = 0;
+      matrix[rr2]![cc2] = 0
     }
   }
 }
@@ -230,81 +230,81 @@ function placeJABFinder(
  */
 export function encodeJABCode(text: string, options: JABCodeOptions = {}): JABCodeResult {
   if (text.length === 0) {
-    throw new InvalidInputError("JAB Code input must not be empty");
+    throw new InvalidInputError("JAB Code input must not be empty")
   }
 
-  const numColors = options.colors ?? 4;
-  const ecPercent = options.ecPercent ?? 20;
-  const bitsPerCell = numColors === 8 ? 3 : 2; // 4 colors = 2 bits, 8 colors = 3 bits
-  const palette = numColors === 8 ? JAB_COLORS_8 : JAB_COLORS_4;
+  const numColors = options.colors ?? 4
+  const ecPercent = options.ecPercent ?? 20
+  const bitsPerCell = numColors === 8 ? 3 : 2 // 4 colors = 2 bits, 8 colors = 3 bits
+  const palette = numColors === 8 ? JAB_COLORS_8 : JAB_COLORS_4
 
   // Encode data as bytes
-  const data = new TextEncoder().encode(text);
-  const dataBits: number[] = [];
+  const data = new TextEncoder().encode(text)
+  const dataBits: number[] = []
   for (const byte of data) {
     for (let i = 7; i >= 0; i--) {
-      dataBits.push((byte >> i) & 1);
+      dataBits.push((byte >> i) & 1)
     }
   }
 
   // Encode metadata
-  const metaBits = encodeMetadata(numColors, ecPercent, data.length);
+  const metaBits = encodeMetadata(numColors, ecPercent, data.length)
 
   // Compute LDPC-like parity bits over the combined metadata + data
-  const payloadBits = [...metaBits, ...dataBits];
-  const numParityBits = Math.ceil((payloadBits.length * ecPercent) / 100);
-  const parityBits = computeLDPCParityBits(payloadBits, numParityBits);
+  const payloadBits = [...metaBits, ...dataBits]
+  const numParityBits = Math.ceil((payloadBits.length * ecPercent) / 100)
+  const parityBits = computeLDPCParityBits(payloadBits, numParityBits)
 
   // Final bitstream: metadata + data + parity
-  const allBits = [...payloadBits, ...parityBits];
+  const allBits = [...payloadBits, ...parityBits]
 
   // Calculate symbol size
-  const totalCells = Math.ceil(allBits.length / bitsPerCell);
-  const finderCells = 7 * 7 * 4; // 4 finder patterns (approximate)
-  const neededCells = totalCells + finderCells;
-  let side = Math.max(21, Math.ceil(Math.sqrt(neededCells)));
-  if (side % 2 === 0) side++; // odd for symmetry
+  const totalCells = Math.ceil(allBits.length / bitsPerCell)
+  const finderCells = 7 * 7 * 4 // 4 finder patterns (approximate)
+  const neededCells = totalCells + finderCells
+  let side = Math.max(21, Math.ceil(Math.sqrt(neededCells)))
+  if (side % 2 === 0) side++ // odd for symmetry
 
   if (side > 85) {
-    throw new CapacityError("Data too long for JAB Code");
+    throw new CapacityError("Data too long for JAB Code")
   }
 
   // Build color matrix
   const matrix: number[][] = Array.from({ length: side }, () =>
     Array.from({ length: side }, () => 0),
-  );
+  )
 
   // Place finder patterns (4 corners) with corner-specific colors
-  placeJABFinder(matrix, 0, 0, 0, numColors);
-  placeJABFinder(matrix, 0, side - 7, 1, numColors);
-  placeJABFinder(matrix, side - 7, 0, 2, numColors);
-  placeJABFinder(matrix, side - 7, side - 7, 3, numColors);
+  placeJABFinder(matrix, 0, 0, 0, numColors)
+  placeJABFinder(matrix, 0, side - 7, 1, numColors)
+  placeJABFinder(matrix, side - 7, 0, 2, numColors)
+  placeJABFinder(matrix, side - 7, side - 7, 3, numColors)
 
   // Mark finder area (including separator)
   const isFinderArea = (r: number, c: number) => {
-    if (r < 8 && c < 8) return true;
-    if (r < 8 && c >= side - 8) return true;
-    if (r >= side - 8 && c < 8) return true;
-    if (r >= side - 8 && c >= side - 8) return true;
-    return false;
-  };
+    if (r < 8 && c < 8) return true
+    if (r < 8 && c >= side - 8) return true
+    if (r >= side - 8 && c < 8) return true
+    if (r >= side - 8 && c >= side - 8) return true
+    return false
+  }
 
   // Place data
-  let bitIdx = 0;
+  let bitIdx = 0
   for (let r = 0; r < side; r++) {
     for (let c = 0; c < side; c++) {
-      if (isFinderArea(r, c)) continue;
+      if (isFinderArea(r, c)) continue
 
-      let colorValue = 0;
+      let colorValue = 0
       for (let b = 0; b < bitsPerCell; b++) {
         if (bitIdx < allBits.length) {
-          colorValue = (colorValue << 1) | allBits[bitIdx]!;
-          bitIdx++;
+          colorValue = (colorValue << 1) | allBits[bitIdx]!
+          bitIdx++
         }
       }
-      matrix[r]![c] = colorValue % numColors;
+      matrix[r]![c] = colorValue % numColors
     }
   }
 
-  return { matrix, rows: side, cols: side, palette };
+  return { matrix, rows: side, cols: side, palette }
 }

--- a/src/encoders/maxicode.ts
+++ b/src/encoders/maxicode.ts
@@ -9,39 +9,39 @@
  * - Reed-Solomon error correction over GF(64)
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
-const ROWS = 33;
-const COLS = 30;
+const ROWS = 33
+const COLS = 30
 
 // ---------------------------------------------------------------------------
 // GF(64) arithmetic — primitive polynomial x^6 + x + 1 (0x43)
 // ---------------------------------------------------------------------------
 
-const GF64_SIZE = 64;
-const GF64_MAX = 63; // order of the multiplicative group
+const GF64_SIZE = 64
+const GF64_MAX = 63 // order of the multiplicative group
 
-const GF64_EXP = new Uint8Array(128);
-const GF64_LOG = new Uint8Array(64);
+const GF64_EXP = new Uint8Array(128)
+const GF64_LOG = new Uint8Array(64)
 
-(function initGF64() {
-  let x = 1;
+;(function initGF64() {
+  let x = 1
   for (let i = 0; i < GF64_MAX; i++) {
-    GF64_EXP[i] = x;
-    GF64_LOG[x] = i;
-    x = x << 1;
-    if (x >= GF64_SIZE) x ^= 0x43; // x^6 + x + 1
+    GF64_EXP[i] = x
+    GF64_LOG[x] = i
+    x = x << 1
+    if (x >= GF64_SIZE) x ^= 0x43 // x^6 + x + 1
   }
   // Extend exp table for modular arithmetic convenience
   for (let i = GF64_MAX; i < 128; i++) {
-    GF64_EXP[i] = GF64_EXP[i - GF64_MAX]!;
+    GF64_EXP[i] = GF64_EXP[i - GF64_MAX]!
   }
-})();
+})()
 
 /** Multiply two GF(64) elements using log/antilog tables */
 function gf64Mul(a: number, b: number): number {
-  if (a === 0 || b === 0) return 0;
-  return GF64_EXP[(GF64_LOG[a]! + GF64_LOG[b]!) % GF64_MAX]!;
+  if (a === 0 || b === 0) return 0
+  return GF64_EXP[(GF64_LOG[a]! + GF64_LOG[b]!) % GF64_MAX]!
 }
 
 /**
@@ -51,33 +51,33 @@ function gf64Mul(a: number, b: number): number {
  */
 function maxicodeRS(data: number[], ecCount: number): number[] {
   // Build generator polynomial g(x) = (x - a^1)(x - a^2)...(x - a^ecCount)
-  const gen = Array.from<number>({ length: ecCount + 1 }).fill(0);
-  gen[0] = 1;
+  const gen = Array.from<number>({ length: ecCount + 1 }).fill(0)
+  gen[0] = 1
 
   for (let i = 1; i <= ecCount; i++) {
-    gen[i] = gen[i - 1]!;
-    const ai = GF64_EXP[i]!;
+    gen[i] = gen[i - 1]!
+    const ai = GF64_EXP[i]!
     for (let j = i - 1; j >= 1; j--) {
-      gen[j] = gf64Mul(gen[j]!, ai) ^ gen[j - 1]!;
+      gen[j] = gf64Mul(gen[j]!, ai) ^ gen[j - 1]!
     }
-    gen[0] = gf64Mul(gen[0]!, ai);
+    gen[0] = gf64Mul(gen[0]!, ai)
   }
 
-  const coeffs = gen.slice(0, ecCount);
+  const coeffs = gen.slice(0, ecCount)
 
   // Polynomial long division (BWIPP order)
-  const ecb = Array.from<number>({ length: ecCount }).fill(0);
-  const rsnc1 = ecCount - 1;
+  const ecb = Array.from<number>({ length: ecCount }).fill(0)
+  const rsnc1 = ecCount - 1
 
   for (const cw of data) {
-    const t = (cw ^ ecb[0]!) & GF64_MAX;
+    const t = (cw ^ ecb[0]!) & GF64_MAX
     for (let j = rsnc1; j >= 1; j--) {
-      ecb[rsnc1 - j] = ecb[rsnc1 - j + 1]! ^ gf64Mul(t, coeffs[j]!);
+      ecb[rsnc1 - j] = ecb[rsnc1 - j + 1]! ^ gf64Mul(t, coeffs[j]!)
     }
-    ecb[rsnc1] = gf64Mul(t, coeffs[0]!);
+    ecb[rsnc1] = gf64Mul(t, coeffs[0]!)
   }
 
-  return ecb;
+  return ecb
 }
 
 // ---------------------------------------------------------------------------
@@ -122,45 +122,45 @@ const MAXICODE_SYMBOL_CHAR: number[] = [
 ];
 
 // Control codes
-const CTRL_LATCH_B = 63; // Latch to Set B (from Set A)
-const CTRL_LATCH_A = 58; // Latch to Set A (from Set B)
+const CTRL_LATCH_B = 63 // Latch to Set B (from Set A)
+const CTRL_LATCH_A = 58 // Latch to Set A (from Set B)
 
 /**
  * Encode text using MaxiCode character sets with automatic set switching.
  * Starts in Code Set A. Uses latch codes when needed.
  */
 function encodeMaxiCodeText(text: string): number[] {
-  const codewords: number[] = [];
-  let currentSet = 1; // Start in Code Set A
+  const codewords: number[] = []
+  let currentSet = 1 // Start in Code Set A
 
   for (let i = 0; i < text.length; i++) {
-    const code = text.charCodeAt(i);
-    if (code > 255) continue; // Skip non-latin
+    const code = text.charCodeAt(i)
+    if (code > 255) continue // Skip non-latin
 
-    const charSet = MAXICODE_SET[code]!;
-    const symbolVal = MAXICODE_SYMBOL_CHAR[code]!;
+    const charSet = MAXICODE_SET[code]!
+    const symbolVal = MAXICODE_SYMBOL_CHAR[code]!
 
     if (charSet === 0 || charSet === currentSet) {
       // Character is in current set or available in multiple sets
-      codewords.push(symbolVal);
+      codewords.push(symbolVal)
     } else if (charSet === 1 && currentSet === 2) {
       // Need to switch from B to A
-      codewords.push(CTRL_LATCH_A);
-      codewords.push(symbolVal);
-      currentSet = 1;
+      codewords.push(CTRL_LATCH_A)
+      codewords.push(symbolVal)
+      currentSet = 1
     } else if (charSet === 2 && currentSet === 1) {
       // Need to switch from A to B
-      codewords.push(CTRL_LATCH_B);
-      codewords.push(symbolVal);
-      currentSet = 2;
+      codewords.push(CTRL_LATCH_B)
+      codewords.push(symbolVal)
+      currentSet = 2
     } else {
       // For sets C/D/E, use shift codes
       // Shift from set A: 59 = shift to set B for one char
       // For simplicity, encode unknown chars as space
-      codewords.push(32);
+      codewords.push(32)
     }
   }
-  return codewords;
+  return codewords
 }
 
 // ---------------------------------------------------------------------------
@@ -176,38 +176,38 @@ function buildPrimary(
   serviceClass: number,
   mode: 2 | 3,
 ): number[] {
-  const primary: number[] = [];
+  const primary: number[] = []
 
   // CW0: mode indicator
-  primary.push(mode);
+  primary.push(mode)
 
   if (mode === 2) {
     // Numeric postal code: 9 digits packed as a 30-bit integer
-    const postal = postalCode.replace(/\D/g, "").padEnd(9, "0").substring(0, 9);
-    const postalNum = Number.parseInt(postal, 10);
+    const postal = postalCode.replace(/\D/g, "").padEnd(9, "0").substring(0, 9)
+    const postalNum = Number.parseInt(postal, 10)
     // 30 bits -> 5 codewords of 6 bits each (MSB first)
-    primary.push((postalNum >> 24) & 0x3f);
-    primary.push((postalNum >> 18) & 0x3f);
-    primary.push((postalNum >> 12) & 0x3f);
-    primary.push((postalNum >> 6) & 0x3f);
-    primary.push(postalNum & 0x3f);
+    primary.push((postalNum >> 24) & 0x3f)
+    primary.push((postalNum >> 18) & 0x3f)
+    primary.push((postalNum >> 12) & 0x3f)
+    primary.push((postalNum >> 6) & 0x3f)
+    primary.push(postalNum & 0x3f)
   } else {
     // International alphanumeric postal code: 6 characters
-    const postal = postalCode.padEnd(6, " ").substring(0, 6);
+    const postal = postalCode.padEnd(6, " ").substring(0, 6)
     for (const ch of postal) {
-      primary.push(ch.charCodeAt(0) & 0x3f);
+      primary.push(ch.charCodeAt(0) & 0x3f)
     }
   }
 
   // Country code (3-digit ISO, max 999 -> 10 bits -> 2 codewords)
-  primary.push((countryCode >> 6) & 0x3f);
-  primary.push(countryCode & 0x3f);
+  primary.push((countryCode >> 6) & 0x3f)
+  primary.push(countryCode & 0x3f)
 
   // Service class (3 digits -> 10 bits -> 2 codewords)
-  primary.push((serviceClass >> 6) & 0x3f);
-  primary.push(serviceClass & 0x3f);
+  primary.push((serviceClass >> 6) & 0x3f)
+  primary.push(serviceClass & 0x3f)
 
-  return primary;
+  return primary
 }
 
 // ---------------------------------------------------------------------------
@@ -285,13 +285,13 @@ const BULLSEYE_DARK: number[] = [
 
 export interface MaxiCodeOptions {
   /** Encoding mode: 2 (US structured), 3 (intl structured), 4 (standard), 5 (full ECC), 6 (reader programming) */
-  mode?: 2 | 3 | 4 | 5 | 6;
+  mode?: 2 | 3 | 4 | 5 | 6
   /** Postal code (modes 2/3) */
-  postalCode?: string;
+  postalCode?: string
   /** ISO country code number (modes 2/3) */
-  countryCode?: number;
+  countryCode?: number
   /** Service class (modes 2/3, e.g. 840 for UPS) */
-  serviceClass?: number;
+  serviceClass?: number
 }
 
 /**
@@ -300,12 +300,12 @@ export interface MaxiCodeOptions {
  */
 export function encodeMaxiCode(text: string, options: MaxiCodeOptions = {}): boolean[][] {
   if (text.length === 0) {
-    throw new InvalidInputError("MaxiCode input must not be empty");
+    throw new InvalidInputError("MaxiCode input must not be empty")
   }
 
-  const mode = options.mode ?? 4;
-  let primaryData: number[];
-  let secondaryRaw: number[];
+  const mode = options.mode ?? 4
+  let primaryData: number[]
+  let secondaryRaw: number[]
 
   if (mode === 2 || mode === 3) {
     // Primary message: 10 codewords from structured header
@@ -314,78 +314,78 @@ export function encodeMaxiCode(text: string, options: MaxiCodeOptions = {}): boo
       options.countryCode ?? 840,
       options.serviceClass ?? 1,
       mode,
-    );
+    )
     // Secondary message: the text payload
-    secondaryRaw = encodeMaxiCodeText(text);
+    secondaryRaw = encodeMaxiCodeText(text)
   } else {
     // Modes 4/5/6: primary is mode + first 9 data chars,
     // secondary is the remainder
-    const allData = [mode, ...encodeMaxiCodeText(text)];
-    primaryData = allData.slice(0, 10);
-    secondaryRaw = allData.slice(10);
+    const allData = [mode, ...encodeMaxiCodeText(text)]
+    primaryData = allData.slice(0, 10)
+    secondaryRaw = allData.slice(10)
   }
 
   // Pad primary to exactly 10 codewords
   while (primaryData.length < 10) {
-    primaryData.push(33); // pad character (space in code set A)
+    primaryData.push(33) // pad character (space in code set A)
   }
-  primaryData = primaryData.slice(0, 10);
+  primaryData = primaryData.slice(0, 10)
 
   // Secondary message: pad to 84 codewords (modes 2/3/4/6) or 68 (mode 5)
-  const SECONDARY_TOTAL = mode === 5 ? 68 : 84;
+  const SECONDARY_TOTAL = mode === 5 ? 68 : 84
   while (secondaryRaw.length < SECONDARY_TOTAL) {
-    secondaryRaw.push(33); // pad character
+    secondaryRaw.push(33) // pad character
   }
-  secondaryRaw = secondaryRaw.slice(0, SECONDARY_TOTAL);
+  secondaryRaw = secondaryRaw.slice(0, SECONDARY_TOTAL)
 
   // Reed-Solomon error correction over GF(64)
   // Primary: 10 data codewords -> 10 EC codewords
-  const primaryEC = maxicodeRS(primaryData, 10);
+  const primaryEC = maxicodeRS(primaryData, 10)
 
   // Secondary: split into odd and even indexed codewords
-  const seco: number[] = [];
-  const sece: number[] = [];
+  const seco: number[] = []
+  const sece: number[] = []
   for (let i = 0; i < secondaryRaw.length; i++) {
     if (i % 2 === 0) {
-      seco.push(secondaryRaw[i]!);
+      seco.push(secondaryRaw[i]!)
     } else {
-      sece.push(secondaryRaw[i]!);
+      sece.push(secondaryRaw[i]!)
     }
   }
 
   // EC count per interleaved part
-  const secECCount = SECONDARY_TOTAL === 84 ? 20 : 28;
-  const secoEC = maxicodeRS(seco, secECCount);
-  const seceEC = maxicodeRS(sece, secECCount);
+  const secECCount = SECONDARY_TOTAL === 84 ? 20 : 28
+  const secoEC = maxicodeRS(seco, secECCount)
+  const seceEC = maxicodeRS(sece, secECCount)
 
   // Reassemble secondary EC by interleaving odd and even EC
-  const secChk: number[] = [];
+  const secChk: number[] = []
   for (let i = 0; i < secECCount; i++) {
-    secChk.push(secoEC[i]!);
-    secChk.push(seceEC[i]!);
+    secChk.push(secoEC[i]!)
+    secChk.push(seceEC[i]!)
   }
 
   // Assemble all codewords in transmission order:
   // Primary data (10) + Primary EC (10) + Secondary data (84/68) + Secondary EC (40/56)
   // Total: 144 codewords = 864 bits
-  const allCW = [...primaryData, ...primaryEC, ...secondaryRaw, ...secChk];
+  const allCW = [...primaryData, ...primaryEC, ...secondaryRaw, ...secChk]
 
   // Convert codewords to bit stream (6 bits per codeword, MSB first)
-  const bits: number[] = [];
+  const bits: number[] = []
   for (const cw of allCW) {
     for (let b = 5; b >= 0; b--) {
-      bits.push((cw >> b) & 1);
+      bits.push((cw >> b) & 1)
     }
   }
 
   // Build 33x30 matrix — initially all white
-  const pixs = new Uint8Array(ROWS * COLS); // 0 = white
+  const pixs = new Uint8Array(ROWS * COLS) // 0 = white
 
   // Place data modules using the MODMAP placement sequence
-  const maxBits = Math.min(bits.length, MODMAP.length);
+  const maxBits = Math.min(bits.length, MODMAP.length)
   for (let i = 0; i < maxBits; i++) {
     if (bits[i] === 1) {
-      pixs[MODMAP[i]!] = 1;
+      pixs[MODMAP[i]!] = 1
     }
   }
 
@@ -393,22 +393,22 @@ export function encodeMaxiCode(text: string, options: MaxiCodeOptions = {}): boo
   // This ensures data bits don't interfere with the finder pattern
   for (let r = 9; r <= 23; r++) {
     for (let c = 7; c <= 22; c++) {
-      pixs[r * COLS + c] = 0;
+      pixs[r * COLS + c] = 0
     }
   }
   // Also clear corner mark area
-  pixs[28] = 0;
-  pixs[29] = 0;
+  pixs[28] = 0
+  pixs[29] = 0
 
   // Place bullseye finder pattern dark modules
   for (const pos of BULLSEYE_DARK) {
-    pixs[pos] = 1;
+    pixs[pos] = 1
   }
 
   // Convert pixel array to boolean matrix
   const matrix: boolean[][] = Array.from({ length: ROWS }, (_, r) =>
     Array.from({ length: COLS }, (_, c) => pixs[r * COLS + c] === 1),
-  );
+  )
 
-  return matrix;
+  return matrix
 }

--- a/src/encoders/micropdf417.ts
+++ b/src/encoders/micropdf417.ts
@@ -9,8 +9,8 @@
  * - Smaller than standard PDF417 for short data
  */
 
-import { InvalidInputError, CapacityError } from "../errors";
-import { encodeData } from "./pdf417/encoder";
+import { InvalidInputError, CapacityError } from "../errors"
+import { encodeData } from "./pdf417/encoder"
 
 // ---------------------------------------------------------------------------
 // PDF417 cluster tables (17-bit bitmasks) — same as standard PDF417
@@ -205,33 +205,33 @@ const CLUSTER_2: number[] = [
   0x1c7ea,
 ];
 
-const CLUSTERS = [CLUSTER_0, CLUSTER_1, CLUSTER_2];
+const CLUSTERS = [CLUSTER_0, CLUSTER_1, CLUSTER_2]
 
 // ---------------------------------------------------------------------------
 // Convert 17-bit bitmask to bar/space widths
 // ---------------------------------------------------------------------------
 
 function bitmaskToWidths(bitmask: number): number[] {
-  const widths: number[] = [];
-  let current = (bitmask >>> 16) & 1;
-  let count = 1;
+  const widths: number[] = []
+  let current = (bitmask >>> 16) & 1
+  let count = 1
   for (let i = 15; i >= 0; i--) {
-    const bit = (bitmask >>> i) & 1;
+    const bit = (bitmask >>> i) & 1
     if (bit === current) {
-      count++;
+      count++
     } else {
-      widths.push(count);
-      current = bit;
-      count = 1;
+      widths.push(count)
+      current = bit
+      count = 1
     }
   }
-  widths.push(count);
-  return widths;
+  widths.push(count)
+  return widths
 }
 
 function getCodewordPattern(codeword: number, cluster: number): number[] {
-  const table = CLUSTERS[cluster]!;
-  return bitmaskToWidths(table[codeword]!);
+  const table = CLUSTERS[cluster]!
+  return bitmaskToWidths(table[codeword]!)
 }
 
 // ---------------------------------------------------------------------------
@@ -304,11 +304,11 @@ const SYMBOL_METRICS: [number, number, number, number, number, number][] = [
 // ---------------------------------------------------------------------------
 
 function renderRAP(rapValue: number): boolean[] {
-  const modules: boolean[] = [];
+  const modules: boolean[] = []
   for (let bit = 9; bit >= 0; bit--) {
-    modules.push(((rapValue >> bit) & 1) === 1);
+    modules.push(((rapValue >> bit) & 1) === 1)
   }
-  return modules;
+  return modules
 }
 
 // ---------------------------------------------------------------------------
@@ -316,22 +316,22 @@ function renderRAP(rapValue: number): boolean[] {
 // ---------------------------------------------------------------------------
 
 function renderPattern(pattern: number[]): boolean[] {
-  const modules: boolean[] = [];
-  let isBar = true;
+  const modules: boolean[] = []
+  let isBar = true
   for (const w of pattern) {
     for (let i = 0; i < w; i++) {
-      modules.push(isBar);
+      modules.push(isBar)
     }
-    isBar = !isBar;
+    isBar = !isBar
   }
-  return modules;
+  return modules
 }
 
 // ---------------------------------------------------------------------------
 // GF(929) RS error correction (same field as PDF417, arbitrary EC count)
 // ---------------------------------------------------------------------------
 
-const GF_MOD = 929;
+const GF_MOD = 929
 
 // MicroPDF417 EC coefficients from ISO/IEC 24728 / Zint zint_pdf_Microcoeffs
 // Indexed by EC count (k), offset into the flat array
@@ -361,26 +361,26 @@ const MICRO_EC_COEFFS: Record<number, number[]> = {
  * Algorithm from Zint pdf417.c — uses pre-computed Microcoeffs table.
  */
 function microPDF417RS(data: number[], ecCW: number): number[] {
-  const coeffs = MICRO_EC_COEFFS[ecCW];
-  if (!coeffs) throw new Error(`No MicroPDF417 EC coefficients for k=${ecCW}`);
+  const coeffs = MICRO_EC_COEFFS[ecCW]
+  if (!coeffs) throw new Error(`No MicroPDF417 EC coefficients for k=${ecCW}`)
 
-  const ec = Array.from<number>({ length: ecCW }).fill(0);
+  const ec = Array.from<number>({ length: ecCW }).fill(0)
   for (const cw of data) {
-    const total = (cw + ec[ecCW - 1]!) % GF_MOD;
+    const total = (cw + ec[ecCW - 1]!) % GF_MOD
     for (let j = ecCW - 1; j >= 0; j--) {
       if (j === 0) {
-        ec[j] = (GF_MOD - ((total * coeffs[j]!) % GF_MOD)) % GF_MOD;
+        ec[j] = (GF_MOD - ((total * coeffs[j]!) % GF_MOD)) % GF_MOD
       } else {
-        ec[j] = (ec[j - 1]! + GF_MOD - ((total * coeffs[j]!) % GF_MOD)) % GF_MOD;
+        ec[j] = (ec[j - 1]! + GF_MOD - ((total * coeffs[j]!) % GF_MOD)) % GF_MOD
       }
     }
   }
 
   // Negate non-zero values and reverse (Zint convention)
   for (let j = 0; j < ecCW; j++) {
-    if (ec[j] !== 0) ec[j] = GF_MOD - ec[j]!;
+    if (ec[j] !== 0) ec[j] = GF_MOD - ec[j]!
   }
-  return ec.reverse();
+  return ec.reverse()
 }
 
 // ---------------------------------------------------------------------------
@@ -388,13 +388,13 @@ function microPDF417RS(data: number[], ecCW: number): number[] {
 // ---------------------------------------------------------------------------
 
 export interface MicroPDF417Options {
-  columns?: 1 | 2 | 3 | 4;
+  columns?: 1 | 2 | 3 | 4
 }
 
 export interface MicroPDF417Result {
-  matrix: boolean[][];
-  rows: number;
-  cols: number;
+  matrix: boolean[][]
+  rows: number
+  cols: number
 }
 
 /**
@@ -405,94 +405,94 @@ export function encodeMicroPDF417(
   options: MicroPDF417Options = {},
 ): MicroPDF417Result {
   if (text.length === 0) {
-    throw new InvalidInputError("MicroPDF417 input must not be empty");
+    throw new InvalidInputError("MicroPDF417 input must not be empty")
   }
 
   // Encode data to codewords using PDF417 compaction
-  const dataCW = encodeData(text);
+  const dataCW = encodeData(text)
 
   // Select symbol size
-  const metric = selectSize(dataCW.length, options.columns);
+  const metric = selectSize(dataCW.length, options.columns)
   if (!metric) {
-    throw new CapacityError(`Data too long for MicroPDF417: ${dataCW.length} codewords needed`);
+    throw new CapacityError(`Data too long for MicroPDF417: ${dataCW.length} codewords needed`)
   }
 
-  const [cols, rows, ecCW, rapl, rapc, rapr] = metric;
-  const maxDataCW = rows * cols - ecCW;
+  const [cols, rows, ecCW, rapl, rapc, rapr] = metric
+  const maxDataCW = rows * cols - ecCW
 
   // Pad data codewords: MicroPDF417 prepends 900 (text latch) as padding
   // This matches Zint/bwip-js behavior where padding goes BEFORE data
   while (dataCW.length < maxDataCW) {
-    dataCW.unshift(900);
+    dataCW.unshift(900)
   }
 
   // Generate EC codewords using RS over GF(929)
   // Generate EC using RS over GF(929) with roots 3^1..3^ecCW
-  const ec = microPDF417RS(dataCW, ecCW);
+  const ec = microPDF417RS(dataCW, ecCW)
 
   // Combine data + EC codewords
-  const allCW = [...dataCW, ...ec];
+  const allCW = [...dataCW, ...ec]
 
   // Build matrix row by row
-  const matrix: boolean[][] = [];
+  const matrix: boolean[][] = []
 
   for (let i = 0; i < rows; i++) {
     // Cluster for this row: (i + rapl - 1) mod 3
-    const cluster = (((i + rapl - 1) % 3) + 3) % 3;
-    const rowModules: boolean[] = [];
+    const cluster = (((i + rapl - 1) % 3) + 3) % 3
+    const rowModules: boolean[] = []
 
     // Left RAP
-    const leftRAPIdx = (((i + rapl - 1) % 52) + 52) % 52;
-    rowModules.push(...renderRAP(RAP_LEFT_RIGHT[leftRAPIdx]!));
+    const leftRAPIdx = (((i + rapl - 1) % 52) + 52) % 52
+    rowModules.push(...renderRAP(RAP_LEFT_RIGHT[leftRAPIdx]!))
 
     // Data codewords and center RAP
     if (cols === 1) {
       // 1 col: left_RAP | cw0 | right_RAP
-      const cw0 = allCW[i]!;
-      rowModules.push(...renderPattern(getCodewordPattern(cw0, cluster)));
+      const cw0 = allCW[i]!
+      rowModules.push(...renderPattern(getCodewordPattern(cw0, cluster)))
     } else if (cols === 2) {
       // 2 col: left_RAP | cw0 | cw1 | right_RAP
-      const cw0 = allCW[i * 2]!;
-      const cw1 = allCW[i * 2 + 1]!;
-      rowModules.push(...renderPattern(getCodewordPattern(cw0, cluster)));
-      rowModules.push(...renderPattern(getCodewordPattern(cw1, cluster)));
+      const cw0 = allCW[i * 2]!
+      const cw1 = allCW[i * 2 + 1]!
+      rowModules.push(...renderPattern(getCodewordPattern(cw0, cluster)))
+      rowModules.push(...renderPattern(getCodewordPattern(cw1, cluster)))
     } else if (cols === 3) {
       // 3 col: left_RAP | cw0 | center_RAP | cw1 | cw2 | right_RAP
-      const cw0 = allCW[i * 3]!;
-      const cw1 = allCW[i * 3 + 1]!;
-      const cw2 = allCW[i * 3 + 2]!;
-      rowModules.push(...renderPattern(getCodewordPattern(cw0, cluster)));
+      const cw0 = allCW[i * 3]!
+      const cw1 = allCW[i * 3 + 1]!
+      const cw2 = allCW[i * 3 + 2]!
+      rowModules.push(...renderPattern(getCodewordPattern(cw0, cluster)))
       // Center RAP
-      const centerRAPIdx = (((i + rapc - 1) % 52) + 52) % 52;
-      rowModules.push(...renderRAP(RAP_CENTER[centerRAPIdx]!));
-      rowModules.push(...renderPattern(getCodewordPattern(cw1, cluster)));
-      rowModules.push(...renderPattern(getCodewordPattern(cw2, cluster)));
+      const centerRAPIdx = (((i + rapc - 1) % 52) + 52) % 52
+      rowModules.push(...renderRAP(RAP_CENTER[centerRAPIdx]!))
+      rowModules.push(...renderPattern(getCodewordPattern(cw1, cluster)))
+      rowModules.push(...renderPattern(getCodewordPattern(cw2, cluster)))
     } else {
       // 4 col: left_RAP | cw0 | cw1 | center_RAP | cw2 | cw3 | right_RAP
-      const cw0 = allCW[i * 4]!;
-      const cw1 = allCW[i * 4 + 1]!;
-      const cw2 = allCW[i * 4 + 2]!;
-      const cw3 = allCW[i * 4 + 3]!;
-      rowModules.push(...renderPattern(getCodewordPattern(cw0, cluster)));
-      rowModules.push(...renderPattern(getCodewordPattern(cw1, cluster)));
+      const cw0 = allCW[i * 4]!
+      const cw1 = allCW[i * 4 + 1]!
+      const cw2 = allCW[i * 4 + 2]!
+      const cw3 = allCW[i * 4 + 3]!
+      rowModules.push(...renderPattern(getCodewordPattern(cw0, cluster)))
+      rowModules.push(...renderPattern(getCodewordPattern(cw1, cluster)))
       // Center RAP
-      const centerRAPIdx = (((i + rapc - 1) % 52) + 52) % 52;
-      rowModules.push(...renderRAP(RAP_CENTER[centerRAPIdx]!));
-      rowModules.push(...renderPattern(getCodewordPattern(cw2, cluster)));
-      rowModules.push(...renderPattern(getCodewordPattern(cw3, cluster)));
+      const centerRAPIdx = (((i + rapc - 1) % 52) + 52) % 52
+      rowModules.push(...renderRAP(RAP_CENTER[centerRAPIdx]!))
+      rowModules.push(...renderPattern(getCodewordPattern(cw2, cluster)))
+      rowModules.push(...renderPattern(getCodewordPattern(cw3, cluster)))
     }
 
     // Right RAP
-    const rightRAPIdx = (((i + rapr - 1) % 52) + 52) % 52;
-    rowModules.push(...renderRAP(RAP_LEFT_RIGHT[rightRAPIdx]!));
+    const rightRAPIdx = (((i + rapr - 1) % 52) + 52) % 52
+    rowModules.push(...renderRAP(RAP_LEFT_RIGHT[rightRAPIdx]!))
 
     // Stop bar (1 module)
-    rowModules.push(true);
+    rowModules.push(true)
 
-    matrix.push(rowModules);
+    matrix.push(rowModules)
   }
 
-  return { matrix, rows, cols: matrix[0]?.length ?? 0 };
+  return { matrix, rows, cols: matrix[0]?.length ?? 0 }
 }
 
 function selectSize(
@@ -500,10 +500,10 @@ function selectSize(
   requestedCols?: number,
 ): [number, number, number, number, number, number] | undefined {
   for (const metric of SYMBOL_METRICS) {
-    const [cols, rows, ecCW] = metric;
-    if (requestedCols && cols !== requestedCols) continue;
-    const maxDataCW = rows * cols - ecCW;
-    if (dataCWCount <= maxDataCW) return metric;
+    const [cols, rows, ecCW] = metric
+    if (requestedCols && cols !== requestedCols) continue
+    const maxDataCW = rows * cols - ecCW
+    if (dataCWCount <= maxDataCW) return metric
   }
-  return undefined;
+  return undefined
 }

--- a/src/encoders/msi.ts
+++ b/src/encoders/msi.ts
@@ -3,39 +3,39 @@
  * Digits 0-9 only, with configurable check digit algorithms
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 /**
  * Available check digit calculation types
  */
-export type MSICheckDigitType = "mod10" | "mod11" | "mod1010" | "mod1110" | "none";
+export type MSICheckDigitType = "mod10" | "mod11" | "mod1010" | "mod1110" | "none"
 
 // Start pattern: wide bar (2), narrow space (1)
-const START = [2, 1];
+const START = [2, 1]
 
 // Stop pattern: narrow bar (1), wide space (2), narrow bar (1)
-const STOP = [1, 2, 1];
+const STOP = [1, 2, 1]
 
 // BCD bit encoding:
 // 0 bit → narrow bar (1), wide space (2)
 // 1 bit → wide bar (2), narrow space (1)
-const BIT_0 = [1, 2];
-const BIT_1 = [2, 1];
+const BIT_0 = [1, 2]
+const BIT_1 = [2, 1]
 
 /**
  * Encode a single digit into bar/space widths using BCD
  * Each digit is 4 bits, MSB first
  */
 function encodeDigit(digit: number): number[] {
-  const result: number[] = [];
+  const result: number[] = []
   for (let bit = 3; bit >= 0; bit--) {
     if ((digit >> bit) & 1) {
-      result.push(BIT_1[0]!, BIT_1[1]!);
+      result.push(BIT_1[0]!, BIT_1[1]!)
     } else {
-      result.push(BIT_0[0]!, BIT_0[1]!);
+      result.push(BIT_0[0]!, BIT_0[1]!)
     }
   }
-  return result;
+  return result
 }
 
 /**
@@ -52,27 +52,27 @@ function calculateMod10(digits: number[]): number {
   // 1. Take digits from right, double every other starting from rightmost
   // 2. Form a string of doubled values, sum individual digits
   // 3. Add non-doubled digits
-  let doubledStr = "";
-  let undoubledSum = 0;
+  let doubledStr = ""
+  let undoubledSum = 0
 
   for (let i = digits.length - 1; i >= 0; i--) {
-    const pos = digits.length - 1 - i;
+    const pos = digits.length - 1 - i
     if (pos % 2 === 0) {
       // Double this digit
-      doubledStr = String(digits[i]! * 2) + doubledStr;
+      doubledStr = String(digits[i]! * 2) + doubledStr
     } else {
-      undoubledSum += digits[i]!;
+      undoubledSum += digits[i]!
     }
   }
 
   // Sum individual digits of the doubled string
-  let doubledSum = 0;
+  let doubledSum = 0
   for (const ch of doubledStr) {
-    doubledSum += Number(ch);
+    doubledSum += Number(ch)
   }
 
-  const total = doubledSum + undoubledSum;
-  return (10 - (total % 10)) % 10;
+  const total = doubledSum + undoubledSum
+  return (10 - (total % 10)) % 10
 }
 
 /**
@@ -84,23 +84,23 @@ function calculateMod10(digits: number[]): number {
  * If remainder is 1, check digit is 0 (some implementations)
  */
 function calculateMod11(digits: number[]): number {
-  let sum = 0;
-  let weight = 2;
+  let sum = 0
+  let weight = 2
 
   for (let i = digits.length - 1; i >= 0; i--) {
-    sum += digits[i]! * weight;
-    weight++;
+    sum += digits[i]! * weight
+    weight++
     if (weight > 7) {
-      weight = 2;
+      weight = 2
     }
   }
 
-  const remainder = sum % 11;
+  const remainder = sum % 11
   // If remainder is 0 or 1, check digit is 0
   if (remainder <= 1) {
-    return 0;
+    return 0
   }
-  return 11 - remainder;
+  return 11 - remainder
 }
 
 /**
@@ -109,22 +109,22 @@ function calculateMod11(digits: number[]): number {
 function calculateCheckDigits(digits: number[], type: MSICheckDigitType): number[] {
   switch (type) {
     case "none":
-      return [];
+      return []
     case "mod10": {
-      return [calculateMod10(digits)];
+      return [calculateMod10(digits)]
     }
     case "mod11": {
-      return [calculateMod11(digits)];
+      return [calculateMod11(digits)]
     }
     case "mod1010": {
-      const c1 = calculateMod10(digits);
-      const c2 = calculateMod10([...digits, c1]);
-      return [c1, c2];
+      const c1 = calculateMod10(digits)
+      const c2 = calculateMod10([...digits, c1])
+      return [c1, c2]
     }
     case "mod1110": {
-      const c1 = calculateMod11(digits);
-      const c2 = calculateMod10([...digits, c1]);
-      return [c1, c2];
+      const c1 = calculateMod11(digits)
+      const c2 = calculateMod10([...digits, c1])
+      return [c1, c2]
     }
   }
 }
@@ -139,46 +139,46 @@ function calculateCheckDigits(digits: number[], type: MSICheckDigitType): number
  */
 export function encodeMSI(text: string, options?: { checkDigit?: MSICheckDigitType }): number[] {
   if (text.length === 0) {
-    throw new InvalidInputError("MSI input must not be empty");
+    throw new InvalidInputError("MSI input must not be empty")
   }
 
   if (!/^\d+$/.test(text)) {
-    throw new InvalidInputError("MSI barcode requires digits only (0-9)");
+    throw new InvalidInputError("MSI barcode requires digits only (0-9)")
   }
 
-  const checkDigitType = options?.checkDigit ?? "mod10";
+  const checkDigitType = options?.checkDigit ?? "mod10"
 
   // Convert text to digit array
-  const digits: number[] = [];
+  const digits: number[] = []
   for (let i = 0; i < text.length; i++) {
-    digits.push(text.charCodeAt(i) - 48);
+    digits.push(text.charCodeAt(i) - 48)
   }
 
   // Calculate check digit(s)
-  const checkDigits = calculateCheckDigits(digits, checkDigitType);
+  const checkDigits = calculateCheckDigits(digits, checkDigitType)
 
   // All digits to encode (data + check digits)
-  const allDigits = [...digits, ...checkDigits];
+  const allDigits = [...digits, ...checkDigits]
 
-  const bars: number[] = [];
+  const bars: number[] = []
 
   // Start pattern
   for (const w of START) {
-    bars.push(w);
+    bars.push(w)
   }
 
   // Encode each digit
   for (const digit of allDigits) {
-    const widths = encodeDigit(digit);
+    const widths = encodeDigit(digit)
     for (const w of widths) {
-      bars.push(w);
+      bars.push(w)
     }
   }
 
   // Stop pattern
   for (const w of STOP) {
-    bars.push(w);
+    bars.push(w)
   }
 
-  return bars;
+  return bars
 }

--- a/src/encoders/pdf417/ec.ts
+++ b/src/encoders/pdf417/ec.ts
@@ -8,7 +8,7 @@
  * Coefficient tables from ISO/IEC 15438:2001(E) Annex F.
  */
 
-const GF_MOD = 929;
+const GF_MOD = 929
 
 /**
  * Get the number of EC codewords for a given EC level.
@@ -17,9 +17,9 @@ const GF_MOD = 929;
  */
 export function getECCount(ecLevel: number): number {
   if (ecLevel < 0 || ecLevel > 8) {
-    throw new Error(`PDF417 EC level must be 0-8, got ${ecLevel}`);
+    throw new Error(`PDF417 EC level must be 0-8, got ${ecLevel}`)
   }
-  return 1 << (ecLevel + 1);
+  return 1 << (ecLevel + 1)
 }
 
 /**
@@ -119,31 +119,31 @@ const EC_COEFFICIENTS: readonly (readonly number[])[] = [
  * @returns Array of EC codewords
  */
 export function generateECCodewords(dataCodewords: number[], ecLevel: number): number[] {
-  const k = getECCount(ecLevel);
-  const coeffs = EC_COEFFICIENTS[ecLevel]!;
-  const e: number[] = Array.from({ length: k }, () => 0);
+  const k = getECCount(ecLevel)
+  const coeffs = EC_COEFFICIENTS[ecLevel]!
+  const e: number[] = Array.from({ length: k }, () => 0)
 
   for (let i = 0; i < dataCodewords.length; i++) {
-    const t1 = (dataCodewords[i]! + e[k - 1]!) % GF_MOD;
+    const t1 = (dataCodewords[i]! + e[k - 1]!) % GF_MOD
     for (let j = k - 1; j >= 1; j--) {
-      const t2 = (t1 * coeffs[j]!) % GF_MOD;
-      const t3 = GF_MOD - t2;
-      e[j] = (e[j - 1]! + t3) % GF_MOD;
+      const t2 = (t1 * coeffs[j]!) % GF_MOD
+      const t3 = GF_MOD - t2
+      e[j] = (e[j - 1]! + t3) % GF_MOD
     }
-    const t2 = (t1 * coeffs[0]!) % GF_MOD;
-    const t3 = GF_MOD - t2;
-    e[0] = t3 % GF_MOD;
+    const t2 = (t1 * coeffs[0]!) % GF_MOD
+    const t3 = GF_MOD - t2
+    e[0] = t3 % GF_MOD
   }
 
   // Negate non-zero remainders
   for (let j = 0; j < k; j++) {
     if (e[j] !== 0) {
-      e[j] = GF_MOD - e[j]!;
+      e[j] = GF_MOD - e[j]!
     }
   }
 
   // Reverse order: EC codewords are appended highest degree first
-  return e.reverse();
+  return e.reverse()
 }
 
 /**
@@ -151,9 +151,9 @@ export function generateECCodewords(dataCodewords: number[], ecLevel: number): n
  * From the PDF417 specification.
  */
 export function recommendedECLevel(dataCodewords: number): number {
-  if (dataCodewords <= 40) return 2;
-  if (dataCodewords <= 160) return 3;
-  if (dataCodewords <= 320) return 4;
-  if (dataCodewords <= 863) return 5;
-  return 6;
+  if (dataCodewords <= 40) return 2
+  if (dataCodewords <= 160) return 3
+  if (dataCodewords <= 320) return 4
+  if (dataCodewords <= 863) return 5
+  return 6
 }

--- a/src/encoders/pdf417/encoder.ts
+++ b/src/encoders/pdf417/encoder.ts
@@ -11,7 +11,7 @@ import {
   TEXT_SWITCH,
   MODE_LATCH,
   TextSubMode,
-} from "./tables";
+} from "./tables"
 
 /**
  * Encode input text into PDF417 data codewords.
@@ -21,33 +21,33 @@ import {
  * @returns Array of codeword values (0-928), not including symbol length descriptor or EC
  */
 export function encodeData(text: string): number[] {
-  const bytes = textToBytes(text);
-  const segments = analyzeSegments(bytes);
-  const codewords: number[] = [];
+  const bytes = textToBytes(text)
+  const segments = analyzeSegments(bytes)
+  const codewords: number[] = []
 
   for (const segment of segments) {
     switch (segment.mode) {
       case "text":
-        encodeTextSegment(text.slice(segment.start, segment.end), codewords);
-        break;
+        encodeTextSegment(text.slice(segment.start, segment.end), codewords)
+        break
       case "numeric":
-        encodeNumericSegment(text.slice(segment.start, segment.end), codewords);
-        break;
+        encodeNumericSegment(text.slice(segment.start, segment.end), codewords)
+        break
       case "byte":
-        encodeByteSegment(bytes.slice(segment.start, segment.end), codewords);
-        break;
+        encodeByteSegment(bytes.slice(segment.start, segment.end), codewords)
+        break
     }
   }
 
-  return codewords;
+  return codewords
 }
 
 // ---- Segment analysis ----
 
 interface Segment {
-  mode: "text" | "byte" | "numeric";
-  start: number;
-  end: number;
+  mode: "text" | "byte" | "numeric"
+  start: number
+  end: number
 }
 
 // ISO-8859-15 differs from ISO-8859-1 at these code points
@@ -60,24 +60,24 @@ const ISO_8859_15_MAP: Record<number, number> = {
   0x0152: 0xbc, // Œ
   0x0153: 0xbd, // œ
   0x0178: 0xbe, // Ÿ
-};
+}
 
 /** Convert string to byte array with ISO-8859-15 support */
 function textToBytes(text: string): number[] {
-  const bytes: number[] = [];
+  const bytes: number[] = []
   for (let i = 0; i < text.length; i++) {
-    const code = text.charCodeAt(i);
-    const mapped = ISO_8859_15_MAP[code];
+    const code = text.charCodeAt(i)
+    const mapped = ISO_8859_15_MAP[code]
     if (mapped !== undefined) {
-      bytes.push(mapped);
+      bytes.push(mapped)
     } else if (code <= 0xff) {
-      bytes.push(code);
+      bytes.push(code)
     } else {
       // Fallback: use byte compaction for non-Latin characters
-      bytes.push(code & 0xff);
+      bytes.push(code & 0xff)
     }
   }
-  return bytes;
+  return bytes
 }
 
 /** Check if a character is encodable in text compaction mode */
@@ -87,13 +87,13 @@ function isTextCompactable(ch: string): boolean {
     TEXT_LOWER_MAP[ch] !== undefined ||
     TEXT_MIXED_MAP[ch] !== undefined ||
     TEXT_PUNCT_MAP[ch] !== undefined
-  );
+  )
 }
 
 /** Check if a character is a digit */
 function isDigit(ch: string): boolean {
-  const c = ch.charCodeAt(0);
-  return c >= 48 && c <= 57;
+  const c = ch.charCodeAt(0)
+  return c >= 48 && c <= 57
 }
 
 /**
@@ -103,60 +103,60 @@ function isDigit(ch: string): boolean {
  * - Everything else uses byte compaction
  */
 function analyzeSegments(bytes: number[]): Segment[] {
-  const text = String.fromCharCode(...bytes);
-  const segments: Segment[] = [];
-  let pos = 0;
+  const text = String.fromCharCode(...bytes)
+  const segments: Segment[] = []
+  let pos = 0
 
   while (pos < text.length) {
     // Check for long numeric run (13+ digits for efficiency)
-    const numericRun = countDigits(text, pos);
+    const numericRun = countDigits(text, pos)
     if (numericRun >= 13) {
-      segments.push({ mode: "numeric", start: pos, end: pos + numericRun });
-      pos += numericRun;
-      continue;
+      segments.push({ mode: "numeric", start: pos, end: pos + numericRun })
+      pos += numericRun
+      continue
     }
 
     // Check for text-compactable run
-    const textRun = countTextCompactable(text, pos);
+    const textRun = countTextCompactable(text, pos)
     if (textRun > 0) {
-      segments.push({ mode: "text", start: pos, end: pos + textRun });
-      pos += textRun;
-      continue;
+      segments.push({ mode: "text", start: pos, end: pos + textRun })
+      pos += textRun
+      continue
     }
 
     // Byte mode for non-text bytes
-    const byteRun = countNonTextCompactable(text, pos);
-    segments.push({ mode: "byte", start: pos, end: pos + byteRun });
-    pos += byteRun;
+    const byteRun = countNonTextCompactable(text, pos)
+    segments.push({ mode: "byte", start: pos, end: pos + byteRun })
+    pos += byteRun
   }
 
-  return segments;
+  return segments
 }
 
 function countDigits(text: string, pos: number): number {
-  let count = 0;
+  let count = 0
   while (pos + count < text.length && isDigit(text[pos + count]!)) {
-    count++;
+    count++
   }
-  return count;
+  return count
 }
 
 function countTextCompactable(text: string, pos: number): number {
-  let count = 0;
+  let count = 0
   while (pos + count < text.length && isTextCompactable(text[pos + count]!)) {
-    count++;
+    count++
   }
-  return count;
+  return count
 }
 
 function countNonTextCompactable(text: string, pos: number): number {
-  let count = 0;
+  let count = 0
   while (pos + count < text.length && !isTextCompactable(text[pos + count]!)) {
     // Also break if we hit a long numeric run
-    if (isDigit(text[pos + count]!)) break;
-    count++;
+    if (isDigit(text[pos + count]!)) break
+    count++
   }
-  return Math.max(count, 1);
+  return Math.max(count, 1)
 }
 
 // ---- Text compaction ----
@@ -171,17 +171,17 @@ function encodeTextSegment(text: string, codewords: number[]): void {
   // For the first segment, text mode is the default so no latch needed.
   // For subsequent segments, we add the latch.
   if (codewords.length > 0) {
-    codewords.push(MODE_LATCH.TEXT_COMPACTION);
+    codewords.push(MODE_LATCH.TEXT_COMPACTION)
   }
 
-  const subCodewords = textToSubCodewords(text);
+  const subCodewords = textToSubCodewords(text)
 
   // Pack sub-codewords into pairs → codewords
   // Each pair: high * 30 + low
   for (let i = 0; i < subCodewords.length; i += 2) {
-    const high = subCodewords[i]!;
-    const low = i + 1 < subCodewords.length ? subCodewords[i + 1]! : 29; // pad with 29 (PS) per ISO 15438 5.4.2.1
-    codewords.push(high * 30 + low);
+    const high = subCodewords[i]!
+    const low = i + 1 < subCodewords.length ? subCodewords[i + 1]! : 29 // pad with 29 (PS) per ISO 15438 5.4.2.1
+    codewords.push(high * 30 + low)
   }
 }
 
@@ -190,16 +190,16 @@ function encodeTextSegment(text: string, codewords: number[]): void {
  * Handles mode switching between Alpha, Lower, Mixed, and Punctuation sub-modes.
  */
 function textToSubCodewords(text: string): number[] {
-  const values: number[] = [];
-  let currentMode: TextSubMode = TextSubMode.Alpha;
+  const values: number[] = []
+  let currentMode: TextSubMode = TextSubMode.Alpha
 
   for (let i = 0; i < text.length; i++) {
-    const ch = text[i]!;
-    const encoded = encodeTextChar(ch, currentMode, values);
-    currentMode = encoded;
+    const ch = text[i]!
+    const encoded = encodeTextChar(ch, currentMode, values)
+    currentMode = encoded
   }
 
-  return values;
+  return values
 }
 
 /**
@@ -208,122 +208,122 @@ function textToSubCodewords(text: string): number[] {
  */
 function encodeTextChar(ch: string, currentMode: TextSubMode, values: number[]): TextSubMode {
   // Try encoding in current mode first
-  const currentVal = getCharValue(ch, currentMode);
+  const currentVal = getCharValue(ch, currentMode)
   if (currentVal !== -1) {
-    values.push(currentVal);
-    return currentMode;
+    values.push(currentVal)
+    return currentMode
   }
 
   // Need to switch mode. Find which mode can encode this character.
   if (currentMode === TextSubMode.Alpha) {
     // Try Lower
-    const lowerVal = getCharValue(ch, TextSubMode.Lower);
+    const lowerVal = getCharValue(ch, TextSubMode.Lower)
     if (lowerVal !== -1) {
-      values.push(TEXT_SWITCH.ALPHA_TO_LOWER); // latch to lower
-      values.push(lowerVal);
-      return TextSubMode.Lower;
+      values.push(TEXT_SWITCH.ALPHA_TO_LOWER) // latch to lower
+      values.push(lowerVal)
+      return TextSubMode.Lower
     }
     // Try Mixed
-    const mixedVal = getCharValue(ch, TextSubMode.Mixed);
+    const mixedVal = getCharValue(ch, TextSubMode.Mixed)
     if (mixedVal !== -1) {
-      values.push(TEXT_SWITCH.ALPHA_TO_MIXED); // latch to mixed
-      values.push(mixedVal);
-      return TextSubMode.Mixed;
+      values.push(TEXT_SWITCH.ALPHA_TO_MIXED) // latch to mixed
+      values.push(mixedVal)
+      return TextSubMode.Mixed
     }
     // Try Punctuation (shift)
-    const punctVal = getCharValue(ch, TextSubMode.Punctuation);
+    const punctVal = getCharValue(ch, TextSubMode.Punctuation)
     if (punctVal !== -1) {
-      values.push(TEXT_SWITCH.ALPHA_TO_PUNCT_SHIFT); // shift to punct
-      values.push(punctVal);
-      return TextSubMode.Alpha; // shift returns to current mode
+      values.push(TEXT_SWITCH.ALPHA_TO_PUNCT_SHIFT) // shift to punct
+      values.push(punctVal)
+      return TextSubMode.Alpha // shift returns to current mode
     }
   } else if (currentMode === TextSubMode.Lower) {
     // Try Alpha (shift for single char)
-    const alphaVal = getCharValue(ch, TextSubMode.Alpha);
+    const alphaVal = getCharValue(ch, TextSubMode.Alpha)
     if (alphaVal !== -1) {
-      values.push(TEXT_SWITCH.LOWER_TO_ALPHA_SHIFT); // shift to alpha
-      values.push(alphaVal);
-      return TextSubMode.Lower; // shift returns to lower
+      values.push(TEXT_SWITCH.LOWER_TO_ALPHA_SHIFT) // shift to alpha
+      values.push(alphaVal)
+      return TextSubMode.Lower // shift returns to lower
     }
     // Try Mixed
-    const mixedVal = getCharValue(ch, TextSubMode.Mixed);
+    const mixedVal = getCharValue(ch, TextSubMode.Mixed)
     if (mixedVal !== -1) {
-      values.push(TEXT_SWITCH.LOWER_TO_MIXED); // latch to mixed
-      values.push(mixedVal);
-      return TextSubMode.Mixed;
+      values.push(TEXT_SWITCH.LOWER_TO_MIXED) // latch to mixed
+      values.push(mixedVal)
+      return TextSubMode.Mixed
     }
     // Try Punctuation (shift)
-    const punctVal = getCharValue(ch, TextSubMode.Punctuation);
+    const punctVal = getCharValue(ch, TextSubMode.Punctuation)
     if (punctVal !== -1) {
-      values.push(TEXT_SWITCH.LOWER_TO_PUNCT_SHIFT); // shift to punct
-      values.push(punctVal);
-      return TextSubMode.Lower; // shift returns to current mode
+      values.push(TEXT_SWITCH.LOWER_TO_PUNCT_SHIFT) // shift to punct
+      values.push(punctVal)
+      return TextSubMode.Lower // shift returns to current mode
     }
   } else if (currentMode === TextSubMode.Mixed) {
     // Try Punctuation (shift for single char)
-    const punctVal = getCharValue(ch, TextSubMode.Punctuation);
+    const punctVal = getCharValue(ch, TextSubMode.Punctuation)
     if (punctVal !== -1) {
-      values.push(TEXT_SWITCH.MIXED_TO_PUNCT_SHIFT); // PS - shift to punct
-      values.push(punctVal);
-      return TextSubMode.Mixed; // shift returns to mixed
+      values.push(TEXT_SWITCH.MIXED_TO_PUNCT_SHIFT) // PS - shift to punct
+      values.push(punctVal)
+      return TextSubMode.Mixed // shift returns to mixed
     }
     // Try Alpha
-    const alphaVal = getCharValue(ch, TextSubMode.Alpha);
+    const alphaVal = getCharValue(ch, TextSubMode.Alpha)
     if (alphaVal !== -1) {
-      values.push(TEXT_SWITCH.MIXED_TO_ALPHA); // AL - latch to alpha
-      values.push(alphaVal);
-      return TextSubMode.Alpha;
+      values.push(TEXT_SWITCH.MIXED_TO_ALPHA) // AL - latch to alpha
+      values.push(alphaVal)
+      return TextSubMode.Alpha
     }
     // Try Lower (Mixed -> Alpha -> Lower)
-    const lowerVal = getCharValue(ch, TextSubMode.Lower);
+    const lowerVal = getCharValue(ch, TextSubMode.Lower)
     if (lowerVal !== -1) {
-      values.push(TEXT_SWITCH.MIXED_TO_ALPHA); // AL - latch to alpha first
-      values.push(TEXT_SWITCH.ALPHA_TO_LOWER); // LL - then latch to lower
-      values.push(lowerVal);
-      return TextSubMode.Lower;
+      values.push(TEXT_SWITCH.MIXED_TO_ALPHA) // AL - latch to alpha first
+      values.push(TEXT_SWITCH.ALPHA_TO_LOWER) // LL - then latch to lower
+      values.push(lowerVal)
+      return TextSubMode.Lower
     }
   } else if (currentMode === TextSubMode.Punctuation) {
     // Try Alpha
-    const alphaVal = getCharValue(ch, TextSubMode.Alpha);
+    const alphaVal = getCharValue(ch, TextSubMode.Alpha)
     if (alphaVal !== -1) {
-      values.push(TEXT_SWITCH.PUNCT_TO_ALPHA); // latch to alpha
-      values.push(alphaVal);
-      return TextSubMode.Alpha;
+      values.push(TEXT_SWITCH.PUNCT_TO_ALPHA) // latch to alpha
+      values.push(alphaVal)
+      return TextSubMode.Alpha
     }
     // Alpha -> Lower
-    const lowerVal = getCharValue(ch, TextSubMode.Lower);
+    const lowerVal = getCharValue(ch, TextSubMode.Lower)
     if (lowerVal !== -1) {
-      values.push(TEXT_SWITCH.PUNCT_TO_ALPHA); // latch to alpha first
-      values.push(TEXT_SWITCH.ALPHA_TO_LOWER); // then latch to lower
-      values.push(lowerVal);
-      return TextSubMode.Lower;
+      values.push(TEXT_SWITCH.PUNCT_TO_ALPHA) // latch to alpha first
+      values.push(TEXT_SWITCH.ALPHA_TO_LOWER) // then latch to lower
+      values.push(lowerVal)
+      return TextSubMode.Lower
     }
     // Alpha -> Mixed
-    const mixedVal = getCharValue(ch, TextSubMode.Mixed);
+    const mixedVal = getCharValue(ch, TextSubMode.Mixed)
     if (mixedVal !== -1) {
-      values.push(TEXT_SWITCH.PUNCT_TO_ALPHA); // latch to alpha first
-      values.push(TEXT_SWITCH.ALPHA_TO_MIXED); // then latch to mixed
-      values.push(mixedVal);
-      return TextSubMode.Mixed;
+      values.push(TEXT_SWITCH.PUNCT_TO_ALPHA) // latch to alpha first
+      values.push(TEXT_SWITCH.ALPHA_TO_MIXED) // then latch to mixed
+      values.push(mixedVal)
+      return TextSubMode.Mixed
     }
   }
 
   // Fallback: encode as byte value (shouldn't reach here for text-compactable chars)
-  values.push(getCharValue(" ", currentMode) !== -1 ? getCharValue(" ", currentMode) : 26);
-  return currentMode;
+  values.push(getCharValue(" ", currentMode) !== -1 ? getCharValue(" ", currentMode) : 26)
+  return currentMode
 }
 
 /** Get the sub-codeword value for a character in a given sub-mode, or -1 if not available */
 function getCharValue(ch: string, mode: TextSubMode): number {
   switch (mode) {
     case TextSubMode.Alpha:
-      return TEXT_ALPHA_MAP[ch] ?? -1;
+      return TEXT_ALPHA_MAP[ch] ?? -1
     case TextSubMode.Lower:
-      return TEXT_LOWER_MAP[ch] ?? -1;
+      return TEXT_LOWER_MAP[ch] ?? -1
     case TextSubMode.Mixed:
-      return TEXT_MIXED_MAP[ch] ?? -1;
+      return TEXT_MIXED_MAP[ch] ?? -1
     case TextSubMode.Punctuation:
-      return TEXT_PUNCT_MAP[ch] ?? -1;
+      return TEXT_PUNCT_MAP[ch] ?? -1
   }
 }
 
@@ -335,17 +335,17 @@ function getCharValue(ch: string, mode: TextSubMode): number {
  * Prepends '1' to digit string, converts to base 900.
  */
 function encodeNumericSegment(digits: string, codewords: number[]): void {
-  codewords.push(MODE_LATCH.NUMERIC_COMPACTION);
+  codewords.push(MODE_LATCH.NUMERIC_COMPACTION)
 
   // Process in groups of up to 44 digits
-  let pos = 0;
+  let pos = 0
   while (pos < digits.length) {
-    const chunk = digits.slice(pos, pos + 44);
-    const numericCodewords = numericToBase900(chunk);
+    const chunk = digits.slice(pos, pos + 44)
+    const numericCodewords = numericToBase900(chunk)
     for (const cw of numericCodewords) {
-      codewords.push(cw);
+      codewords.push(cw)
     }
-    pos += 44;
+    pos += 44
   }
 }
 
@@ -355,19 +355,19 @@ function encodeNumericSegment(digits: string, codewords: number[]): void {
  */
 function numericToBase900(digits: string): number[] {
   // Prepend '1' to ensure leading zeros are preserved
-  const numStr = "1" + digits;
+  const numStr = "1" + digits
 
   // Use BigInt for arbitrary precision arithmetic
-  let value = BigInt(numStr);
-  const base = BigInt(900);
-  const result: number[] = [];
+  let value = BigInt(numStr)
+  const base = BigInt(900)
+  const result: number[] = []
 
   while (value > 0n) {
-    result.unshift(Number(value % base));
-    value = value / base;
+    result.unshift(Number(value % base))
+    value = value / base
   }
 
-  return result;
+  return result
 }
 
 // ---- Byte compaction ----
@@ -379,27 +379,27 @@ function numericToBase900(digits: string): number[] {
  */
 function encodeByteSegment(bytes: number[], codewords: number[]): void {
   if (bytes.length % 6 === 0) {
-    codewords.push(MODE_LATCH.BYTE_COMPACTION_6); // groups of 6 optimization
+    codewords.push(MODE_LATCH.BYTE_COMPACTION_6) // groups of 6 optimization
   } else {
-    codewords.push(MODE_LATCH.BYTE_COMPACTION);
+    codewords.push(MODE_LATCH.BYTE_COMPACTION)
   }
 
-  let pos = 0;
+  let pos = 0
 
   // Encode full groups of 6 bytes as 5 codewords
   while (pos + 6 <= bytes.length) {
-    const group = bytes.slice(pos, pos + 6);
-    const groupCodewords = bytesToBase900(group);
+    const group = bytes.slice(pos, pos + 6)
+    const groupCodewords = bytesToBase900(group)
     for (const cw of groupCodewords) {
-      codewords.push(cw);
+      codewords.push(cw)
     }
-    pos += 6;
+    pos += 6
   }
 
   // Encode remaining bytes 1:1 (each byte becomes a codeword)
   while (pos < bytes.length) {
-    codewords.push(bytes[pos]!);
-    pos++;
+    codewords.push(bytes[pos]!)
+    pos++
   }
 }
 
@@ -408,18 +408,18 @@ function encodeByteSegment(bytes: number[], codewords: number[]): void {
  */
 function bytesToBase900(bytes: number[]): number[] {
   // Compute: value = b0*256^5 + b1*256^4 + b2*256^3 + b3*256^2 + b4*256 + b5
-  let value = BigInt(0);
+  let value = BigInt(0)
   for (const b of bytes) {
-    value = value * BigInt(256) + BigInt(b);
+    value = value * BigInt(256) + BigInt(b)
   }
 
   // Convert to base 900, yielding 5 codewords
-  const result: number[] = Array.from({ length: 5 }, () => 0);
-  const base = BigInt(900);
+  const result: number[] = Array.from({ length: 5 }, () => 0)
+  const base = BigInt(900)
   for (let i = 4; i >= 0; i--) {
-    result[i] = Number(value % base);
-    value = value / base;
+    result[i] = Number(value % base)
+    value = value / base
   }
 
-  return result;
+  return result
 }

--- a/src/encoders/pdf417/index.ts
+++ b/src/encoders/pdf417/index.ts
@@ -6,39 +6,39 @@
  * Reed-Solomon error correction over GF(929).
  */
 
-import { InvalidInputError, CapacityError } from "../../errors";
-import { encodeData } from "./encoder";
-import { generateECCodewords, getECCount, recommendedECLevel } from "./ec";
-import { getCodewordPattern, getRowCluster, START_PATTERN, STOP_PATTERN } from "./tables";
+import { InvalidInputError, CapacityError } from "../../errors"
+import { encodeData } from "./encoder"
+import { generateECCodewords, getECCount, recommendedECLevel } from "./ec"
+import { getCodewordPattern, getRowCluster, START_PATTERN, STOP_PATTERN } from "./tables"
 
 export interface PDF417Options {
   /** Error correction level 0-8, default auto-selected based on data size */
-  ecLevel?: number;
+  ecLevel?: number
   /** Number of data columns (1-30), auto-calculated if omitted */
-  columns?: number;
+  columns?: number
   /** Compact PDF417 (omits right row indicator) */
-  compact?: boolean;
+  compact?: boolean
 }
 
 export interface PDF417Result {
   /** 2D boolean matrix (true = black bar, false = white space) */
-  matrix: boolean[][];
+  matrix: boolean[][]
   /** Number of rows in the symbol */
-  rows: number;
+  rows: number
   /** Number of module columns in the symbol */
-  cols: number;
+  cols: number
 }
 
 /** Maximum data codewords in a PDF417 symbol */
-const MAX_DATA_CODEWORDS = 925; // 929 - 1 (length) - 3 (reserved)
+const MAX_DATA_CODEWORDS = 925 // 929 - 1 (length) - 3 (reserved)
 /** Minimum rows */
-const MIN_ROWS = 3;
+const MIN_ROWS = 3
 /** Maximum rows */
-const MAX_ROWS = 90;
+const MAX_ROWS = 90
 /** Minimum data columns */
-const MIN_COLS = 1;
+const MIN_COLS = 1
 /** Maximum data columns */
-const MAX_COLS = 30;
+const MAX_COLS = 30
 
 /**
  * Encode text as a PDF417 barcode.
@@ -56,66 +56,66 @@ const MAX_COLS = 30;
  */
 export function encodePDF417(text: string, options: PDF417Options = {}): PDF417Result {
   if (text.length === 0) {
-    throw new InvalidInputError("PDF417 input must not be empty");
+    throw new InvalidInputError("PDF417 input must not be empty")
   }
 
-  const compact = options.compact ?? false;
+  const compact = options.compact ?? false
 
   // Step 1: Encode text into data codewords
-  const dataCodewords = encodeData(text);
+  const dataCodewords = encodeData(text)
 
   if (dataCodewords.length > MAX_DATA_CODEWORDS) {
     throw new CapacityError(
       `PDF417 data too large: ${dataCodewords.length} codewords exceeds maximum of ${MAX_DATA_CODEWORDS}`,
-    );
+    )
   }
 
   // Step 2: Determine EC level
-  const ecLevel = options.ecLevel ?? recommendedECLevel(dataCodewords.length);
+  const ecLevel = options.ecLevel ?? recommendedECLevel(dataCodewords.length)
   if (ecLevel < 0 || ecLevel > 8) {
-    throw new InvalidInputError("PDF417 EC level must be 0-8");
+    throw new InvalidInputError("PDF417 EC level must be 0-8")
   }
-  const ecCount = getECCount(ecLevel);
+  const ecCount = getECCount(ecLevel)
 
   // Step 3: Calculate symbol dimensions
   // Total codewords = 1 (length descriptor) + data + EC
-  const totalDataWithLength = 1 + dataCodewords.length;
+  const totalDataWithLength = 1 + dataCodewords.length
   // const totalCodewords = totalDataWithLength + ecCount;
 
-  const { rows, cols } = calculateDimensions(totalDataWithLength, ecCount, options.columns);
+  const { rows, cols } = calculateDimensions(totalDataWithLength, ecCount, options.columns)
 
   // Step 4: Pad data to fill the grid
   // Total data codeword slots = rows * cols - ecCount
-  const dataSlots = rows * cols;
-  const paddedData: number[] = [];
+  const dataSlots = rows * cols
+  const paddedData: number[] = []
 
   // Symbol length descriptor (total codewords including this one, excluding EC)
-  paddedData.push(totalDataWithLength);
+  paddedData.push(totalDataWithLength)
 
   // Data codewords
   for (const cw of dataCodewords) {
-    paddedData.push(cw);
+    paddedData.push(cw)
   }
 
   // Padding codewords (900 = text compaction latch, used as padding)
   while (paddedData.length < dataSlots - ecCount) {
-    paddedData.push(900);
+    paddedData.push(900)
   }
 
   // Step 5: Generate EC codewords
-  const ecCodewords = generateECCodewords(paddedData, ecLevel);
+  const ecCodewords = generateECCodewords(paddedData, ecLevel)
 
   // Step 6: Combine data + EC into codeword array
-  const allCodewords = [...paddedData, ...ecCodewords];
+  const allCodewords = [...paddedData, ...ecCodewords]
 
   // Step 7: Build the module matrix
-  const matrix = buildMatrix(allCodewords, rows, cols, ecLevel, compact);
+  const matrix = buildMatrix(allCodewords, rows, cols, ecLevel, compact)
 
   return {
     matrix,
     rows: matrix.length,
     cols: matrix[0]!.length,
-  };
+  }
 }
 
 /**
@@ -126,24 +126,24 @@ function calculateDimensions(
   ecCount: number,
   requestedCols?: number,
 ): { rows: number; cols: number } {
-  const totalCodewords = dataWithLength + ecCount;
+  const totalCodewords = dataWithLength + ecCount
 
   if (requestedCols !== undefined) {
     if (requestedCols < MIN_COLS || requestedCols > MAX_COLS) {
       throw new InvalidInputError(
         `PDF417 columns must be ${MIN_COLS}-${MAX_COLS}, got ${requestedCols}`,
-      );
+      )
     }
-    const rows = Math.ceil(totalCodewords / requestedCols);
+    const rows = Math.ceil(totalCodewords / requestedCols)
     if (rows < MIN_ROWS) {
-      return { rows: MIN_ROWS, cols: requestedCols };
+      return { rows: MIN_ROWS, cols: requestedCols }
     }
     if (rows > MAX_ROWS) {
       throw new CapacityError(
         `PDF417 data too large: requires ${rows} rows with ${requestedCols} columns (max ${MAX_ROWS})`,
-      );
+      )
     }
-    return { rows, cols: requestedCols };
+    return { rows, cols: requestedCols }
   }
 
   // Auto-determine columns: try to find a good aspect ratio
@@ -153,35 +153,35 @@ function calculateDimensions(
   // Try columns from 1 to 30, pick one that gives rows in valid range
   // with a reasonable aspect ratio
 
-  let bestCols = MIN_COLS;
-  let bestRows = MAX_ROWS;
-  let bestScore = Infinity;
+  let bestCols = MIN_COLS
+  let bestRows = MAX_ROWS
+  let bestScore = Infinity
 
   for (let c = MIN_COLS; c <= MAX_COLS; c++) {
-    const r = Math.ceil(totalCodewords / c);
-    if (r < MIN_ROWS || r > MAX_ROWS) continue;
+    const r = Math.ceil(totalCodewords / c)
+    if (r < MIN_ROWS || r > MAX_ROWS) continue
 
     // Actual total including padding
     // Score based on wasted space and aspect ratio
-    const totalSlots = r * c;
-    const waste = totalSlots - totalCodewords;
-    const moduleWidth = 69 + c * 17;
-    const aspectRatio = moduleWidth / r;
+    const totalSlots = r * c
+    const waste = totalSlots - totalCodewords
+    const moduleWidth = 69 + c * 17
+    const aspectRatio = moduleWidth / r
     // Target aspect ratio ~3-4 for readability
-    const aspectPenalty = Math.abs(aspectRatio - 3.5) * 10;
-    const score = waste + aspectPenalty;
+    const aspectPenalty = Math.abs(aspectRatio - 3.5) * 10
+    const score = waste + aspectPenalty
 
     if (score < bestScore) {
-      bestScore = score;
-      bestCols = c;
-      bestRows = r;
+      bestScore = score
+      bestCols = c
+      bestRows = r
     }
   }
 
   // Ensure minimum rows
-  if (bestRows < MIN_ROWS) bestRows = MIN_ROWS;
+  if (bestRows < MIN_ROWS) bestRows = MIN_ROWS
 
-  return { rows: bestRows, cols: bestCols };
+  return { rows: bestRows, cols: bestCols }
 }
 
 /**
@@ -203,48 +203,48 @@ function buildMatrix(
 ): boolean[][] {
   const modulesPerRow = compact
     ? 17 + 17 + cols * 17 + 1 // start + left indicator + data + 1-module stop
-    : 17 + 17 + cols * 17 + 17 + 18; // start + left indicator + data + right indicator + stop
+    : 17 + 17 + cols * 17 + 17 + 18 // start + left indicator + data + right indicator + stop
 
-  const matrix: boolean[][] = [];
+  const matrix: boolean[][] = []
 
   for (let row = 0; row < rows; row++) {
-    const cluster = getRowCluster(row);
-    const rowModules: boolean[] = Array.from({ length: modulesPerRow }, () => false);
-    let modulePos = 0;
+    const cluster = getRowCluster(row)
+    const rowModules: boolean[] = Array.from({ length: modulesPerRow }, () => false)
+    let modulePos = 0
 
     // Start pattern
-    modulePos = writePattern(rowModules, modulePos, START_PATTERN as number[]);
+    modulePos = writePattern(rowModules, modulePos, START_PATTERN as number[])
 
     // Left row indicator
-    const leftIndicator = computeLeftIndicator(row, rows, cols, ecLevel);
-    const leftPattern = getCodewordPattern(leftIndicator, cluster);
-    modulePos = writePattern(rowModules, modulePos, leftPattern);
+    const leftIndicator = computeLeftIndicator(row, rows, cols, ecLevel)
+    const leftPattern = getCodewordPattern(leftIndicator, cluster)
+    modulePos = writePattern(rowModules, modulePos, leftPattern)
 
     // Data codewords for this row
     for (let col = 0; col < cols; col++) {
-      const cwIndex = row * cols + col;
-      const cw = cwIndex < allCodewords.length ? allCodewords[cwIndex]! : 900; // padding
-      const pattern = getCodewordPattern(cw, cluster);
-      modulePos = writePattern(rowModules, modulePos, pattern);
+      const cwIndex = row * cols + col
+      const cw = cwIndex < allCodewords.length ? allCodewords[cwIndex]! : 900 // padding
+      const pattern = getCodewordPattern(cw, cluster)
+      modulePos = writePattern(rowModules, modulePos, pattern)
     }
 
     if (compact) {
       // Compact mode: 1-module stop bar
-      rowModules[modulePos] = true;
+      rowModules[modulePos] = true
     } else {
       // Right row indicator
-      const rightIndicator = computeRightIndicator(row, rows, cols, ecLevel);
-      const rightPattern = getCodewordPattern(rightIndicator, cluster);
-      modulePos = writePattern(rowModules, modulePos, rightPattern);
+      const rightIndicator = computeRightIndicator(row, rows, cols, ecLevel)
+      const rightPattern = getCodewordPattern(rightIndicator, cluster)
+      modulePos = writePattern(rowModules, modulePos, rightPattern)
 
       // Stop pattern
-      writePattern(rowModules, modulePos, STOP_PATTERN as number[]);
+      writePattern(rowModules, modulePos, STOP_PATTERN as number[])
     }
 
-    matrix.push(rowModules);
+    matrix.push(rowModules)
   }
 
-  return matrix;
+  return matrix
 }
 
 /**
@@ -253,18 +253,18 @@ function buildMatrix(
  * Returns the new module position.
  */
 function writePattern(modules: boolean[], startPos: number, pattern: number[]): number {
-  let pos = startPos;
+  let pos = startPos
   for (let i = 0; i < pattern.length; i++) {
-    const width = pattern[i]!;
-    const isBar = i % 2 === 0; // even index = bar, odd index = space
+    const width = pattern[i]!
+    const isBar = i % 2 === 0 // even index = bar, odd index = space
     for (let w = 0; w < width; w++) {
       if (pos < modules.length) {
-        modules[pos] = isBar;
+        modules[pos] = isBar
       }
-      pos++;
+      pos++
     }
   }
-  return pos;
+  return pos
 }
 
 /**
@@ -276,18 +276,18 @@ function writePattern(modules: boolean[], startPos: number, pattern: number[]): 
  * - Cluster 6 (row % 3 == 2): (row/3) * 30 + (cols-1)
  */
 function computeLeftIndicator(row: number, rows: number, cols: number, ecLevel: number): number {
-  const clusterIndex = row % 3;
-  const rowGroup = Math.floor(row / 3);
+  const clusterIndex = row % 3
+  const rowGroup = Math.floor(row / 3)
 
   switch (clusterIndex) {
     case 0:
-      return rowGroup * 30 + Math.floor((rows - 1) / 3);
+      return rowGroup * 30 + Math.floor((rows - 1) / 3)
     case 1:
-      return rowGroup * 30 + ecLevel * 3 + ((rows - 1) % 3);
+      return rowGroup * 30 + ecLevel * 3 + ((rows - 1) % 3)
     case 2:
-      return rowGroup * 30 + (cols - 1);
+      return rowGroup * 30 + (cols - 1)
     default:
-      return 0;
+      return 0
   }
 }
 
@@ -300,19 +300,19 @@ function computeLeftIndicator(row: number, rows: number, cols: number, ecLevel: 
  * - Cluster 6 (row % 3 == 2): (row/3) * 30 + ecLevel * 3 + (rows-1) % 3
  */
 function computeRightIndicator(row: number, rows: number, cols: number, ecLevel: number): number {
-  const clusterIndex = row % 3;
-  const rowGroup = Math.floor(row / 3);
+  const clusterIndex = row % 3
+  const rowGroup = Math.floor(row / 3)
 
   switch (clusterIndex) {
     case 0:
-      return rowGroup * 30 + (cols - 1);
+      return rowGroup * 30 + (cols - 1)
     case 1:
-      return rowGroup * 30 + Math.floor((rows - 1) / 3);
+      return rowGroup * 30 + Math.floor((rows - 1) / 3)
     case 2:
-      return rowGroup * 30 + ecLevel * 3 + ((rows - 1) % 3);
+      return rowGroup * 30 + ecLevel * 3 + ((rows - 1) % 3)
     default:
-      return 0;
+      return 0
   }
 }
 
-export type { PDF417Options as PDF417EncoderOptions };
+export type { PDF417Options as PDF417EncoderOptions }

--- a/src/encoders/pdf417/tables.ts
+++ b/src/encoders/pdf417/tables.ts
@@ -9,10 +9,10 @@
  */
 
 /** Start pattern: 17 modules — bar,space,bar,space,bar,space,bar,space */
-export const START_PATTERN: readonly number[] = [8, 1, 1, 1, 1, 1, 1, 3];
+export const START_PATTERN: readonly number[] = [8, 1, 1, 1, 1, 1, 1, 3]
 
 /** Stop pattern: 18 modules (includes terminating bar) — bar,space,bar,space,bar,space,bar,space,bar */
-export const STOP_PATTERN: readonly number[] = [7, 1, 1, 1, 1, 1, 1, 2, 1];
+export const STOP_PATTERN: readonly number[] = [7, 1, 1, 1, 1, 1, 1, 2, 1]
 
 /**
  * PDF417 codeword-to-module-pattern tables from ISO/IEC 15438:2001(E) Annex A.
@@ -214,28 +214,28 @@ const CLUSTER_2: number[] = [
   0x1c7ea,
 ];
 
-const CLUSTERS = [CLUSTER_0, CLUSTER_1, CLUSTER_2];
+const CLUSTERS = [CLUSTER_0, CLUSTER_1, CLUSTER_2]
 
 /**
  * Convert a 17-bit module bitmask to an array of 8 bar/space widths.
  * The bitmask starts with a bar (1-bit) and ends with a space (0-bit).
  */
 function bitmaskToWidths(bitmask: number): number[] {
-  const widths: number[] = [];
-  let current = (bitmask >>> 16) & 1;
-  let count = 1;
+  const widths: number[] = []
+  let current = (bitmask >>> 16) & 1
+  let count = 1
   for (let i = 15; i >= 0; i--) {
-    const bit = (bitmask >>> i) & 1;
+    const bit = (bitmask >>> i) & 1
     if (bit === current) {
-      count++;
+      count++
     } else {
-      widths.push(count);
-      current = bit;
-      count = 1;
+      widths.push(count)
+      current = bit
+      count = 1
     }
   }
-  widths.push(count);
-  return widths;
+  widths.push(count)
+  return widths
 }
 
 /**
@@ -245,8 +245,8 @@ function bitmaskToWidths(bitmask: number): number[] {
  * @returns Array of 8 bar/space widths totaling 17 modules
  */
 export function getCodewordPattern(codeword: number, cluster: number): number[] {
-  const clusterIndex = cluster / 3;
-  const table = CLUSTERS[clusterIndex]!;
+  const clusterIndex = cluster / 3
+  const table = CLUSTERS[clusterIndex]!
   if (codeword < 0 || codeword >= table.length) {
     throw new Error(
       "Codeword " +
@@ -256,9 +256,9 @@ export function getCodewordPattern(codeword: number, cluster: number): number[] 
         " (max " +
         (table.length - 1) +
         ")",
-    );
+    )
   }
-  return bitmaskToWidths(table[codeword]!);
+  return bitmaskToWidths(table[codeword]!)
 }
 
 /**
@@ -266,7 +266,7 @@ export function getCodewordPattern(codeword: number, cluster: number): number[] 
  * Cluster cycles: row 0 -> cluster 0, row 1 -> cluster 3, row 2 -> cluster 6, row 3 -> cluster 0, etc.
  */
 export function getRowCluster(row: number): number {
-  return (row % 3) * 3;
+  return (row % 3) * 3
 }
 
 // ---- Text compaction sub-mode tables ----
@@ -355,7 +355,7 @@ export const TEXT_SWITCH = {
 
   // from Punct
   PUNCT_TO_ALPHA: 29, // PAL - latch to alpha
-} as const;
+} as const
 
 /** High-level mode latch codewords */
 export const MODE_LATCH = {
@@ -363,4 +363,4 @@ export const MODE_LATCH = {
   BYTE_COMPACTION: 901,
   NUMERIC_COMPACTION: 902,
   BYTE_COMPACTION_6: 924, // byte compaction, groups of 6
-} as const;
+} as const

--- a/src/encoders/pharmacode.ts
+++ b/src/encoders/pharmacode.ts
@@ -4,14 +4,14 @@
  * Encodes numeric values from 3 to 131070
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Bar widths: thin bar = 2 modules, thick bar = 4 modules
-const THIN_BAR = 2;
-const THICK_BAR = 4;
+const THIN_BAR = 2
+const THICK_BAR = 4
 
 // Gap between bars: 2 modules
-const GAP = 2;
+const GAP = 2
 
 /**
  * Encode a Pharmacode barcode
@@ -26,35 +26,35 @@ const GAP = 2;
  */
 export function encodePharmacode(value: number): number[] {
   if (!Number.isInteger(value)) {
-    throw new InvalidInputError(`Pharmacode value must be an integer, got ${value}`);
+    throw new InvalidInputError(`Pharmacode value must be an integer, got ${value}`)
   }
 
   if (value < 3 || value > 131070) {
-    throw new InvalidInputError(`Pharmacode value must be between 3 and 131070, got ${value}`);
+    throw new InvalidInputError(`Pharmacode value must be between 3 and 131070, got ${value}`)
   }
 
   // Generate bar widths (right-to-left)
-  const barWidths: number[] = [];
-  let num = value;
+  const barWidths: number[] = []
+  let num = value
 
   while (num > 0) {
     if (num % 2 === 0) {
-      barWidths.unshift(THICK_BAR);
-      num = (num - 2) / 2;
+      barWidths.unshift(THICK_BAR)
+      num = (num - 2) / 2
     } else {
-      barWidths.unshift(THIN_BAR);
-      num = (num - 1) / 2;
+      barWidths.unshift(THIN_BAR)
+      num = (num - 1) / 2
     }
   }
 
   // Convert to alternating bar/space array
-  const bars: number[] = [];
+  const bars: number[] = []
   for (let i = 0; i < barWidths.length; i++) {
-    bars.push(barWidths[i]!);
+    bars.push(barWidths[i]!)
     if (i < barWidths.length - 1) {
-      bars.push(GAP); // gap between bars
+      bars.push(GAP) // gap between bars
     }
   }
 
-  return bars;
+  return bars
 }

--- a/src/encoders/plessey.ts
+++ b/src/encoders/plessey.ts
@@ -6,7 +6,7 @@
  * where 0 = narrow bar + narrow space, 1 = wide bar + wide space
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Plessey encoding: each hex digit maps to 4-bit pattern
 // Each bit: 0 = narrow(1) bar + narrow(1) space, 1 = wide(2) bar + wide(2) space
@@ -27,12 +27,12 @@ const PLESSEY_PATTERNS: Record<string, number[]> = {
   D: [1, 0, 1, 1],
   E: [0, 1, 1, 1],
   F: [1, 1, 1, 1],
-};
+}
 
 // Start: narrow bar, narrow space, wide bar, wide space (1,1,2,2 -> "01" pattern)
-const START_PATTERN = [1, 1, 2, 2];
+const START_PATTERN = [1, 1, 2, 2]
 // Stop: wide bar, narrow space (2,1) — termination
-const STOP_PATTERN = [2, 1];
+const STOP_PATTERN = [2, 1]
 
 /**
  * Calculate Plessey CRC check digits using polynomial division
@@ -40,44 +40,44 @@ const STOP_PATTERN = [2, 1];
  * Produces 8-bit CRC = 2 hex check digits
  */
 function plesseyCRC(digits: string): [number, number] {
-  const POLY = 0x1e9; // x^8+x^7+x^6+x^5+x^3+1
+  const POLY = 0x1e9 // x^8+x^7+x^6+x^5+x^3+1
 
   // Convert hex digits to bit array (LSB first per Plessey convention)
-  const bits: number[] = [];
+  const bits: number[] = []
   for (const ch of digits) {
-    const val = Number.parseInt(ch, 16);
+    const val = Number.parseInt(ch, 16)
     for (let b = 0; b < 4; b++) {
-      bits.push((val >> b) & 1);
+      bits.push((val >> b) & 1)
     }
   }
 
   // Append 8 zero bits for CRC space
   for (let i = 0; i < 8; i++) {
-    bits.push(0);
+    bits.push(0)
   }
 
   // Polynomial division over GF(2)
-  const reg = bits.slice();
+  const reg = bits.slice()
   for (let i = 0; i < reg.length - 8; i++) {
     if (reg[i]) {
       for (let j = 0; j < 9; j++) {
-        reg[i + j]! ^= (POLY >> j) & 1;
+        reg[i + j]! ^= (POLY >> j) & 1
       }
     }
   }
 
   // Last 8 bits are the CRC remainder
-  const crcBits = reg.slice(-8);
+  const crcBits = reg.slice(-8)
 
   // Convert 2 groups of 4 bits (LSB first) to hex digits
-  let crc1 = 0;
-  let crc2 = 0;
+  let crc1 = 0
+  let crc2 = 0
   for (let b = 0; b < 4; b++) {
-    crc1 |= crcBits[b]! << b;
-    crc2 |= crcBits[b + 4]! << b;
+    crc1 |= crcBits[b]! << b
+    crc2 |= crcBits[b + 4]! << b
   }
 
-  return [crc1, crc2];
+  return [crc1, crc2]
 }
 
 /**
@@ -88,27 +88,27 @@ function plesseyCRC(digits: string): [number, number] {
  * @returns Array of bar widths (alternating bar/space)
  */
 export function encodePlessey(text: string): number[] {
-  const upper = text.toUpperCase();
+  const upper = text.toUpperCase()
   if (!/^[0-9A-F]+$/.test(upper)) {
-    throw new InvalidInputError("Plessey only accepts hexadecimal characters (0-9, A-F)");
+    throw new InvalidInputError("Plessey only accepts hexadecimal characters (0-9, A-F)")
   }
   if (upper.length === 0) {
-    throw new InvalidInputError("Plessey input must not be empty");
+    throw new InvalidInputError("Plessey input must not be empty")
   }
 
-  const [crc1, crc2] = plesseyCRC(upper);
-  const dataWithCheck = upper + crc1.toString(16).toUpperCase() + crc2.toString(16).toUpperCase();
+  const [crc1, crc2] = plesseyCRC(upper)
+  const dataWithCheck = upper + crc1.toString(16).toUpperCase() + crc2.toString(16).toUpperCase()
 
-  const bars: number[] = [...START_PATTERN];
+  const bars: number[] = [...START_PATTERN]
 
   for (const ch of dataWithCheck) {
-    const pattern = PLESSEY_PATTERNS[ch]!;
+    const pattern = PLESSEY_PATTERNS[ch]!
     for (const bit of pattern) {
-      bars.push(bit === 0 ? 1 : 2); // bar: narrow or wide
-      bars.push(bit === 0 ? 1 : 2); // space: narrow or wide
+      bars.push(bit === 0 ? 1 : 2) // bar: narrow or wide
+      bars.push(bit === 0 ? 1 : 2) // space: narrow or wide
     }
   }
 
-  bars.push(...STOP_PATTERN);
-  return bars;
+  bars.push(...STOP_PATTERN)
+  return bars
 }

--- a/src/encoders/postnet.ts
+++ b/src/encoders/postnet.ts
@@ -7,7 +7,7 @@
  * PLANET: tall=0, short=1 (inverted)
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // POSTNET digit encoding: each digit = 5 bars (tall=1, short=0)
 // Encoding uses 2-of-5 scheme where exactly 2 bars are tall
@@ -22,15 +22,15 @@ const POSTNET_PATTERNS: number[][] = [
   [1, 0, 0, 0, 1], // 7
   [1, 0, 0, 1, 0], // 8
   [1, 0, 1, 0, 0], // 9
-];
+]
 
 /** Calculate POSTNET/PLANET check digit (sum of digits mod 10, then 10 - remainder) */
 export function postnetCheckDigit(digits: string): number {
-  let sum = 0;
+  let sum = 0
   for (const ch of digits) {
-    sum += Number.parseInt(ch, 10);
+    sum += Number.parseInt(ch, 10)
   }
-  return (10 - (sum % 10)) % 10;
+  return (10 - (sum % 10)) % 10
 }
 
 /**
@@ -44,25 +44,25 @@ export function postnetCheckDigit(digits: string): number {
  * @returns Array of bar heights (1=tall, 0=short) including frame bars
  */
 export function encodePOSTNET(zip: string): number[] {
-  const digits = zip.replace(/[\s-]/g, "");
+  const digits = zip.replace(/[\s-]/g, "")
   if (!/^\d+$/.test(digits)) {
-    throw new InvalidInputError("POSTNET only accepts digits");
+    throw new InvalidInputError("POSTNET only accepts digits")
   }
   if (digits.length !== 5 && digits.length !== 9 && digits.length !== 11) {
-    throw new InvalidInputError("POSTNET requires 5, 9, or 11 digits");
+    throw new InvalidInputError("POSTNET requires 5, 9, or 11 digits")
   }
 
-  const check = postnetCheckDigit(digits);
-  const allDigits = digits + check;
+  const check = postnetCheckDigit(digits)
+  const allDigits = digits + check
 
-  const bars: number[] = [1]; // Start frame bar (tall)
+  const bars: number[] = [1] // Start frame bar (tall)
   for (const ch of allDigits) {
-    const digit = Number.parseInt(ch, 10);
-    bars.push(...POSTNET_PATTERNS[digit]!);
+    const digit = Number.parseInt(ch, 10)
+    bars.push(...POSTNET_PATTERNS[digit]!)
   }
-  bars.push(1); // End frame bar (tall)
+  bars.push(1) // End frame bar (tall)
 
-  return bars;
+  return bars
 }
 
 /**
@@ -73,25 +73,25 @@ export function encodePOSTNET(zip: string): number[] {
  * @returns Array of bar heights (1=tall, 0=short)
  */
 export function encodePLANET(code: string): number[] {
-  const digits = code.replace(/[\s-]/g, "");
+  const digits = code.replace(/[\s-]/g, "")
   if (!/^\d+$/.test(digits)) {
-    throw new InvalidInputError("PLANET only accepts digits");
+    throw new InvalidInputError("PLANET only accepts digits")
   }
   if (digits.length !== 11 && digits.length !== 13) {
-    throw new InvalidInputError("PLANET requires 11 or 13 digits");
+    throw new InvalidInputError("PLANET requires 11 or 13 digits")
   }
 
-  const check = postnetCheckDigit(digits);
-  const allDigits = digits + check;
+  const check = postnetCheckDigit(digits)
+  const allDigits = digits + check
 
-  const bars: number[] = [1]; // Start frame bar
+  const bars: number[] = [1] // Start frame bar
   for (const ch of allDigits) {
-    const digit = Number.parseInt(ch, 10);
+    const digit = Number.parseInt(ch, 10)
     // PLANET inverts: tall becomes short, short becomes tall
-    const pattern = POSTNET_PATTERNS[digit]!;
-    bars.push(...pattern.map((b) => (b === 1 ? 0 : 1)));
+    const pattern = POSTNET_PATTERNS[digit]!
+    bars.push(...pattern.map((b) => (b === 1 ? 0 : 1)))
   }
-  bars.push(1); // End frame bar
+  bars.push(1) // End frame bar
 
-  return bars;
+  return bars
 }

--- a/src/encoders/qr/data.ts
+++ b/src/encoders/qr/data.ts
@@ -2,10 +2,10 @@
  * QR Code data encoding and bitstream construction
  */
 
-import type { ErrorCorrectionLevel, QRCodeOptions } from "./types";
-import { MODE_INDICATOR } from "./types";
-import { getECInfo, getCharCountBits } from "./tables";
-import { selectVersion, selectMode } from "./version";
+import type { ErrorCorrectionLevel, QRCodeOptions } from "./types"
+import { MODE_INDICATOR } from "./types"
+import { getECInfo, getCharCountBits } from "./tables"
+import { selectVersion, selectMode } from "./version"
 import {
   encodeNumericData,
   encodeAlphanumericData,
@@ -13,29 +13,29 @@ import {
   encodeKanjiData,
   unicodeToShiftJIS,
   pushBits,
-} from "./mode";
-import { addErrorCorrection } from "./reed-solomon";
+} from "./mode"
+import { addErrorCorrection } from "./reed-solomon"
 
 export interface EncodedData {
-  version: number;
-  ecLevel: ErrorCorrectionLevel;
-  bits: number[];
+  version: number
+  ecLevel: ErrorCorrectionLevel
+  bits: number[]
 }
 
 /**
  * Encode text into QR code data bits with error correction
  */
 export function encodeData(text: string, options: QRCodeOptions = {}): EncodedData {
-  const ecLevel = options.ecLevel ?? "M";
-  const mode = selectMode(text, options.mode);
-  const version = selectVersion(text, ecLevel, mode, options.version);
-  const ecInfo = getECInfo(version, ecLevel);
+  const ecLevel = options.ecLevel ?? "M"
+  const mode = selectMode(text, options.mode)
+  const version = selectVersion(text, ecLevel, mode, options.version)
+  const ecInfo = getECInfo(version, ecLevel)
 
   // Build data bitstream
-  const dataBits = buildDataBits(text, mode, version, ecInfo.totalDataCodewords);
+  const dataBits = buildDataBits(text, mode, version, ecInfo.totalDataCodewords)
 
   // Convert bits to bytes
-  const dataBytes = bitsToBytes(dataBits);
+  const dataBytes = bitsToBytes(dataBits)
 
   // Add error correction with interleaving
   const finalBytes = addErrorCorrection(
@@ -45,15 +45,15 @@ export function encodeData(text: string, options: QRCodeOptions = {}): EncodedDa
     ecInfo.group1DataCW,
     ecInfo.group2Blocks,
     ecInfo.group2DataCW,
-  );
+  )
 
   // Convert back to bits
-  const bits: number[] = [];
+  const bits: number[] = []
   for (const byte of finalBytes) {
-    pushBits(bits, byte, 8);
+    pushBits(bits, byte, 8)
   }
 
-  return { version, ecLevel, bits };
+  return { version, ecLevel, bits }
 }
 
 /** Build the data bitstream (before EC) */
@@ -63,66 +63,66 @@ function buildDataBits(
   version: number,
   totalDataCodewords: number,
 ): number[] {
-  const bits: number[] = [];
-  const charCountBits = getCharCountBits(version, mode);
-  const data = new TextEncoder().encode(text);
+  const bits: number[] = []
+  const charCountBits = getCharCountBits(version, mode)
+  const data = new TextEncoder().encode(text)
 
   // Mode indicator (4 bits)
-  pushBits(bits, MODE_INDICATOR[mode], 4);
+  pushBits(bits, MODE_INDICATOR[mode], 4)
 
   // Character count
-  const charCount = mode === "byte" ? data.length : text.length;
-  pushBits(bits, charCount, charCountBits);
+  const charCount = mode === "byte" ? data.length : text.length
+  pushBits(bits, charCount, charCountBits)
 
   // Data bits
   switch (mode) {
     case "numeric":
-      bits.push(...encodeNumericData(text));
-      break;
+      bits.push(...encodeNumericData(text))
+      break
     case "alphanumeric":
-      bits.push(...encodeAlphanumericData(text));
-      break;
+      bits.push(...encodeAlphanumericData(text))
+      break
     case "byte":
-      bits.push(...encodeByteData(data));
-      break;
+      bits.push(...encodeByteData(data))
+      break
     case "kanji": {
-      const sjisValues = unicodeToShiftJIS(text);
-      bits.push(...encodeKanjiData(sjisValues));
-      break;
+      const sjisValues = unicodeToShiftJIS(text)
+      bits.push(...encodeKanjiData(sjisValues))
+      break
     }
   }
 
   // Terminator
-  const totalDataBits = totalDataCodewords * 8;
-  const terminatorLen = Math.min(4, totalDataBits - bits.length);
+  const totalDataBits = totalDataCodewords * 8
+  const terminatorLen = Math.min(4, totalDataBits - bits.length)
   if (terminatorLen > 0) {
-    pushBits(bits, 0, terminatorLen);
+    pushBits(bits, 0, terminatorLen)
   }
 
   // Pad to byte boundary
   while (bits.length % 8 !== 0) {
-    bits.push(0);
+    bits.push(0)
   }
 
   // Pad to capacity with alternating bytes
-  let padToggle = true;
+  let padToggle = true
   while (bits.length < totalDataBits) {
-    pushBits(bits, padToggle ? 236 : 17, 8);
-    padToggle = !padToggle;
+    pushBits(bits, padToggle ? 236 : 17, 8)
+    padToggle = !padToggle
   }
 
-  return bits;
+  return bits
 }
 
 /** Convert bit array to byte array */
 function bitsToBytes(bits: number[]): number[] {
-  const bytes: number[] = [];
+  const bytes: number[] = []
   for (let i = 0; i < bits.length; i += 8) {
-    let byte = 0;
+    let byte = 0
     for (let j = 0; j < 8 && i + j < bits.length; j++) {
-      byte = (byte << 1) | bits[i + j]!;
+      byte = (byte << 1) | bits[i + j]!
     }
-    bytes.push(byte);
+    bytes.push(byte)
   }
-  return bytes;
+  return bytes
 }

--- a/src/encoders/qr/format.ts
+++ b/src/encoders/qr/format.ts
@@ -3,31 +3,31 @@
  * BCH encoding for format info, Golay encoding for version info
  */
 
-import type { Module } from "./matrix";
-import type { ErrorCorrectionLevel } from "./types";
-import { EC_LEVEL_BITS } from "./types";
-import { VERSION_INFO } from "./tables";
+import type { Module } from "./matrix"
+import type { ErrorCorrectionLevel } from "./types"
+import { EC_LEVEL_BITS } from "./types"
+import { VERSION_INFO } from "./tables"
 
 /**
  * Format info: 15-bit BCH code
  * 2 bits EC level + 3 bits mask -> 5 data bits -> 15 bit BCH with XOR mask 0x5412
  */
-const FORMAT_MASK = 0x5412;
+const FORMAT_MASK = 0x5412
 
 /** Generate 15-bit format info for given EC level and mask */
 export function generateFormatInfo(ecLevel: ErrorCorrectionLevel, mask: number): number {
-  const data = (EC_LEVEL_BITS[ecLevel] << 3) | mask;
-  let bch = data << 10;
-  let gen = 0x537; // Generator polynomial for BCH(15,5)
+  const data = (EC_LEVEL_BITS[ecLevel] << 3) | mask
+  let bch = data << 10
+  let gen = 0x537 // Generator polynomial for BCH(15,5)
 
   // Long division
   for (let i = 4; i >= 0; i--) {
     if (bch & (1 << (i + 10))) {
-      bch ^= gen << i;
+      bch ^= gen << i
     }
   }
 
-  return ((data << 10) | bch) ^ FORMAT_MASK;
+  return ((data << 10) | bch) ^ FORMAT_MASK
 }
 
 /** Write format info to the matrix at the reserved positions */
@@ -36,8 +36,8 @@ export function writeFormatInfo(
   ecLevel: ErrorCorrectionLevel,
   mask: number,
 ): void {
-  const size = matrix.length;
-  const formatInfo = generateFormatInfo(ecLevel, mask);
+  const size = matrix.length
+  const formatInfo = generateFormatInfo(ecLevel, mask)
 
   // Around top-left finder pattern
   // Horizontal: row 8, columns 0-7 (skipping col 6 timing) and col 8
@@ -57,44 +57,44 @@ export function writeFormatInfo(
     [2, 8],
     [1, 8],
     [0, 8],
-  ];
+  ]
 
   for (let i = 0; i < 15; i++) {
-    const bit = ((formatInfo >> (14 - i)) & 1) === 1;
-    const [r, c] = horizontalPositions[i]!;
-    matrix[r]![c] = bit;
+    const bit = ((formatInfo >> (14 - i)) & 1) === 1
+    const [r, c] = horizontalPositions[i]!
+    matrix[r]![c] = bit
   }
 
   // Bottom-left: column 8, rows from bottom
   for (let i = 0; i < 7; i++) {
-    const bit = ((formatInfo >> (14 - i)) & 1) === 1;
-    matrix[size - 1 - i]![8] = bit;
+    const bit = ((formatInfo >> (14 - i)) & 1) === 1
+    matrix[size - 1 - i]![8] = bit
   }
 
   // Top-right: row 8, columns from right
   for (let i = 0; i < 8; i++) {
-    const bit = ((formatInfo >> (7 - i)) & 1) === 1;
-    matrix[8]![size - 8 + i] = bit;
+    const bit = ((formatInfo >> (7 - i)) & 1) === 1
+    matrix[8]![size - 8 + i] = bit
   }
 }
 
 /** Write version info for version 7+ */
 export function writeVersionInfo(matrix: Module[][], version: number): void {
-  if (version < 7) return;
-  const size = matrix.length;
-  const versionInfo = VERSION_INFO[version]!;
+  if (version < 7) return
+  const size = matrix.length
+  const versionInfo = VERSION_INFO[version]!
 
   // 18 bits: bit 0 is LSB
   // Bottom-left block: 6 rows x 3 cols at rows [size-11, size-10, size-9], cols [0..5]
   // Top-right block: 3 rows x 6 cols at rows [0..5], cols [size-11, size-10, size-9]
   for (let i = 0; i < 18; i++) {
-    const bit = ((versionInfo >> i) & 1) === 1;
-    const row = Math.floor(i / 3);
-    const col = i % 3;
+    const bit = ((versionInfo >> i) & 1) === 1
+    const row = Math.floor(i / 3)
+    const col = i % 3
 
     // Bottom-left: rows (size-11+col), cols (row)
-    matrix[size - 11 + col]![row] = bit;
+    matrix[size - 11 + col]![row] = bit
     // Top-right: rows (row), cols (size-11+col)
-    matrix[row]![size - 11 + col] = bit;
+    matrix[row]![size - 11 + col] = bit
   }
 }

--- a/src/encoders/qr/index.ts
+++ b/src/encoders/qr/index.ts
@@ -3,14 +3,14 @@
  * Supports versions 1-40, all EC levels (L/M/Q/H), all encoding modes
  */
 
-import type { QRCodeOptions } from "./types";
-import { encodeData } from "./data";
-import { createMatrix, placeFunctionPatterns, placeData } from "./matrix";
-import { selectBestMask, applyMask } from "./mask";
-import { writeFormatInfo, writeVersionInfo } from "./format";
-import { InvalidInputError } from "../../errors";
+import type { QRCodeOptions } from "./types"
+import { encodeData } from "./data"
+import { createMatrix, placeFunctionPatterns, placeData } from "./matrix"
+import { selectBestMask, applyMask } from "./mask"
+import { writeFormatInfo, writeVersionInfo } from "./format"
+import { InvalidInputError } from "../../errors"
 
-export type { QRCodeOptions, ErrorCorrectionLevel, EncodingMode, QRSegment } from "./types";
+export type { QRCodeOptions, ErrorCorrectionLevel, EncodingMode, QRSegment } from "./types"
 
 /**
  * Encode text as a QR code matrix
@@ -18,30 +18,30 @@ export type { QRCodeOptions, ErrorCorrectionLevel, EncodingMode, QRSegment } fro
  */
 export function encodeQR(text: string, options: QRCodeOptions = {}): boolean[][] {
   if (text.length === 0) {
-    throw new InvalidInputError("QR Code input must not be empty");
+    throw new InvalidInputError("QR Code input must not be empty")
   }
-  const { version, ecLevel, bits } = encodeData(text, options);
-  const size = version * 4 + 17;
+  const { version, ecLevel, bits } = encodeData(text, options)
+  const size = version * 4 + 17
 
   // Create matrix and place function patterns
-  const matrix = createMatrix(size);
-  placeFunctionPatterns(matrix, version);
+  const matrix = createMatrix(size)
+  placeFunctionPatterns(matrix, version)
 
   // Place data bits
-  placeData(matrix, bits, version);
+  placeData(matrix, bits, version)
 
   // Select and apply best mask
-  const bestMask = selectBestMask(matrix, size, version, options.mask);
-  applyMask(matrix, bestMask, size, version);
+  const bestMask = selectBestMask(matrix, size, version, options.mask)
+  applyMask(matrix, bestMask, size, version)
 
   // Write format info
-  writeFormatInfo(matrix, ecLevel, bestMask);
+  writeFormatInfo(matrix, ecLevel, bestMask)
 
   // Write version info
   if (version >= 7) {
-    writeVersionInfo(matrix, version);
+    writeVersionInfo(matrix, version)
   }
 
   // Convert to boolean array (null -> false)
-  return matrix.map((row) => row.map((cell) => cell === true));
+  return matrix.map((row) => row.map((cell) => cell === true))
 }

--- a/src/encoders/qr/mask.ts
+++ b/src/encoders/qr/mask.ts
@@ -3,41 +3,41 @@
  * 8 mask patterns, 4 penalty rules
  */
 
-import type { Module } from "./matrix";
-import { isDataModule } from "./matrix";
+import type { Module } from "./matrix"
+import { isDataModule } from "./matrix"
 
 /** Get mask function for a given mask pattern (0-7) */
 export function getMaskFn(mask: number): (r: number, c: number) => boolean {
   switch (mask) {
     case 0:
-      return (r, c) => (r + c) % 2 === 0;
+      return (r, c) => (r + c) % 2 === 0
     case 1:
-      return (r) => r % 2 === 0;
+      return (r) => r % 2 === 0
     case 2:
-      return (_, c) => c % 3 === 0;
+      return (_, c) => c % 3 === 0
     case 3:
-      return (r, c) => (r + c) % 3 === 0;
+      return (r, c) => (r + c) % 3 === 0
     case 4:
-      return (r, c) => (Math.floor(r / 2) + Math.floor(c / 3)) % 2 === 0;
+      return (r, c) => (Math.floor(r / 2) + Math.floor(c / 3)) % 2 === 0
     case 5:
-      return (r, c) => ((r * c) % 2) + ((r * c) % 3) === 0;
+      return (r, c) => ((r * c) % 2) + ((r * c) % 3) === 0
     case 6:
-      return (r, c) => (((r * c) % 2) + ((r * c) % 3)) % 2 === 0;
+      return (r, c) => (((r * c) % 2) + ((r * c) % 3)) % 2 === 0
     case 7:
-      return (r, c) => (((r + c) % 2) + ((r * c) % 3)) % 2 === 0;
+      return (r, c) => (((r + c) % 2) + ((r * c) % 3)) % 2 === 0
     default:
-      return () => false;
+      return () => false
   }
 }
 
 /** Apply a mask pattern to the matrix (only data modules) */
 export function applyMask(matrix: Module[][], mask: number, size: number, version: number): void {
-  const fn = getMaskFn(mask);
+  const fn = getMaskFn(mask)
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
       if (isDataModule(r, c, size, version)) {
         if (fn(r, c)) {
-          matrix[r]![c] = !matrix[r]![c];
+          matrix[r]![c] = !matrix[r]![c]
         }
       }
     }
@@ -55,23 +55,23 @@ export function selectBestMask(
   requestedMask?: number,
 ): number {
   if (requestedMask !== undefined && requestedMask >= 0 && requestedMask <= 7) {
-    return requestedMask;
+    return requestedMask
   }
 
-  let bestMask = 0;
-  let bestScore = Infinity;
+  let bestMask = 0
+  let bestScore = Infinity
 
   for (let mask = 0; mask < 8; mask++) {
-    const copy = matrix.map((row) => [...row]);
-    applyMask(copy, mask, size, version);
-    const score = evaluatePenalty(copy, size);
+    const copy = matrix.map((row) => [...row])
+    applyMask(copy, mask, size, version)
+    const score = evaluatePenalty(copy, size)
     if (score < bestScore) {
-      bestScore = score;
-      bestMask = mask;
+      bestScore = score
+      bestMask = mask
     }
   }
 
-  return bestMask;
+  return bestMask
 }
 
 /**
@@ -84,7 +84,7 @@ export function evaluatePenalty(matrix: Module[][], size: number): number {
     penaltyRule2(matrix, size) +
     penaltyRule3(matrix, size) +
     penaltyRule4(matrix, size)
-  );
+  )
 }
 
 /**
@@ -92,37 +92,37 @@ export function evaluatePenalty(matrix: Module[][], size: number): number {
  * 5+ same-color → 3 + (count - 5) points
  */
 function penaltyRule1(matrix: Module[][], size: number): number {
-  let score = 0;
+  let score = 0
 
   // Rows
   for (let r = 0; r < size; r++) {
-    let count = 1;
+    let count = 1
     for (let c = 1; c < size; c++) {
       if (!!matrix[r]![c] === !!matrix[r]![c - 1]) {
-        count++;
-        if (count === 5) score += 3;
-        else if (count > 5) score++;
+        count++
+        if (count === 5) score += 3
+        else if (count > 5) score++
       } else {
-        count = 1;
+        count = 1
       }
     }
   }
 
   // Columns
   for (let c = 0; c < size; c++) {
-    let count = 1;
+    let count = 1
     for (let r = 1; r < size; r++) {
       if (!!matrix[r]![c] === !!matrix[r - 1]![c]) {
-        count++;
-        if (count === 5) score += 3;
-        else if (count > 5) score++;
+        count++
+        if (count === 5) score += 3
+        else if (count > 5) score++
       } else {
-        count = 1;
+        count = 1
       }
     }
   }
 
-  return score;
+  return score
 }
 
 /**
@@ -130,22 +130,22 @@ function penaltyRule1(matrix: Module[][], size: number): number {
  * 3 points for each 2x2 block of same color
  */
 function penaltyRule2(matrix: Module[][], size: number): number {
-  let score = 0;
+  let score = 0
 
   for (let r = 0; r < size - 1; r++) {
     for (let c = 0; c < size - 1; c++) {
-      const val = !!matrix[r]![c];
+      const val = !!matrix[r]![c]
       if (
         val === !!matrix[r]![c + 1] &&
         val === !!matrix[r + 1]![c] &&
         val === !!matrix[r + 1]![c + 1]
       ) {
-        score += 3;
+        score += 3
       }
     }
   }
 
-  return score;
+  return score
 }
 
 /**
@@ -154,42 +154,42 @@ function penaltyRule2(matrix: Module[][], size: number): number {
  * Pattern: dark-light-dark(3)-light-dark followed/preceded by 4 light modules
  */
 function penaltyRule3(matrix: Module[][], size: number): number {
-  let score = 0;
+  let score = 0
   // Pattern: 1,0,1,1,1,0,1,0,0,0,0 or 0,0,0,0,1,0,1,1,1,0,1
-  const p1 = [1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0];
-  const p2 = [0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1];
+  const p1 = [1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0]
+  const p2 = [0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1]
 
   for (let r = 0; r < size; r++) {
     for (let c = 0; c <= size - 11; c++) {
-      let match1 = true;
-      let match2 = true;
+      let match1 = true
+      let match2 = true
       for (let i = 0; i < 11; i++) {
-        const val = matrix[r]![c + i] ? 1 : 0;
-        if (val !== p1[i]) match1 = false;
-        if (val !== p2[i]) match2 = false;
-        if (!match1 && !match2) break;
+        const val = matrix[r]![c + i] ? 1 : 0
+        if (val !== p1[i]) match1 = false
+        if (val !== p2[i]) match2 = false
+        if (!match1 && !match2) break
       }
-      if (match1) score += 40;
-      if (match2) score += 40;
+      if (match1) score += 40
+      if (match2) score += 40
     }
   }
 
   for (let c = 0; c < size; c++) {
     for (let r = 0; r <= size - 11; r++) {
-      let match1 = true;
-      let match2 = true;
+      let match1 = true
+      let match2 = true
       for (let i = 0; i < 11; i++) {
-        const val = matrix[r + i]![c] ? 1 : 0;
-        if (val !== p1[i]) match1 = false;
-        if (val !== p2[i]) match2 = false;
-        if (!match1 && !match2) break;
+        const val = matrix[r + i]![c] ? 1 : 0
+        if (val !== p1[i]) match1 = false
+        if (val !== p2[i]) match2 = false
+        if (!match1 && !match2) break
       }
-      if (match1) score += 40;
-      if (match2) score += 40;
+      if (match1) score += 40
+      if (match2) score += 40
     }
   }
 
-  return score;
+  return score
 }
 
 /**
@@ -198,15 +198,15 @@ function penaltyRule3(matrix: Module[][], size: number): number {
  * 10 points per 5% step
  */
 function penaltyRule4(matrix: Module[][], size: number): number {
-  let dark = 0;
+  let dark = 0
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
-      if (matrix[r]![c]) dark++;
+      if (matrix[r]![c]) dark++
     }
   }
-  const total = size * size;
-  const percent = (dark * 100) / total;
-  const prev5 = Math.floor(percent / 5) * 5;
-  const next5 = prev5 + 5;
-  return Math.min(Math.abs(prev5 - 50) / 5, Math.abs(next5 - 50) / 5) * 10;
+  const total = size * size
+  const percent = (dark * 100) / total
+  const prev5 = Math.floor(percent / 5) * 5
+  const next5 = prev5 + 5
+  return Math.min(Math.abs(prev5 - 50) / 5, Math.abs(next5 - 50) / 5) * 10
 }

--- a/src/encoders/qr/matrix.ts
+++ b/src/encoders/qr/matrix.ts
@@ -3,91 +3,91 @@
  * Function patterns, data placement, alignment patterns
  */
 
-import { ALIGNMENT_POSITIONS } from "./tables";
+import { ALIGNMENT_POSITIONS } from "./tables"
 
-export type Module = boolean | null;
+export type Module = boolean | null
 
 /** Create an empty matrix of the given size */
 export function createMatrix(size: number): Module[][] {
-  return Array.from({ length: size }, () => Array.from<Module>({ length: size }).fill(null));
+  return Array.from({ length: size }, () => Array.from<Module>({ length: size }).fill(null))
 }
 
 /** Place all function patterns on the matrix */
 export function placeFunctionPatterns(matrix: Module[][], version: number): void {
-  const size = matrix.length;
+  const size = matrix.length
 
   // Finder patterns (3 corners)
-  placeFinder(matrix, 0, 0);
-  placeFinder(matrix, size - 7, 0);
-  placeFinder(matrix, 0, size - 7);
+  placeFinder(matrix, 0, 0)
+  placeFinder(matrix, size - 7, 0)
+  placeFinder(matrix, 0, size - 7)
 
   // Timing patterns
-  placeTiming(matrix, size);
+  placeTiming(matrix, size)
 
   // Alignment patterns
-  placeAlignmentPatterns(matrix, version);
+  placeAlignmentPatterns(matrix, version)
 
   // Dark module
-  matrix[4 * version + 9]![8] = true;
+  matrix[4 * version + 9]![8] = true
 
   // Reserve format info areas
-  reserveFormatInfo(matrix, size);
+  reserveFormatInfo(matrix, size)
 
   // Reserve version info areas (v7+)
   if (version >= 7) {
-    reserveVersionInfo(matrix, size);
+    reserveVersionInfo(matrix, size)
   }
 }
 
 /** Place a 7x7 finder pattern with separator at (row, col) */
 function placeFinder(matrix: Module[][], row: number, col: number): void {
-  const size = matrix.length;
+  const size = matrix.length
 
   for (let r = 0; r < 7; r++) {
     for (let c = 0; c < 7; c++) {
-      const isOuter = r === 0 || r === 6 || c === 0 || c === 6;
-      const isInner = r >= 2 && r <= 4 && c >= 2 && c <= 4;
-      matrix[row + r]![col + c] = isOuter || isInner;
+      const isOuter = r === 0 || r === 6 || c === 0 || c === 6
+      const isInner = r >= 2 && r <= 4 && c >= 2 && c <= 4
+      matrix[row + r]![col + c] = isOuter || isInner
     }
   }
 
   // Separator (white border)
   for (let i = -1; i <= 7; i++) {
-    setSafe(matrix, row - 1, col + i, false, size);
-    setSafe(matrix, row + 7, col + i, false, size);
-    setSafe(matrix, row + i, col - 1, false, size);
-    setSafe(matrix, row + i, col + 7, false, size);
+    setSafe(matrix, row - 1, col + i, false, size)
+    setSafe(matrix, row + 7, col + i, false, size)
+    setSafe(matrix, row + i, col - 1, false, size)
+    setSafe(matrix, row + i, col + 7, false, size)
   }
 }
 
 function setSafe(matrix: Module[][], r: number, c: number, val: boolean, size: number): void {
   if (r >= 0 && r < size && c >= 0 && c < size) {
-    matrix[r]![c] = val;
+    matrix[r]![c] = val
   }
 }
 
 /** Place timing patterns (row 6 and column 6) */
 function placeTiming(matrix: Module[][], size: number): void {
   for (let i = 8; i < size - 8; i++) {
-    if (matrix[6]![i] === null) matrix[6]![i] = i % 2 === 0;
-    if (matrix[i]![6] === null) matrix[i]![6] = i % 2 === 0;
+    if (matrix[6]![i] === null) matrix[6]![i] = i % 2 === 0
+    if (matrix[i]![6] === null) matrix[i]![6] = i % 2 === 0
   }
 }
 
 /** Place alignment patterns for version 2+ */
 function placeAlignmentPatterns(matrix: Module[][], version: number): void {
-  if (version < 2) return;
-  const positions = ALIGNMENT_POSITIONS[version - 1]!;
-  const last = positions.length - 1;
+  if (version < 2) return
+  const positions = ALIGNMENT_POSITIONS[version - 1]!
+  const last = positions.length - 1
 
   for (let i = 0; i < positions.length; i++) {
     for (let j = 0; j < positions.length; j++) {
       // Skip positions that overlap with finder patterns:
       // top-left (first,first), top-right (first,last), bottom-left (last,first)
-      if (i === 0 && j === 0) continue;
-      if (i === 0 && j === last) continue;
-      if (i === last && j === 0) continue;
-      placeAlignment(matrix, positions[i]!, positions[j]!);
+      if (i === 0 && j === 0) continue
+      if (i === 0 && j === last) continue
+      if (i === last && j === 0) continue
+      placeAlignment(matrix, positions[i]!, positions[j]!)
     }
   }
 }
@@ -96,9 +96,9 @@ function placeAlignmentPatterns(matrix: Module[][], version: number): void {
 function placeAlignment(matrix: Module[][], row: number, col: number): void {
   for (let r = -2; r <= 2; r++) {
     for (let c = -2; c <= 2; c++) {
-      const isOuter = Math.abs(r) === 2 || Math.abs(c) === 2;
-      const isCenter = r === 0 && c === 0;
-      matrix[row + r]![col + c] = isOuter || isCenter;
+      const isOuter = Math.abs(r) === 2 || Math.abs(c) === 2
+      const isCenter = r === 0 && c === 0
+      matrix[row + r]![col + c] = isOuter || isCenter
     }
   }
 }
@@ -107,18 +107,18 @@ function placeAlignment(matrix: Module[][], row: number, col: number): void {
 function reserveFormatInfo(matrix: Module[][], size: number): void {
   // Around top-left finder
   for (let i = 0; i <= 8; i++) {
-    if (i < size && matrix[8]![i] === null) matrix[8]![i] = false;
-    if (i < size && matrix[i]![8] === null) matrix[i]![8] = false;
+    if (i < size && matrix[8]![i] === null) matrix[8]![i] = false
+    if (i < size && matrix[i]![8] === null) matrix[i]![8] = false
   }
 
   // Bottom-left
   for (let i = 0; i < 7; i++) {
-    if (matrix[size - 1 - i]![8] === null) matrix[size - 1 - i]![8] = false;
+    if (matrix[size - 1 - i]![8] === null) matrix[size - 1 - i]![8] = false
   }
 
   // Top-right
   for (let i = 0; i < 8; i++) {
-    if (matrix[8]![size - 1 - i] === null) matrix[8]![size - 1 - i] = false;
+    if (matrix[8]![size - 1 - i] === null) matrix[8]![size - 1 - i] = false
   }
 }
 
@@ -127,13 +127,13 @@ function reserveVersionInfo(matrix: Module[][], size: number): void {
   // Bottom-left block: rows [size-11, size-10, size-9], cols [0..5]
   for (let r = 0; r < 6; r++) {
     for (let c = 0; c < 3; c++) {
-      if (matrix[size - 11 + c]![r] === null) matrix[size - 11 + c]![r] = false;
+      if (matrix[size - 11 + c]![r] === null) matrix[size - 11 + c]![r] = false
     }
   }
   // Top-right block: rows [0..5], cols [size-11, size-10, size-9]
   for (let r = 0; r < 6; r++) {
     for (let c = 0; c < 3; c++) {
-      if (matrix[r]![size - 11 + c] === null) matrix[r]![size - 11 + c] = false;
+      if (matrix[r]![size - 11 + c] === null) matrix[r]![size - 11 + c] = false
     }
   }
 }
@@ -143,28 +143,28 @@ function reserveVersionInfo(matrix: Module[][], size: number): void {
  * Right-to-left, alternating upward/downward, 2-column wide
  */
 export function placeData(matrix: Module[][], bits: number[], _version: number): void {
-  const size = matrix.length;
-  let bitIdx = 0;
-  let upward = true;
+  const size = matrix.length
+  let bitIdx = 0
+  let upward = true
 
   for (let col = size - 1; col >= 1; col -= 2) {
     // Skip timing column
-    if (col === 6) col = 5;
+    if (col === 6) col = 5
 
     const rows = upward
       ? Array.from({ length: size }, (_, i) => size - 1 - i)
-      : Array.from({ length: size }, (_, i) => i);
+      : Array.from({ length: size }, (_, i) => i)
 
     for (const row of rows) {
       for (const c of [col, col - 1]) {
         if (matrix[row]![c] === null) {
-          matrix[row]![c] = bitIdx < bits.length ? bits[bitIdx]! === 1 : false;
-          bitIdx++;
+          matrix[row]![c] = bitIdx < bits.length ? bits[bitIdx]! === 1 : false
+          bitIdx++
         }
       }
     }
 
-    upward = !upward;
+    upward = !upward
   }
 }
 
@@ -173,36 +173,36 @@ export function placeData(matrix: Module[][], bits: number[], _version: number):
  */
 export function isDataModule(r: number, c: number, size: number, version: number): boolean {
   // Finder patterns + separators
-  if (r < 9 && c < 9) return false; // top-left
-  if (r < 9 && c >= size - 8) return false; // top-right
-  if (r >= size - 8 && c < 9) return false; // bottom-left
+  if (r < 9 && c < 9) return false // top-left
+  if (r < 9 && c >= size - 8) return false // top-right
+  if (r >= size - 8 && c < 9) return false // bottom-left
 
   // Timing patterns
-  if (r === 6 || c === 6) return false;
+  if (r === 6 || c === 6) return false
 
   // Alignment patterns
   if (version >= 2) {
-    const positions = ALIGNMENT_POSITIONS[version - 1]!;
+    const positions = ALIGNMENT_POSITIONS[version - 1]!
     for (const ar of positions) {
       for (const ac of positions) {
         // Skip alignment patterns that overlap with finder
-        if (ar < 9 && ac < 9) continue;
-        if (ar < 9 && ac >= size - 8) continue;
-        if (ar >= size - 8 && ac < 9) continue;
+        if (ar < 9 && ac < 9) continue
+        if (ar < 9 && ac >= size - 8) continue
+        if (ar >= size - 8 && ac < 9) continue
 
-        if (r >= ar - 2 && r <= ar + 2 && c >= ac - 2 && c <= ac + 2) return false;
+        if (r >= ar - 2 && r <= ar + 2 && c >= ac - 2 && c <= ac + 2) return false
       }
     }
   }
 
   // Version info (v7+)
   if (version >= 7) {
-    if (r < 6 && c >= size - 11 && c <= size - 9) return false;
-    if (c < 6 && r >= size - 11 && r <= size - 9) return false;
+    if (r < 6 && c >= size - 11 && c <= size - 9) return false
+    if (c < 6 && r >= size - 11 && r <= size - 9) return false
   }
 
   // Dark module
-  if (r === 4 * version + 9 && c === 8) return false;
+  if (r === 4 * version + 9 && c === 8) return false
 
-  return true;
+  return true
 }

--- a/src/encoders/qr/micro.ts
+++ b/src/encoders/qr/micro.ts
@@ -8,25 +8,25 @@
  * M4: 17x17, numeric/alphanumeric/byte/kanji, EC L/M/Q
  */
 
-import { CapacityError, InvalidInputError } from "../../errors";
-import { pushBits, encodeNumericData, encodeAlphanumericData, encodeByteData } from "./mode";
-import { generateECCodewords } from "./reed-solomon";
+import { CapacityError, InvalidInputError } from "../../errors"
+import { pushBits, encodeNumericData, encodeAlphanumericData, encodeByteData } from "./mode"
+import { generateECCodewords } from "./reed-solomon"
 
 export interface MicroQROptions {
-  version?: 1 | 2 | 3 | 4;
-  ecLevel?: "L" | "M" | "Q";
-  mask?: 0 | 1 | 2 | 3;
+  version?: 1 | 2 | 3 | 4
+  ecLevel?: "L" | "M" | "Q"
+  mask?: 0 | 1 | 2 | 3
 }
 
-export const MICRO_QR_SIZES = [11, 13, 15, 17] as const;
+export const MICRO_QR_SIZES = [11, 13, 15, 17] as const
 
 // Capacity table: [version][ecLevel] = { numeric, alphanumeric, byte, dataCW, ecCW }
 interface MicroQRCapacity {
-  numeric: number;
-  alphanumeric: number;
-  byte: number;
-  dataCW: number;
-  ecCW: number;
+  numeric: number
+  alphanumeric: number
+  byte: number
+  dataCW: number
+  ecCW: number
 }
 
 const CAPACITY: Record<number, Record<string, MicroQRCapacity>> = {
@@ -46,7 +46,7 @@ const CAPACITY: Record<number, Record<string, MicroQRCapacity>> = {
     M: { numeric: 30, alphanumeric: 18, byte: 13, dataCW: 14, ecCW: 10 },
     Q: { numeric: 21, alphanumeric: 12, byte: 9, dataCW: 10, ecCW: 14 },
   },
-};
+}
 
 /**
  * Character count indicator bit lengths per version and mode
@@ -57,7 +57,7 @@ const CC_BITS: Record<number, Record<string, number>> = {
   2: { numeric: 4, alphanumeric: 3 },
   3: { numeric: 5, alphanumeric: 4, byte: 4 },
   4: { numeric: 6, alphanumeric: 5, byte: 5 },
-};
+}
 
 /**
  * Symbol number mapping: version + EC level -> symbol number (0-7)
@@ -69,7 +69,7 @@ const SYMBOL_NUMBER: Record<number, Record<string, number>> = {
   2: { L: 1, M: 2 },
   3: { L: 3, M: 4 },
   4: { L: 5, M: 6, Q: 7 },
-};
+}
 
 /**
  * Micro QR format information lookup table (32 entries)
@@ -80,7 +80,7 @@ const FORMAT_INFO_MICRO: number[] = [
   0x4445, 0x4172, 0x4e2b, 0x4b1c, 0x55ae, 0x5099, 0x5fc0, 0x5af7, 0x6793, 0x62a4, 0x6dfd, 0x68ca,
   0x7678, 0x734f, 0x7c16, 0x7921, 0x06de, 0x03e9, 0x0cb0, 0x0987, 0x1735, 0x1202, 0x1d5b, 0x186c,
   0x2508, 0x203f, 0x2f66, 0x2a51, 0x34e3, 0x31d4, 0x3e8d, 0x3bba,
-];
+]
 
 /**
  * Micro QR mask patterns (4 masks, corresponding to standard QR masks 1, 4, 6, 7)
@@ -91,7 +91,7 @@ const MICRO_MASK_FNS: ((r: number, c: number) => boolean)[] = [
   (r, c) => (Math.floor(r / 2) + Math.floor(c / 3)) % 2 === 0,
   (r, c) => (((r * c) % 2) + ((r * c) % 3)) % 2 === 0,
   (r, c) => (((r + c) % 2) + ((r * c) % 3)) % 2 === 0,
-];
+]
 
 /**
  * Encode text as a Micro QR code
@@ -99,82 +99,82 @@ const MICRO_MASK_FNS: ((r: number, c: number) => boolean)[] = [
  */
 export function encodeMicroQR(text: string, options: MicroQROptions = {}): boolean[][] {
   if (text.length === 0) {
-    throw new InvalidInputError("Micro QR input must not be empty");
+    throw new InvalidInputError("Micro QR input must not be empty")
   }
 
   // Detect mode
-  const isNum = /^\d+$/.test(text);
-  const isAlpha = !isNum && /^[0-9A-Z $%*+\-./:]+$/.test(text);
+  const isNum = /^\d+$/.test(text)
+  const isAlpha = !isNum && /^[0-9A-Z $%*+\-./:]+$/.test(text)
   const mode: "numeric" | "alphanumeric" | "byte" = isNum
     ? "numeric"
     : isAlpha
       ? "alphanumeric"
-      : "byte";
+      : "byte"
 
   // Select version
-  const { version, cap, ecKey } = selectMicroVersion(text, mode, options);
-  const size = version * 2 + 9; // M1=11, M2=13, M3=15, M4=17
+  const { version, cap, ecKey } = selectMicroVersion(text, mode, options)
+  const size = version * 2 + 9 // M1=11, M2=13, M3=15, M4=17
 
   // Encode data
-  const data = new TextEncoder().encode(text);
-  const bits = buildMicroDataBits(text, data, mode, version, cap);
+  const data = new TextEncoder().encode(text)
+  const bits = buildMicroDataBits(text, data, mode, version, cap)
 
   // Convert to full 8-bit codewords (RS needs full bytes)
-  const dataBytes: number[] = [];
+  const dataBytes: number[] = []
   for (let i = 0; i < bits.length; i += 8) {
-    let byte = 0;
+    let byte = 0
     for (let j = 0; j < 8 && i + j < bits.length; j++) {
-      byte = (byte << 1) | bits[i + j]!;
+      byte = (byte << 1) | bits[i + j]!
     }
-    dataBytes.push(byte);
+    dataBytes.push(byte)
   }
 
   // Error correction (computed on full 8-bit codewords)
-  const ecBytes = cap.ecCW > 0 ? generateECCodewords(dataBytes, cap.ecCW) : [];
+  const ecBytes = cap.ecCW > 0 ? generateECCodewords(dataBytes, cap.ecCW) : []
 
   // Build final bit array
   // M1 and M3 have a 4-bit final data codeword (ISO/IEC 18004 7.4.10)
   // RS is computed on full 8-bit CW, then last data CW is truncated to 4 bits
-  const allBits: number[] = [];
-  const hasFourBitCW = version === 1 || version === 3;
+  const allBits: number[] = []
+  const hasFourBitCW = version === 1 || version === 3
   if (hasFourBitCW) {
     // Full data codewords except last
     for (let i = 0; i < dataBytes.length - 1; i++) {
-      pushBits(allBits, dataBytes[i]!, 8);
+      pushBits(allBits, dataBytes[i]!, 8)
     }
     // Last data codeword: only top 4 bits (right-shift by 4)
-    pushBits(allBits, dataBytes[dataBytes.length - 1]! >> 4, 4);
+    pushBits(allBits, dataBytes[dataBytes.length - 1]! >> 4, 4)
     // EC codewords (all full 8-bit)
     for (const ec of ecBytes) {
-      pushBits(allBits, ec, 8);
+      pushBits(allBits, ec, 8)
     }
   } else {
     for (const byte of [...dataBytes, ...ecBytes]) {
-      pushBits(allBits, byte, 8);
+      pushBits(allBits, byte, 8)
     }
   }
 
   // Build matrix with function patterns
-  const matrix = buildFunctionPatterns(size);
+  const matrix = buildFunctionPatterns(size)
 
   // Reserve format info area (set to 0x0 so data placement skips it)
-  reserveMicroFormatInfo(matrix, size);
+  reserveMicroFormatInfo(matrix, size)
 
   // Place data using Micro QR zigzag
-  placeMicroData(matrix, allBits, size, version);
+  placeMicroData(matrix, allBits, size, version)
 
   // Find and apply best mask
-  const symbolNum = SYMBOL_NUMBER[version]![ecKey]!;
-  const bestMask = selectMicroMask(matrix, size, options.mask);
+  const symbolNum = SYMBOL_NUMBER[version]![ecKey]!
+  const bestMask = selectMicroMask(matrix, size, options.mask)
 
   // Apply mask to data modules only
-  applyMicroMask(matrix, bestMask, size);
+  applyMicroMask(matrix, bestMask, size)
 
   // Write format information
-  writeMicroFormatInfo(matrix, symbolNum, bestMask);
+  writeMicroFormatInfo(matrix, symbolNum, bestMask)
 
   // Convert to boolean (anything > 0 is dark)
-  return matrix.map((row) => row.map((cell) => cell === 1));
+  return matrix.map((row) => row.map((cell) => cell === 1))
 }
 
 function selectMicroVersion(
@@ -182,38 +182,38 @@ function selectMicroVersion(
   mode: string,
   options: MicroQROptions,
 ): { version: number; cap: MicroQRCapacity; ecKey: string } {
-  const requestedEc = options.ecLevel;
+  const requestedEc = options.ecLevel
 
   // Determine the EC key for the given version
   function getEcKey(v: number): string {
-    if (v === 1) return "_";
-    if (requestedEc && CAPACITY[v]![requestedEc]) return requestedEc;
-    return "L";
+    if (v === 1) return "_"
+    if (requestedEc && CAPACITY[v]![requestedEc]) return requestedEc
+    return "L"
   }
 
   if (options.version) {
-    const v = options.version;
-    const ecKey = getEcKey(v);
-    const caps = CAPACITY[v];
-    const cap = caps?.[ecKey];
-    if (!cap) throw new CapacityError(`Micro QR M${v} does not support EC level ${ecKey}`);
-    return { version: v, cap, ecKey };
+    const v = options.version
+    const ecKey = getEcKey(v)
+    const caps = CAPACITY[v]
+    const cap = caps?.[ecKey]
+    if (!cap) throw new CapacityError(`Micro QR M${v} does not support EC level ${ecKey}`)
+    return { version: v, cap, ecKey }
   }
 
-  const dataLen = mode === "byte" ? new TextEncoder().encode(text).length : text.length;
+  const dataLen = mode === "byte" ? new TextEncoder().encode(text).length : text.length
 
   for (let v = 1; v <= 4; v++) {
-    const ecKey = getEcKey(v);
-    const caps = CAPACITY[v]!;
-    const cap = caps[ecKey];
-    if (!cap) continue;
-    const modeKey = mode as keyof MicroQRCapacity;
+    const ecKey = getEcKey(v)
+    const caps = CAPACITY[v]!
+    const cap = caps[ecKey]
+    if (!cap) continue
+    const modeKey = mode as keyof MicroQRCapacity
     if (typeof cap[modeKey] === "number" && dataLen <= (cap[modeKey] as number)) {
-      return { version: v, cap, ecKey };
+      return { version: v, cap, ecKey }
     }
   }
 
-  throw new CapacityError(`Data too long for Micro QR Code with ${mode} mode`);
+  throw new CapacityError(`Data too long for Micro QR Code with ${mode} mode`)
 }
 
 function buildMicroDataBits(
@@ -223,7 +223,7 @@ function buildMicroDataBits(
   version: number,
   cap: MicroQRCapacity,
 ): number[] {
-  const bits: number[] = [];
+  const bits: number[] = []
 
   // Mode indicator (variable length for Micro QR)
   // M1: no mode indicator (numeric only)
@@ -231,45 +231,45 @@ function buildMicroDataBits(
   // M3: 2 bits (00=numeric, 01=alpha, 10=byte)
   // M4: 3 bits (000=numeric, 001=alpha, 010=byte)
   if (version === 2) {
-    pushBits(bits, mode === "numeric" ? 0 : 1, 1);
+    pushBits(bits, mode === "numeric" ? 0 : 1, 1)
   } else if (version === 3) {
-    pushBits(bits, mode === "numeric" ? 0 : mode === "alphanumeric" ? 1 : 2, 2);
+    pushBits(bits, mode === "numeric" ? 0 : mode === "alphanumeric" ? 1 : 2, 2)
   } else if (version === 4) {
-    pushBits(bits, mode === "numeric" ? 0 : mode === "alphanumeric" ? 1 : 2, 3);
+    pushBits(bits, mode === "numeric" ? 0 : mode === "alphanumeric" ? 1 : 2, 3)
   }
 
   // Character count indicator (correct bit lengths per ISO spec)
-  const ccBits = CC_BITS[version]![mode]!;
-  const count = mode === "byte" ? data.length : text.length;
-  pushBits(bits, count, ccBits);
+  const ccBits = CC_BITS[version]![mode]!
+  const count = mode === "byte" ? data.length : text.length
+  pushBits(bits, count, ccBits)
 
   // Data encoding
-  if (mode === "numeric") bits.push(...encodeNumericData(text));
-  else if (mode === "alphanumeric") bits.push(...encodeAlphanumericData(text));
-  else bits.push(...encodeByteData(data));
+  if (mode === "numeric") bits.push(...encodeNumericData(text))
+  else if (mode === "alphanumeric") bits.push(...encodeAlphanumericData(text))
+  else bits.push(...encodeByteData(data))
 
   // Terminator + padding
-  const totalBits = cap.dataCW * 8;
+  const totalBits = cap.dataCW * 8
   const termLen = Math.min(
     version === 1 ? 3 : version === 2 ? 5 : version === 3 ? 7 : 9,
     totalBits - bits.length,
-  );
-  pushBits(bits, 0, termLen);
+  )
+  pushBits(bits, 0, termLen)
 
   // M1 and M3: zero-pad to fill remaining capacity (4-bit final CW)
   // M2 and M4: pad to byte boundary then add alternating 0xEC/0x11
   if (version === 1 || version === 3) {
-    while (bits.length < totalBits) bits.push(0);
+    while (bits.length < totalBits) bits.push(0)
   } else {
-    while (bits.length % 8 !== 0) bits.push(0);
-    let toggle = true;
+    while (bits.length % 8 !== 0) bits.push(0)
+    let toggle = true
     while (bits.length < totalBits) {
-      pushBits(bits, toggle ? 236 : 17, 8);
-      toggle = !toggle;
+      pushBits(bits, toggle ? 236 : 17, 8)
+      toggle = !toggle
     }
   }
 
-  return bits;
+  return bits
 }
 
 /**
@@ -280,7 +280,7 @@ function buildFunctionPatterns(size: number): number[][] {
   // Initialize all cells as data region (0x2)
   const matrix: number[][] = Array.from({ length: size }, () =>
     Array.from<number>({ length: size }).fill(0x2),
-  );
+  )
 
   // Place 7x7 finder pattern at (0,0) with separator
   // The finder includes a white separator row/column
@@ -288,22 +288,22 @@ function buildFunctionPatterns(size: number): number[][] {
     for (let c = 0; c < 8; c++) {
       if (r === 7 || c === 7) {
         // Separator (white)
-        matrix[r]![c] = 0;
+        matrix[r]![c] = 0
       } else {
-        const isOuter = r === 0 || r === 6 || c === 0 || c === 6;
-        const isInner = r >= 2 && r <= 4 && c >= 2 && c <= 4;
-        matrix[r]![c] = isOuter || isInner ? 1 : 0;
+        const isOuter = r === 0 || r === 6 || c === 0 || c === 6
+        const isInner = r >= 2 && r <= 4 && c >= 2 && c <= 4
+        matrix[r]![c] = isOuter || isInner ? 1 : 0
       }
     }
   }
 
   // Timing patterns along row 0 and column 0
   for (let i = 8; i < size; i++) {
-    matrix[0]![i] = i % 2 === 0 ? 1 : 0;
-    matrix[i]![0] = i % 2 === 0 ? 1 : 0;
+    matrix[0]![i] = i % 2 === 0 ? 1 : 0
+    matrix[i]![0] = i % 2 === 0 ? 1 : 0
   }
 
-  return matrix;
+  return matrix
 }
 
 /**
@@ -314,8 +314,8 @@ function reserveMicroFormatInfo(matrix: number[][], size: number): void {
   // Format info goes along row 8 (columns 1-8) and column 8 (rows 1-8)
   for (let i = 1; i <= 8; i++) {
     if (i < size) {
-      matrix[8]![i] = 0;
-      matrix[i]![8] = 0;
+      matrix[8]![i] = 0
+      matrix[i]![8] = 0
     }
   }
 }
@@ -329,19 +329,19 @@ function reserveMicroFormatInfo(matrix: number[][], size: number): void {
 function placeMicroData(matrix: number[][], bits: number[], size: number, version: number): void {
   // For M1 and M3, we need to adjust the upward/downward direction
   // This is the "inc" trick from segno: inc=2 for M1/M3, inc=0 for M2/M4
-  const inc = version === 1 || version === 3 ? 2 : 0;
-  let bitIdx = 0;
+  const inc = version === 1 || version === 3 ? 2 : 0
+  let bitIdx = 0
 
   for (let right = size - 1; right >= 1; right -= 2) {
     for (let vertical = 0; vertical < size; vertical++) {
       for (let z = 0; z < 2; z++) {
-        const j = right - z;
-        if (j < 0) continue;
-        const upwards = ((right + inc) & 2) === 0;
-        const i = upwards ? size - 1 - vertical : vertical;
+        const j = right - z
+        if (j < 0) continue
+        const upwards = ((right + inc) & 2) === 0
+        const i = upwards ? size - 1 - vertical : vertical
         if (matrix[i]![j] === 0x2) {
-          matrix[i]![j] = bitIdx < bits.length ? bits[bitIdx]! : 0;
-          bitIdx++;
+          matrix[i]![j] = bitIdx < bits.length ? bits[bitIdx]! : 0
+          bitIdx++
         }
       }
     }
@@ -358,18 +358,18 @@ function isMicroDataModule(matrix: number[][], r: number, c: number): boolean {
   // We need a different approach: check against the function pattern layout
 
   // Finder pattern + separator: rows 0-7, cols 0-7
-  if (r <= 7 && c <= 7) return false;
+  if (r <= 7 && c <= 7) return false
 
   // Timing row 0
-  if (r === 0) return false;
+  if (r === 0) return false
   // Timing col 0
-  if (c === 0) return false;
+  if (c === 0) return false
 
   // Format info: row 8 cols 1-8, and col 8 rows 1-8
-  if (r === 8 && c >= 1 && c <= 8) return false;
-  if (c === 8 && r >= 1 && r <= 8) return false;
+  if (r === 8 && c >= 1 && c <= 8) return false
+  if (c === 8 && r >= 1 && r <= 8) return false
 
-  return true;
+  return true
 }
 
 /**
@@ -379,16 +379,16 @@ function isMicroDataModule(matrix: number[][], r: number, c: number): boolean {
  * Higher score = better mask (opposite of standard QR)
  */
 function evaluateMicroMask(matrix: number[][], size: number): number {
-  let sum1 = 0; // rightmost column
-  let sum2 = 0; // bottom row
+  let sum1 = 0 // rightmost column
+  let sum2 = 0 // bottom row
 
   for (let i = 1; i < size; i++) {
-    sum1 += matrix[i]![size - 1]!; // rightmost column, rows 1..size-1
-    sum2 += matrix[size - 1]![i]!; // bottom row, cols 1..size-1
+    sum1 += matrix[i]![size - 1]! // rightmost column, rows 1..size-1
+    sum2 += matrix[size - 1]![i]! // bottom row, cols 1..size-1
   }
 
   // Formula: min(sum1,sum2) * 16 + max(sum1,sum2)
-  return sum1 <= sum2 ? sum1 * 16 + sum2 : sum2 * 16 + sum1;
+  return sum1 <= sum2 ? sum1 * 16 + sum2 : sum2 * 16 + sum1
 }
 
 /**
@@ -397,38 +397,38 @@ function evaluateMicroMask(matrix: number[][], size: number): number {
  */
 function selectMicroMask(matrix: number[][], size: number, requestedMask?: number): number {
   if (requestedMask !== undefined && requestedMask >= 0 && requestedMask <= 3) {
-    return requestedMask;
+    return requestedMask
   }
 
-  let bestMask = 0;
-  let bestScore = -1;
+  let bestMask = 0
+  let bestScore = -1
 
   for (let mask = 0; mask < 4; mask++) {
     // Make a copy
-    const copy = matrix.map((row) => [...row]);
+    const copy = matrix.map((row) => [...row])
     // Apply mask
-    applyMicroMask(copy, mask, size);
+    applyMicroMask(copy, mask, size)
     // Evaluate
-    const score = evaluateMicroMask(copy, size);
+    const score = evaluateMicroMask(copy, size)
     if (score > bestScore) {
-      bestScore = score;
-      bestMask = mask;
+      bestScore = score
+      bestMask = mask
     }
   }
 
-  return bestMask;
+  return bestMask
 }
 
 /**
  * Apply mask pattern to data modules only
  */
 function applyMicroMask(matrix: number[][], mask: number, size: number): void {
-  const fn = MICRO_MASK_FNS[mask]!;
+  const fn = MICRO_MASK_FNS[mask]!
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
       if (isMicroDataModule(matrix, r, c)) {
         if (fn(r, c)) {
-          matrix[r]![c] = matrix[r]![c]! ^ 1; // flip bit
+          matrix[r]![c] = matrix[r]![c]! ^ 1 // flip bit
         }
       }
     }
@@ -441,18 +441,18 @@ function applyMicroMask(matrix: number[][], mask: number, size: number): void {
  * Placed along row 8 (horizontal) and column 8 (vertical)
  */
 function writeMicroFormatInfo(matrix: number[][], symbolNum: number, mask: number): void {
-  const formatIdx = (symbolNum << 2) | mask;
-  const formatInfo = FORMAT_INFO_MICRO[formatIdx]!;
+  const formatIdx = (symbolNum << 2) | mask
+  const formatInfo = FORMAT_INFO_MICRO[formatIdx]!
 
   // Vertical strip: column 8, rows 1-8 (bottom to top = LSB to MSB, bits 0-7)
   for (let i = 0; i < 8; i++) {
-    const bit = (formatInfo >> i) & 1;
-    matrix[i + 1]![8] = bit;
+    const bit = (formatInfo >> i) & 1
+    matrix[i + 1]![8] = bit
   }
 
   // Horizontal strip: row 8, columns 1-8 (left to right, bits 14 down to 7)
   for (let i = 0; i < 8; i++) {
-    const bit = (formatInfo >> (14 - i)) & 1;
-    matrix[8]![i + 1] = bit;
+    const bit = (formatInfo >> (14 - i)) & 1
+    matrix[8]![i + 1] = bit
   }
 }

--- a/src/encoders/qr/mode.ts
+++ b/src/encoders/qr/mode.ts
@@ -2,97 +2,97 @@
  * QR Code encoding modes - detection and encoding
  */
 
-import { ALPHANUMERIC_CHARS } from "./tables";
+import { ALPHANUMERIC_CHARS } from "./tables"
 
 /** Check if a string can be encoded in numeric mode */
 export function isNumeric(text: string): boolean {
-  return /^\d+$/.test(text);
+  return /^\d+$/.test(text)
 }
 
 /** Check if a string can be encoded in alphanumeric mode */
 export function isAlphanumeric(text: string): boolean {
   for (let i = 0; i < text.length; i++) {
-    if (ALPHANUMERIC_CHARS.indexOf(text[i]!) === -1) return false;
+    if (ALPHANUMERIC_CHARS.indexOf(text[i]!) === -1) return false
   }
-  return true;
+  return true
 }
 
 /** Check if a string can be encoded in Kanji mode (Shift JIS double-byte) */
 export function isKanji(_text: string): boolean {
   // Kanji detection requires checking Shift JIS encoding ranges
   // For now, return false - users can explicitly set kanji mode
-  return false;
+  return false
 }
 
 /** Auto-detect the best encoding mode for the given text */
 export function detectMode(text: string): "numeric" | "alphanumeric" | "byte" | "kanji" {
-  if (isNumeric(text)) return "numeric";
-  if (isAlphanumeric(text)) return "alphanumeric";
-  return "byte";
+  if (isNumeric(text)) return "numeric"
+  if (isAlphanumeric(text)) return "alphanumeric"
+  return "byte"
 }
 
 /** Get alphanumeric character value (0-44) */
 export function getAlphanumericValue(char: string): number {
-  const idx = ALPHANUMERIC_CHARS.indexOf(char);
-  if (idx === -1) throw new Error(`Invalid alphanumeric character: ${char}`);
-  return idx;
+  const idx = ALPHANUMERIC_CHARS.indexOf(char)
+  if (idx === -1) throw new Error(`Invalid alphanumeric character: ${char}`)
+  return idx
 }
 
 /** Encode numeric data to bits */
 export function encodeNumericData(text: string): number[] {
-  const bits: number[] = [];
-  let i = 0;
+  const bits: number[] = []
+  let i = 0
 
   // Process groups of 3 digits -> 10 bits
   while (i + 2 < text.length) {
-    const val = Number.parseInt(text.substring(i, i + 3), 10);
-    pushBits(bits, val, 10);
-    i += 3;
+    const val = Number.parseInt(text.substring(i, i + 3), 10)
+    pushBits(bits, val, 10)
+    i += 3
   }
 
   // Remaining 2 digits -> 7 bits
   if (i + 1 < text.length) {
-    const val = Number.parseInt(text.substring(i, i + 2), 10);
-    pushBits(bits, val, 7);
-    i += 2;
+    const val = Number.parseInt(text.substring(i, i + 2), 10)
+    pushBits(bits, val, 7)
+    i += 2
   }
 
   // Remaining 1 digit -> 4 bits
   if (i < text.length) {
-    const val = Number.parseInt(text[i]!, 10);
-    pushBits(bits, val, 4);
+    const val = Number.parseInt(text[i]!, 10)
+    pushBits(bits, val, 4)
   }
 
-  return bits;
+  return bits
 }
 
 /** Encode alphanumeric data to bits */
 export function encodeAlphanumericData(text: string): number[] {
-  const bits: number[] = [];
-  let i = 0;
+  const bits: number[] = []
+  let i = 0
 
   // Process pairs -> 11 bits each
   while (i + 1 < text.length) {
-    const val = getAlphanumericValue(text[i]!) * 45 + getAlphanumericValue(text[i + 1]!);
-    pushBits(bits, val, 11);
-    i += 2;
+    const val = getAlphanumericValue(text[i]!) * 45 + getAlphanumericValue(text[i + 1]!)
+    pushBits(bits, val, 11)
+    i += 2
   }
 
   // Remaining single character -> 6 bits
   if (i < text.length) {
-    pushBits(bits, getAlphanumericValue(text[i]!), 6);
+    pushBits(bits, getAlphanumericValue(text[i]!), 6)
   }
 
-  return bits;
+  return bits
 }
 
 /** Encode byte data to bits */
 export function encodeByteData(data: Uint8Array): number[] {
-  const bits: number[] = [];
+  const bits: number[] = []
   for (const byte of data) {
-    pushBits(bits, byte, 8);
+    pushBits(bits, byte, 8)
   }
-  return bits;
+  return bits
 }
 
 /**
@@ -100,22 +100,22 @@ export function encodeByteData(data: Uint8Array): number[] {
  * Input must be pre-converted to Shift JIS double-byte values
  */
 export function encodeKanjiData(sjisValues: number[]): number[] {
-  const bits: number[] = [];
+  const bits: number[] = []
   for (const code of sjisValues) {
-    let adjusted: number;
+    let adjusted: number
     if (code >= 0x8140 && code <= 0x9ffc) {
-      adjusted = code - 0x8140;
+      adjusted = code - 0x8140
     } else if (code >= 0xe040 && code <= 0xebbf) {
-      adjusted = code - 0xc140;
+      adjusted = code - 0xc140
     } else {
-      throw new Error(`Invalid Shift JIS kanji value: 0x${code.toString(16)}`);
+      throw new Error(`Invalid Shift JIS kanji value: 0x${code.toString(16)}`)
     }
-    const hi = (adjusted >> 8) & 0xff;
-    const lo = adjusted & 0xff;
-    const value = hi * 0xc0 + lo;
-    pushBits(bits, value, 13);
+    const hi = (adjusted >> 8) & 0xff
+    const lo = adjusted & 0xff
+    const value = hi * 0xc0 + lo
+    pushBits(bits, value, 13)
   }
-  return bits;
+  return bits
 }
 
 /**
@@ -124,31 +124,31 @@ export function encodeKanjiData(sjisValues: number[]): number[] {
  * For full support, a complete Unicode-to-SJIS table would be needed.
  */
 export function unicodeToShiftJIS(text: string): number[] {
-  const values: number[] = [];
+  const values: number[] = []
   for (let i = 0; i < text.length; i++) {
-    const code = text.charCodeAt(i);
+    const code = text.charCodeAt(i)
     // Simple mapping for common ranges
     // Full SJIS mapping would require a large lookup table
     // For now, encode the code point directly if in Kanji range
     if (code >= 0x3000 && code <= 0x9fff) {
       // Approximate mapping: many CJK characters fall in SJIS 0x8140-0x9FFC range
       // This is a simplification — production use would need a full mapping table
-      const sjis = 0x8140 + (code - 0x3000);
+      const sjis = 0x8140 + (code - 0x3000)
       if (sjis <= 0x9ffc) {
-        values.push(sjis);
+        values.push(sjis)
       } else {
-        values.push(0xe040 + (code - 0x3000 - (0x9ffc - 0x8140)));
+        values.push(0xe040 + (code - 0x3000 - (0x9ffc - 0x8140)))
       }
     } else {
-      throw new Error(`Character U+${code.toString(16)} cannot be encoded as Kanji`);
+      throw new Error(`Character U+${code.toString(16)} cannot be encoded as Kanji`)
     }
   }
-  return values;
+  return values
 }
 
 /** Push a value as the specified number of bits (MSB first) */
 export function pushBits(arr: number[], value: number, count: number): void {
   for (let i = count - 1; i >= 0; i--) {
-    arr.push((value >> i) & 1);
+    arr.push((value >> i) & 1)
   }
 }

--- a/src/encoders/qr/reed-solomon.ts
+++ b/src/encoders/qr/reed-solomon.ts
@@ -4,57 +4,57 @@
  */
 
 // Galois Field GF(256) lookup tables
-const GF_EXP = new Uint8Array(512);
-const GF_LOG = new Uint8Array(256);
+const GF_EXP = new Uint8Array(512)
+const GF_LOG = new Uint8Array(256)
 
 // Initialize GF(256) tables with primitive polynomial 0x11D
-(function initGF() {
-  let x = 1;
+;(function initGF() {
+  let x = 1
   for (let i = 0; i < 255; i++) {
-    GF_EXP[i] = x;
-    GF_LOG[x] = i;
-    x = x << 1;
-    if (x >= 256) x ^= 0x11d;
+    GF_EXP[i] = x
+    GF_LOG[x] = i
+    x = x << 1
+    if (x >= 256) x ^= 0x11d
   }
   // Extend exp table for easier modular arithmetic
   for (let i = 255; i < 512; i++) {
-    GF_EXP[i] = GF_EXP[i - 255]!;
+    GF_EXP[i] = GF_EXP[i - 255]!
   }
-})();
+})()
 
 /** Multiply two GF(256) elements */
 export function gfMultiply(a: number, b: number): number {
-  if (a === 0 || b === 0) return 0;
-  return GF_EXP[(GF_LOG[a]! + GF_LOG[b]!) % 255]!;
+  if (a === 0 || b === 0) return 0
+  return GF_EXP[(GF_LOG[a]! + GF_LOG[b]!) % 255]!
 }
 
 /** Generate error correction codewords for a data block */
 export function generateECCodewords(data: number[], ecCount: number): number[] {
   // Build generator polynomial: gen[0] = leading coeff (x^ecCount), gen[ecCount] = constant
   // Polynomial is product of (x - alpha^i) for i = 0..ecCount-1
-  let gen = new Uint8Array([1]);
+  let gen = new Uint8Array([1])
   for (let i = 0; i < ecCount; i++) {
-    const factor = new Uint8Array([1, GF_EXP[i]!]);
-    const newGen = new Uint8Array(gen.length + 1);
+    const factor = new Uint8Array([1, GF_EXP[i]!])
+    const newGen = new Uint8Array(gen.length + 1)
     for (let j = 0; j < gen.length; j++) {
       for (let k = 0; k < factor.length; k++) {
-        newGen[j + k] ^= gfMultiply(gen[j]!, factor[k]!);
+        newGen[j + k] ^= gfMultiply(gen[j]!, factor[k]!)
       }
     }
-    gen = newGen;
+    gen = newGen
   }
 
   // Polynomial division
-  const result = Array.from({ length: ecCount }, () => 0);
+  const result = Array.from({ length: ecCount }, () => 0)
   for (const byte of data) {
-    const lead = byte ^ result[0]!;
+    const lead = byte ^ result[0]!
     for (let j = 0; j < ecCount - 1; j++) {
-      result[j] = result[j + 1]! ^ gfMultiply(lead, gen[j + 1]!);
+      result[j] = result[j + 1]! ^ gfMultiply(lead, gen[j + 1]!)
     }
-    result[ecCount - 1] = gfMultiply(lead, gen[ecCount]!);
+    result[ecCount - 1] = gfMultiply(lead, gen[ecCount]!)
   }
 
-  return result;
+  return result
 }
 
 /**
@@ -69,41 +69,41 @@ export function addErrorCorrection(
   group2Blocks: number,
   group2DataCW: number,
 ): number[] {
-  const blocks: number[][] = [];
-  const ecBlocks: number[][] = [];
-  let pos = 0;
+  const blocks: number[][] = []
+  const ecBlocks: number[][] = []
+  let pos = 0
 
   // Group 1 blocks
   for (let b = 0; b < group1Blocks; b++) {
-    const block = dataBytes.slice(pos, pos + group1DataCW);
-    blocks.push(block);
-    ecBlocks.push(generateECCodewords(block, ecCodewordsPerBlock));
-    pos += group1DataCW;
+    const block = dataBytes.slice(pos, pos + group1DataCW)
+    blocks.push(block)
+    ecBlocks.push(generateECCodewords(block, ecCodewordsPerBlock))
+    pos += group1DataCW
   }
 
   // Group 2 blocks
   for (let b = 0; b < group2Blocks; b++) {
-    const block = dataBytes.slice(pos, pos + group2DataCW);
-    blocks.push(block);
-    ecBlocks.push(generateECCodewords(block, ecCodewordsPerBlock));
-    pos += group2DataCW;
+    const block = dataBytes.slice(pos, pos + group2DataCW)
+    blocks.push(block)
+    ecBlocks.push(generateECCodewords(block, ecCodewordsPerBlock))
+    pos += group2DataCW
   }
 
   // Interleave data codewords
-  const result: number[] = [];
-  const maxDataLen = Math.max(group1DataCW, group2DataCW);
+  const result: number[] = []
+  const maxDataLen = Math.max(group1DataCW, group2DataCW)
   for (let i = 0; i < maxDataLen; i++) {
     for (const block of blocks) {
-      if (i < block.length) result.push(block[i]!);
+      if (i < block.length) result.push(block[i]!)
     }
   }
 
   // Interleave EC codewords
   for (let i = 0; i < ecCodewordsPerBlock; i++) {
     for (const ec of ecBlocks) {
-      if (i < ec.length) result.push(ec[i]!);
+      if (i < ec.length) result.push(ec[i]!)
     }
   }
 
-  return result;
+  return result
 }

--- a/src/encoders/qr/segment.ts
+++ b/src/encoders/qr/segment.ts
@@ -10,33 +10,33 @@
  * exceed this overhead, it's better to stay in the current mode.
  */
 
-import type { QRSegment } from "./types";
-import { getCharCountBits, ALPHANUMERIC_CHARS } from "./tables";
+import type { QRSegment } from "./types"
+import { getCharCountBits, ALPHANUMERIC_CHARS } from "./tables"
 
-type Mode = "numeric" | "alphanumeric" | "byte";
+type Mode = "numeric" | "alphanumeric" | "byte"
 
 /** Bits per character in each mode */
 function bitsPerChar(mode: Mode): number {
   switch (mode) {
     case "numeric":
-      return 10 / 3; // ~3.33 bits per digit
+      return 10 / 3 // ~3.33 bits per digit
     case "alphanumeric":
-      return 11 / 2; // 5.5 bits per char
+      return 11 / 2 // 5.5 bits per char
     case "byte":
-      return 8;
+      return 8
   }
 }
 
 /** Mode switch cost: 4 bits (mode indicator) + character count bits */
 function switchCost(version: number, targetMode: Mode): number {
-  return 4 + getCharCountBits(version, targetMode);
+  return 4 + getCharCountBits(version, targetMode)
 }
 
 /** Detect the most efficient mode for a single character */
 function charMode(char: string): Mode {
-  if (char >= "0" && char <= "9") return "numeric";
-  if (ALPHANUMERIC_CHARS.includes(char)) return "alphanumeric";
-  return "byte";
+  if (char >= "0" && char <= "9") return "numeric"
+  if (ALPHANUMERIC_CHARS.includes(char)) return "alphanumeric"
+  return "byte"
 }
 
 /**
@@ -49,49 +49,49 @@ function charMode(char: string): Mode {
  * 4. Otherwise, stay in the current (less efficient but cheaper) mode
  */
 export function optimizeSegments(text: string, version: number): QRSegment[] {
-  if (text.length === 0) return [];
+  if (text.length === 0) return []
 
-  const segments: QRSegment[] = [];
-  let currentMode: Mode = charMode(text[0]!);
-  let segStart = 0;
+  const segments: QRSegment[] = []
+  let currentMode: Mode = charMode(text[0]!)
+  let segStart = 0
 
-  let i = 1;
+  let i = 1
   while (i < text.length) {
-    const cm = charMode(text[i]!);
+    const cm = charMode(text[i]!)
 
     if (cm === currentMode) {
-      i++;
-      continue;
+      i++
+      continue
     }
 
     // Different mode detected — should we switch?
     // Count how many consecutive chars are in the new mode
-    let runLen = 1;
-    let j = i + 1;
+    let runLen = 1
+    let j = i + 1
     while (j < text.length && charMode(text[j]!) === cm) {
-      runLen++;
-      j++;
+      runLen++
+      j++
     }
 
     // Calculate: is switching cheaper than encoding in current mode?
-    const costInCurrent = runLen * bitsPerChar(currentMode);
-    const costInNew = switchCost(version, cm) + runLen * bitsPerChar(cm);
+    const costInCurrent = runLen * bitsPerChar(currentMode)
+    const costInNew = switchCost(version, cm) + runLen * bitsPerChar(cm)
 
     if (costInNew < costInCurrent) {
       // Switch: flush current segment, start new one
-      pushSegment(segments, text, segStart, i, currentMode);
-      currentMode = cm;
-      segStart = i;
+      pushSegment(segments, text, segStart, i, currentMode)
+      currentMode = cm
+      segStart = i
     }
     // Else: stay in current mode (absorb the chars)
 
-    i = j;
+    i = j
   }
 
   // Flush final segment
-  pushSegment(segments, text, segStart, text.length, currentMode);
+  pushSegment(segments, text, segStart, text.length, currentMode)
 
-  return segments;
+  return segments
 }
 
 function pushSegment(
@@ -101,11 +101,11 @@ function pushSegment(
   end: number,
   mode: Mode,
 ): void {
-  const segText = text.substring(start, end);
-  const data = new TextEncoder().encode(segText);
+  const segText = text.substring(start, end)
+  const data = new TextEncoder().encode(segText)
   segments.push({
     mode,
     data,
     charCount: mode === "byte" ? data.length : segText.length,
-  });
+  })
 }

--- a/src/encoders/qr/tables.ts
+++ b/src/encoders/qr/tables.ts
@@ -3,7 +3,7 @@
  * Based on ISO/IEC 18004:2015
  */
 
-import type { ErrorCorrectionLevel } from "./types";
+import type { ErrorCorrectionLevel } from "./types"
 
 /**
  * Character count indicator bit lengths by version group and mode
@@ -14,33 +14,33 @@ export const CHAR_COUNT_BITS: Record<string, [number, number, number]> = {
   alphanumeric: [9, 11, 13],
   byte: [8, 16, 16],
   kanji: [8, 10, 12],
-};
+}
 
 /** Get character count bits for a version and mode */
 export function getCharCountBits(version: number, mode: string): number {
-  const bits = CHAR_COUNT_BITS[mode];
-  if (!bits) return 8;
-  if (version <= 9) return bits[0];
-  if (version <= 26) return bits[1];
-  return bits[2];
+  const bits = CHAR_COUNT_BITS[mode]
+  if (!bits) return 8
+  if (version <= 9) return bits[0]
+  if (version <= 26) return bits[1]
+  return bits[2]
 }
 
 /**
  * Alphanumeric character values
  */
-export const ALPHANUMERIC_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+export const ALPHANUMERIC_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:"
 
 /**
  * Error correction block information for each version and EC level
  * Format: [totalCodewords, ecCodewordsPerBlock, group1Blocks, group1DataCW, group2Blocks, group2DataCW]
  */
 interface ECBlockInfo {
-  totalDataCodewords: number;
-  ecCodewordsPerBlock: number;
-  group1Blocks: number;
-  group1DataCW: number;
-  group2Blocks: number;
-  group2DataCW: number;
+  totalDataCodewords: number
+  ecCodewordsPerBlock: number
+  group1Blocks: number
+  group1DataCW: number
+  group2Blocks: number
+  group2DataCW: number
 }
 
 // prettier-ignore
@@ -220,7 +220,7 @@ const EC_TABLE: Record<ErrorCorrectionLevel, ECBlockInfo[]> = {
 }
 
 export function getECInfo(version: number, ecLevel: ErrorCorrectionLevel): ECBlockInfo {
-  return EC_TABLE[ecLevel][version]!;
+  return EC_TABLE[ecLevel][version]!
 }
 
 /**

--- a/src/encoders/qr/types.ts
+++ b/src/encoders/qr/types.ts
@@ -2,27 +2,27 @@
  * QR Code types and interfaces
  */
 
-export type ErrorCorrectionLevel = "L" | "M" | "Q" | "H";
+export type ErrorCorrectionLevel = "L" | "M" | "Q" | "H"
 
-export type EncodingMode = "numeric" | "alphanumeric" | "byte" | "kanji" | "auto";
+export type EncodingMode = "numeric" | "alphanumeric" | "byte" | "kanji" | "auto"
 
 export interface QRCodeOptions {
-  ecLevel?: ErrorCorrectionLevel;
-  version?: number; // 1-40, auto if omitted
-  mode?: EncodingMode;
-  mask?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7; // auto if omitted
-  micro?: boolean;
+  ecLevel?: ErrorCorrectionLevel
+  version?: number // 1-40, auto if omitted
+  mode?: EncodingMode
+  mask?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 // auto if omitted
+  micro?: boolean
   structuredAppend?: {
-    index: number;
-    total: number;
-    parity: number;
-  };
+    index: number
+    total: number
+    parity: number
+  }
 }
 
 export interface QRSegment {
-  mode: "numeric" | "alphanumeric" | "byte" | "kanji" | "eci";
-  data: Uint8Array | string;
-  charCount: number;
+  mode: "numeric" | "alphanumeric" | "byte" | "kanji" | "eci"
+  data: Uint8Array | string
+  charCount: number
 }
 
 /** EC level indicators: L=01, M=00, Q=11, H=10 */
@@ -31,7 +31,7 @@ export const EC_LEVEL_BITS: Record<ErrorCorrectionLevel, number> = {
   M: 0b00,
   Q: 0b11,
   H: 0b10,
-};
+}
 
 /** Mode indicators (4 bits) */
 export const MODE_INDICATOR = {
@@ -44,4 +44,4 @@ export const MODE_INDICATOR = {
   fnc1First: 0b0101,
   fnc1Second: 0b1001,
   terminator: 0b0000,
-} as const;
+} as const

--- a/src/encoders/qr/version.ts
+++ b/src/encoders/qr/version.ts
@@ -3,14 +3,14 @@
  * Versions 1-40, size = 4*V + 17 modules per side
  */
 
-import type { ErrorCorrectionLevel } from "./types";
-import { getECInfo, getCharCountBits } from "./tables";
-import { detectMode, isNumeric, isAlphanumeric } from "./mode";
+import type { ErrorCorrectionLevel } from "./types"
+import { getECInfo, getCharCountBits } from "./tables"
+import { detectMode, isNumeric, isAlphanumeric } from "./mode"
 
 /** Calculate data capacity in bits for a given version and EC level */
 export function getDataCapacityBits(version: number, ecLevel: ErrorCorrectionLevel): number {
-  const info = getECInfo(version, ecLevel);
-  return info.totalDataCodewords * 8;
+  const info = getECInfo(version, ecLevel)
+  return info.totalDataCodewords * 8
 }
 
 /**
@@ -23,27 +23,27 @@ export function selectVersion(
   mode?: string,
   requestedVersion?: number,
 ): number {
-  const resolvedMode = mode === "auto" || !mode ? detectMode(text) : mode;
-  const data = new TextEncoder().encode(text);
+  const resolvedMode = mode === "auto" || !mode ? detectMode(text) : mode
+  const data = new TextEncoder().encode(text)
 
   if (requestedVersion) {
     // Verify the requested version can hold the data
-    const capacity = getDataCapacityBits(requestedVersion, ecLevel);
-    const needed = calculateBitsNeeded(text, data, resolvedMode, requestedVersion);
+    const capacity = getDataCapacityBits(requestedVersion, ecLevel)
+    const needed = calculateBitsNeeded(text, data, resolvedMode, requestedVersion)
     if (needed > capacity) {
-      throw new Error(`Data too long for QR version ${requestedVersion} with EC level ${ecLevel}`);
+      throw new Error(`Data too long for QR version ${requestedVersion} with EC level ${ecLevel}`)
     }
-    return requestedVersion;
+    return requestedVersion
   }
 
   // Find smallest version that fits
   for (let v = 1; v <= 40; v++) {
-    const capacity = getDataCapacityBits(v, ecLevel);
-    const needed = calculateBitsNeeded(text, data, resolvedMode, v);
-    if (needed <= capacity) return v;
+    const capacity = getDataCapacityBits(v, ecLevel)
+    const needed = calculateBitsNeeded(text, data, resolvedMode, v)
+    if (needed <= capacity) return v
   }
 
-  throw new Error(`Data too long for any QR code version with EC level ${ecLevel}`);
+  throw new Error(`Data too long for any QR code version with EC level ${ecLevel}`)
 }
 
 /** Calculate total bits needed to encode data in a given mode */
@@ -53,32 +53,32 @@ function calculateBitsNeeded(
   mode: string,
   version: number,
 ): number {
-  const charCountBits = getCharCountBits(version, mode);
+  const charCountBits = getCharCountBits(version, mode)
 
   // Mode indicator (4 bits) + char count + data
-  let dataBits: number;
+  let dataBits: number
 
   switch (mode) {
     case "numeric":
       dataBits =
         Math.floor(text.length / 3) * 10 +
-        (text.length % 3 === 2 ? 7 : text.length % 3 === 1 ? 4 : 0);
-      return 4 + charCountBits + dataBits;
+        (text.length % 3 === 2 ? 7 : text.length % 3 === 1 ? 4 : 0)
+      return 4 + charCountBits + dataBits
     case "alphanumeric":
-      dataBits = Math.floor(text.length / 2) * 11 + (text.length % 2 === 1 ? 6 : 0);
-      return 4 + charCountBits + dataBits;
+      dataBits = Math.floor(text.length / 2) * 11 + (text.length % 2 === 1 ? 6 : 0)
+      return 4 + charCountBits + dataBits
     case "byte":
-      return 4 + charCountBits + data.length * 8;
+      return 4 + charCountBits + data.length * 8
     case "kanji":
-      return 4 + charCountBits + text.length * 13;
+      return 4 + charCountBits + text.length * 13
     default:
-      return 4 + charCountBits + data.length * 8;
+      return 4 + charCountBits + data.length * 8
   }
 }
 
 /** Get the module count (size) for a version */
 export function getModuleCount(version: number): number {
-  return version * 4 + 17;
+  return version * 4 + 17
 }
 
 /**
@@ -90,9 +90,9 @@ export function selectMode(
   requestedMode?: string,
 ): "numeric" | "alphanumeric" | "byte" | "kanji" {
   if (requestedMode && requestedMode !== "auto") {
-    return requestedMode as "numeric" | "alphanumeric" | "byte" | "kanji";
+    return requestedMode as "numeric" | "alphanumeric" | "byte" | "kanji"
   }
-  if (isNumeric(text)) return "numeric";
-  if (isAlphanumeric(text)) return "alphanumeric";
-  return "byte";
+  if (isNumeric(text)) return "numeric"
+  if (isAlphanumeric(text)) return "alphanumeric"
+  return "byte"
 }

--- a/src/encoders/rmqr.ts
+++ b/src/encoders/rmqr.ts
@@ -9,9 +9,9 @@
  * - Numeric, alphanumeric, byte, kanji modes
  */
 
-import { InvalidInputError, CapacityError } from "../errors";
-import { encodeNumericData, encodeAlphanumericData, encodeByteData, pushBits } from "./qr/mode";
-import { generateECCodewords } from "./qr/reed-solomon";
+import { InvalidInputError, CapacityError } from "../errors"
+import { encodeNumericData, encodeAlphanumericData, encodeByteData, pushBits } from "./qr/mode"
+import { generateECCodewords } from "./qr/reed-solomon"
 
 // rMQR symbol sizes from Zint/ISO 23941: [rows, cols, dataCW_M, dataCW_H, ecCW_M, ecCW_H]
 // prettier-ignore
@@ -25,9 +25,9 @@ const RMQR_SIZES: [number, number, number, number, number, number][] = [
 ];
 
 // rMQR mode indicators (3 bits each, per ISO/IEC 23941)
-const RMQR_MODE_NUMERIC = 0b001;
-const RMQR_MODE_ALPHANUMERIC = 0b010;
-const RMQR_MODE_BYTE = 0b011;
+const RMQR_MODE_NUMERIC = 0b001
+const RMQR_MODE_ALPHANUMERIC = 0b010
+const RMQR_MODE_BYTE = 0b011
 // const RMQR_MODE_KANJI = 0b100;
 
 /**
@@ -67,7 +67,7 @@ const RMQR_CCI_LENGTHS: [number, number, number, number][] = [
   [8, 7, 7, 6], // 29: R17x77
   [8, 8, 7, 6], // 30: R17x99
   [9, 8, 8, 7], // 31: R17x139
-];
+]
 
 // Pre-computed rMQR format info tables from Zint (ISO/IEC 23941)
 // Index = version_index + (ecLevel == "H" ? 32 : 0)
@@ -95,8 +95,8 @@ const RMQR_FORMAT_RIGHT: number[] = [
 ];
 
 export interface RMQROptions {
-  ecLevel?: "M" | "H";
-  version?: number; // index into RMQR_SIZES (0-31)
+  ecLevel?: "M" | "H"
+  version?: number // index into RMQR_SIZES (0-31)
 }
 
 /**
@@ -109,25 +109,25 @@ function encodeRMQRData(
   versionIdx: number,
   mode: "numeric" | "alphanumeric" | "byte",
 ): number[] {
-  const cci = RMQR_CCI_LENGTHS[versionIdx]!;
-  const bits: number[] = [];
-  const data = new TextEncoder().encode(text);
+  const cci = RMQR_CCI_LENGTHS[versionIdx]!
+  const bits: number[] = []
+  const data = new TextEncoder().encode(text)
 
   if (mode === "numeric") {
-    pushBits(bits, RMQR_MODE_NUMERIC, 3);
-    pushBits(bits, text.length, cci[0]);
-    bits.push(...encodeNumericData(text));
+    pushBits(bits, RMQR_MODE_NUMERIC, 3)
+    pushBits(bits, text.length, cci[0])
+    bits.push(...encodeNumericData(text))
   } else if (mode === "alphanumeric") {
-    pushBits(bits, RMQR_MODE_ALPHANUMERIC, 3);
-    pushBits(bits, text.length, cci[1]);
-    bits.push(...encodeAlphanumericData(text));
+    pushBits(bits, RMQR_MODE_ALPHANUMERIC, 3)
+    pushBits(bits, text.length, cci[1])
+    bits.push(...encodeAlphanumericData(text))
   } else {
-    pushBits(bits, RMQR_MODE_BYTE, 3);
-    pushBits(bits, data.length, cci[2]);
-    bits.push(...encodeByteData(data));
+    pushBits(bits, RMQR_MODE_BYTE, 3)
+    pushBits(bits, data.length, cci[2])
+    bits.push(...encodeByteData(data))
   }
 
-  return bits;
+  return bits
 }
 
 /**
@@ -136,132 +136,132 @@ function encodeRMQRData(
  */
 export function encodeRMQR(text: string, options: RMQROptions = {}): boolean[][] {
   if (text.length === 0) {
-    throw new InvalidInputError("rMQR input must not be empty");
+    throw new InvalidInputError("rMQR input must not be empty")
   }
 
-  const ecLevel = options.ecLevel ?? "M";
-  const isNum = /^\d+$/.test(text);
-  const isAlpha = !isNum && /^[0-9A-Z $%*+\-./:]+$/.test(text);
+  const ecLevel = options.ecLevel ?? "M"
+  const isNum = /^\d+$/.test(text)
+  const isAlpha = !isNum && /^[0-9A-Z $%*+\-./:]+$/.test(text)
   const mode: "numeric" | "alphanumeric" | "byte" = isNum
     ? "numeric"
     : isAlpha
       ? "alphanumeric"
-      : "byte";
+      : "byte"
 
   // Select symbol size — CCI length depends on version, so iterate to find the
   // smallest version whose data capacity fits the encoded bit stream.
-  let sizeIdx = -1;
-  let bits: number[] = [];
+  let sizeIdx = -1
+  let bits: number[] = []
 
   if (options.version !== undefined) {
     // User requested a specific version
-    sizeIdx = options.version;
-    bits = encodeRMQRData(text, sizeIdx, mode);
-    const size = RMQR_SIZES[sizeIdx];
+    sizeIdx = options.version
+    bits = encodeRMQRData(text, sizeIdx, mode)
+    const size = RMQR_SIZES[sizeIdx]
     if (!size) {
-      throw new CapacityError("Invalid rMQR version index");
+      throw new CapacityError("Invalid rMQR version index")
     }
-    const dataCW = ecLevel === "M" ? size[2] : size[3];
+    const dataCW = ecLevel === "M" ? size[2] : size[3]
     if (bits.length > dataCW * 8) {
-      throw new CapacityError("Data too long for requested rMQR symbol size");
+      throw new CapacityError("Data too long for requested rMQR symbol size")
     }
   } else {
     for (let i = 0; i < RMQR_SIZES.length; i++) {
-      const size = RMQR_SIZES[i]!;
-      const dataCW = ecLevel === "M" ? size[2] : size[3];
-      const candidateBits = encodeRMQRData(text, i, mode);
+      const size = RMQR_SIZES[i]!
+      const dataCW = ecLevel === "M" ? size[2] : size[3]
+      const candidateBits = encodeRMQRData(text, i, mode)
       if (candidateBits.length <= dataCW * 8) {
-        sizeIdx = i;
-        bits = candidateBits;
-        break;
+        sizeIdx = i
+        bits = candidateBits
+        break
       }
     }
     if (sizeIdx === -1) {
-      throw new CapacityError("Data too long for any rMQR symbol size");
+      throw new CapacityError("Data too long for any rMQR symbol size")
     }
   }
 
-  const size = RMQR_SIZES[sizeIdx]!;
-  const [rows, cols, dataCW_M, dataCW_H, ecCW_M, ecCW_H] = size;
-  const dataCW = ecLevel === "M" ? dataCW_M : dataCW_H;
-  const ecCW = ecLevel === "M" ? ecCW_M : ecCW_H;
+  const size = RMQR_SIZES[sizeIdx]!
+  const [rows, cols, dataCW_M, dataCW_H, ecCW_M, ecCW_H] = size
+  const dataCW = ecLevel === "M" ? dataCW_M : dataCW_H
+  const ecCW = ecLevel === "M" ? ecCW_M : ecCW_H
 
   // Pad bits to data capacity
-  const totalDataBits = dataCW * 8;
-  const termLen = Math.min(3, totalDataBits - bits.length);
-  pushBits(bits, 0, termLen);
-  while (bits.length % 8 !== 0) bits.push(0);
-  let toggle = true;
+  const totalDataBits = dataCW * 8
+  const termLen = Math.min(3, totalDataBits - bits.length)
+  pushBits(bits, 0, termLen)
+  while (bits.length % 8 !== 0) bits.push(0)
+  let toggle = true
   while (bits.length < totalDataBits) {
-    pushBits(bits, toggle ? 236 : 17, 8);
-    toggle = !toggle;
+    pushBits(bits, toggle ? 236 : 17, 8)
+    toggle = !toggle
   }
 
   // Convert to bytes
-  const dataBytes: number[] = [];
+  const dataBytes: number[] = []
   for (let i = 0; i < bits.length; i += 8) {
-    let byte = 0;
+    let byte = 0
     for (let j = 0; j < 8 && i + j < bits.length; j++) {
-      byte = (byte << 1) | bits[i + j]!;
+      byte = (byte << 1) | bits[i + j]!
     }
-    dataBytes.push(byte);
+    dataBytes.push(byte)
   }
 
   // EC
-  const ecBytes = generateECCodewords(dataBytes, ecCW);
-  const allBytes = [...dataBytes, ...ecBytes];
+  const ecBytes = generateECCodewords(dataBytes, ecCW)
+  const allBytes = [...dataBytes, ...ecBytes]
 
   // Build matrix (null = data area, boolean = function pattern)
   const matrix: (boolean | null)[][] = Array.from({ length: rows }, () =>
     Array.from<boolean | null>({ length: cols }).fill(null),
-  );
+  )
 
   // Follow EXACT Zint rmqr_setup_grid order:
   // 1. Timing patterns FIRST (all 4 edges)
   for (let c = 0; c < cols; c++) {
-    matrix[0]![c] = !(c & 1);
-    matrix[rows - 1]![c] = !(c & 1);
+    matrix[0]![c] = !(c & 1)
+    matrix[rows - 1]![c] = !(c & 1)
   }
   for (let r = 0; r < rows; r++) {
-    matrix[r]![0] = !(r & 1);
-    matrix[r]![cols - 1] = !(r & 1);
+    matrix[r]![0] = !(r & 1)
+    matrix[r]![cols - 1] = !(r & 1)
   }
 
   // 2. Finder pattern (7×7 at top-left) - OVERRIDES timing
   for (let r = 0; r < 7; r++) {
     for (let c = 0; c < 7; c++) {
-      const isOuter = r === 0 || r === 6 || c === 0 || c === 6;
-      const isInner = r >= 2 && r <= 4 && c >= 2 && c <= 4;
-      matrix[r]![c] = isOuter || isInner;
+      const isOuter = r === 0 || r === 6 || c === 0 || c === 6
+      const isInner = r >= 2 && r <= 4 && c >= 2 && c <= 4
+      matrix[r]![c] = isOuter || isInner
     }
   }
 
   // 3. Bottom-right alignment (5×5) - OVERRIDES timing
-  const arx = cols - 5;
-  const ary = rows - 5;
-  const AP = [0x1f, 0x11, 0x15, 0x11, 0x1f];
+  const arx = cols - 5
+  const ary = rows - 5
+  const AP = [0x1f, 0x11, 0x15, 0x11, 0x1f]
   for (let r = 0; r < 5; r++) {
     for (let c = 0; c < 5; c++) {
-      matrix[ary + r]![arx + c] = ((AP[r]! >> (4 - c)) & 1) === 1;
+      matrix[ary + r]![arx + c] = ((AP[r]! >> (4 - c)) & 1) === 1
     }
   }
 
   // 4. Corner finder patterns
-  matrix[rows - 2]![0] = true;
-  matrix[rows - 2]![1] = false;
-  matrix[rows - 1]![1] = true;
-  matrix[0]![cols - 2] = true;
-  matrix[1]![cols - 2] = false;
-  matrix[1]![cols - 1] = true;
+  matrix[rows - 2]![0] = true
+  matrix[rows - 2]![1] = false
+  matrix[rows - 1]![1] = true
+  matrix[0]![cols - 2] = true
+  matrix[1]![cols - 2] = false
+  matrix[1]![cols - 1] = true
 
   // 5. Separator
-  for (let r = 0; r < 7; r++) matrix[r]![7] = false;
-  if (rows > 7) for (let c = 0; c < 8; c++) matrix[7]![c] = false;
+  for (let r = 0; r < 7; r++) matrix[r]![7] = false
+  if (rows > 7) for (let c = 0; c < 8; c++) matrix[7]![c] = false
 
   // 4b. Sub-alignment vertical timing columns (rMQR-specific)
   // Column positions from rmqr_table_d1, indexed by width group
   // These must be placed BEFORE data, as they are function patterns
-  const widthGroupIdx = [43, 59, 77, 99, 139].indexOf(cols);
+  const widthGroupIdx = [43, 59, 77, 99, 139].indexOf(cols)
   // prettier-ignore
   const SUB_ALIGN: number[][] = [
     [21], [19,39], [25,51], [23,49,75], [27,55,83,111],
@@ -270,102 +270,102 @@ export function encodeRMQR(text: string, options: RMQROptions = {}): boolean[][]
     for (const ac of SUB_ALIGN[widthGroupIdx]!) {
       // Vertical timing column
       for (let r = 0; r < rows; r++) {
-        matrix[r]![ac] = r % 2 === 0;
+        matrix[r]![ac] = r % 2 === 0
       }
       // Top square (2x2 dark at rows 1-2, cols ac±1)
       if (ac - 1 >= 0) {
-        matrix[1]![ac - 1] = true;
-        matrix[2]![ac - 1] = true;
+        matrix[1]![ac - 1] = true
+        matrix[2]![ac - 1] = true
       }
       if (ac + 1 < cols) {
-        matrix[1]![ac + 1] = true;
-        matrix[2]![ac + 1] = true;
+        matrix[1]![ac + 1] = true
+        matrix[2]![ac + 1] = true
       }
       // Bottom square (2x2 dark at rows v_size-3/-2, cols ac±1)
       if (ac - 1 >= 0) {
-        matrix[rows - 3]![ac - 1] = true;
-        matrix[rows - 2]![ac - 1] = true;
+        matrix[rows - 3]![ac - 1] = true
+        matrix[rows - 2]![ac - 1] = true
       }
       if (ac + 1 < cols) {
-        matrix[rows - 3]![ac + 1] = true;
-        matrix[rows - 2]![ac + 1] = true;
+        matrix[rows - 3]![ac + 1] = true
+        matrix[rows - 2]![ac + 1] = true
       }
     }
   }
 
   // 5. Format info from pre-computed Zint tables (18 bits each side)
-  const fmtIdx = sizeIdx + (ecLevel === "H" ? 32 : 0);
-  const leftFmt = RMQR_FORMAT_LEFT[fmtIdx]!;
-  const rightFmt = RMQR_FORMAT_RIGHT[fmtIdx]!;
+  const fmtIdx = sizeIdx + (ecLevel === "H" ? 32 : 0)
+  const leftFmt = RMQR_FORMAT_LEFT[fmtIdx]!
+  const rightFmt = RMQR_FORMAT_RIGHT[fmtIdx]!
 
   // Left format info: rows 1-5, cols 8-10 (bit = j*5+i), rows 1-3 col 11 (bits 15-17)
   for (let i = 0; i < 5; i++) {
     for (let j = 0; j < 3; j++) {
-      matrix[i + 1]![j + 8] = ((leftFmt >> (j * 5 + i)) & 1) === 1;
+      matrix[i + 1]![j + 8] = ((leftFmt >> (j * 5 + i)) & 1) === 1
     }
   }
-  matrix[1]![11] = ((leftFmt >> 15) & 1) === 1;
-  matrix[2]![11] = ((leftFmt >> 16) & 1) === 1;
-  matrix[3]![11] = ((leftFmt >> 17) & 1) === 1;
+  matrix[1]![11] = ((leftFmt >> 15) & 1) === 1
+  matrix[2]![11] = ((leftFmt >> 16) & 1) === 1
+  matrix[3]![11] = ((leftFmt >> 17) & 1) === 1
 
   // Right format info: rows (rows-6)-(rows-2), cols (cols-8)-(cols-6), + 3 extra
   for (let i = 0; i < 5; i++) {
     for (let j = 0; j < 3; j++) {
-      matrix[i + rows - 6]![j + cols - 8] = ((rightFmt >> (j * 5 + i)) & 1) === 1;
+      matrix[i + rows - 6]![j + cols - 8] = ((rightFmt >> (j * 5 + i)) & 1) === 1
     }
   }
-  matrix[rows - 6]![cols - 5] = ((rightFmt >> 15) & 1) === 1;
-  matrix[rows - 6]![cols - 4] = ((rightFmt >> 16) & 1) === 1;
-  matrix[rows - 6]![cols - 3] = ((rightFmt >> 17) & 1) === 1;
+  matrix[rows - 6]![cols - 5] = ((rightFmt >> 15) & 1) === 1
+  matrix[rows - 6]![cols - 4] = ((rightFmt >> 16) & 1) === 1
+  matrix[rows - 6]![cols - 3] = ((rightFmt >> 17) & 1) === 1
 
   // 6. Place data bits (column-pair zigzag, skip timing columns)
-  const allBits: number[] = [];
+  const allBits: number[] = []
   for (const byte of allBytes) {
-    pushBits(allBits, byte, 8);
+    pushBits(allBits, byte, 8)
   }
 
   // Record which cells are data (null) before placement
-  const isData: boolean[][] = matrix.map((row) => row.map((cell) => cell === null));
+  const isData: boolean[][] = matrix.map((row) => row.map((cell) => cell === null))
 
   // 6b. Data placement: exact Zint qr_populate_grid algorithm for rMQR
   // x_start = cols - 3 (righthand timing pattern)
   // Start from bottom (y = rows-1), going up, right col first then left
-  let i = 0;
-  const n = allBits.length;
-  let y = rows - 1;
-  let direction = 1; // 1 = up, 0 = down
-  let row = 0;
-  const xStart = cols - 3;
+  let i = 0
+  const n = allBits.length
+  let y = rows - 1
+  let direction = 1 // 1 = up, 0 = down
+  let row = 0
+  const xStart = cols - 3
 
   while (i < n) {
-    const x = xStart - row * 2;
-    if (x < 0) break;
+    const x = xStart - row * 2
+    if (x < 0) break
 
     // Right column of pair (x + 1)
     if (x + 1 < cols && matrix[y]![x + 1] === null) {
-      matrix[y]![x + 1] = allBits[i]! === 1;
-      i++;
+      matrix[y]![x + 1] = allBits[i]! === 1
+      i++
     }
 
     // Left column of pair (x)
     if (i < n && x >= 0 && matrix[y]![x] === null) {
-      matrix[y]![x] = allBits[i]! === 1;
-      i++;
+      matrix[y]![x] = allBits[i]! === 1
+      i++
     }
 
     if (direction === 1) {
-      y--;
+      y--
       if (y === -1) {
-        row++;
-        y = 0;
-        direction = 0;
+        row++
+        y = 0
+        direction = 0
       }
     } else {
-      y++;
+      y++
       if (y === rows) {
-        row++;
-        y = rows - 1;
-        direction = 1;
+        row++
+        y = rows - 1
+        direction = 1
       }
     }
   }
@@ -373,22 +373,22 @@ export function encodeRMQR(text: string, options: RMQROptions = {}): boolean[][]
   // Fill remaining data cells with 0
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
-      if (matrix[r]![c] === null) matrix[r]![c] = false;
+      if (matrix[r]![c] === null) matrix[r]![c] = false
     }
   }
 
   // 7. Apply mask: (row/2 + col/3) % 2 == 0 (fixed mask per ISO/IEC 23941)
-  const result = matrix.map((row) => row.map((cell) => cell === true));
+  const result = matrix.map((row) => row.map((cell) => cell === true))
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
       // Only mask data modules (recorded before data placement)
       if (isData[r]![c]) {
         if ((Math.floor(r / 2) + Math.floor(c / 3)) % 2 === 0) {
-          result[r]![c] = !result[r]![c];
+          result[r]![c] = !result[r]![c]
         }
       }
     }
   }
 
-  return result;
+  return result
 }

--- a/src/encoders/upc.ts
+++ b/src/encoders/upc.ts
@@ -2,7 +2,7 @@
  * UPC-A and UPC-E barcode encoder
  */
 
-import { InvalidInputError } from "../errors";
+import { InvalidInputError } from "../errors"
 
 // Encoding patterns for digits (same as EAN, duplicated to avoid inter-encoder dependencies)
 // L = left odd parity, G = left even parity, R = right
@@ -17,7 +17,7 @@ const L_PATTERNS: number[][] = [
   [1, 3, 1, 2], // 7
   [1, 2, 1, 3], // 8
   [3, 1, 1, 2], // 9
-];
+]
 
 const R_PATTERNS: number[][] = [
   [3, 2, 1, 1], // 0
@@ -30,7 +30,7 @@ const R_PATTERNS: number[][] = [
   [1, 3, 1, 2], // 7
   [1, 2, 1, 3], // 8
   [3, 1, 1, 2], // 9
-];
+]
 
 // G patterns (even parity, used for UPC-E encoding)
 const G_PATTERNS: number[][] = [
@@ -44,15 +44,15 @@ const G_PATTERNS: number[][] = [
   [2, 1, 3, 1], // 7
   [3, 1, 2, 1], // 8
   [2, 1, 1, 3], // 9
-];
+]
 
 // Guard patterns
-const GUARD_START = [1, 1, 1];
-const GUARD_CENTER = [1, 1, 1, 1, 1];
-const GUARD_END = [1, 1, 1];
+const GUARD_START = [1, 1, 1]
+const GUARD_CENTER = [1, 1, 1, 1, 1]
+const GUARD_END = [1, 1, 1]
 
 // UPC-E special end guard (6 modules)
-const GUARD_END_UPCE = [1, 1, 1, 1, 1, 1];
+const GUARD_END_UPCE = [1, 1, 1, 1, 1, 1]
 
 // UPC-E parity patterns for number system 0, indexed by check digit
 // O = odd parity (L_PATTERNS), E = even parity (G_PATTERNS)
@@ -67,17 +67,17 @@ const UPCE_PARITY_NS0: number[][] = [
   [1, 0, 1, 0, 1, 0], // 7: EOEOEO
   [1, 0, 1, 0, 0, 1], // 8: EOEOOE
   [1, 0, 0, 1, 0, 1], // 9: EOOEOE
-];
+]
 
 /**
  * Calculate UPC/EAN check digit using the standard weighted algorithm
  */
 function calculateCheckDigit(digits: number[]): number {
-  let sum = 0;
+  let sum = 0
   for (let i = 0; i < digits.length; i++) {
-    sum += digits[i]! * (i % 2 === 0 ? 3 : 1);
+    sum += digits[i]! * (i % 2 === 0 ? 3 : 1)
   }
-  return (10 - (sum % 10)) % 10;
+  return (10 - (sum % 10)) % 10
 }
 
 /**
@@ -85,31 +85,31 @@ function calculateCheckDigit(digits: number[]): number {
  * (without check digit). numberSystem is 0 or 1.
  */
 function expandUPCE(numberSystem: number, middleDigits: number[]): number[] {
-  const d = middleDigits;
-  const lastDigit = d[5]!;
+  const d = middleDigits
+  const lastDigit = d[5]!
 
-  let manufacturer: number[];
-  let product: number[];
+  let manufacturer: number[]
+  let product: number[]
 
   if (lastDigit === 0 || lastDigit === 1 || lastDigit === 2) {
     // NS + d1 d2 (lastDigit) 0000 d3 d4 d5 + check
-    manufacturer = [d[0]!, d[1]!, lastDigit, 0, 0];
-    product = [0, 0, d[2]!, d[3]!, d[4]!];
+    manufacturer = [d[0]!, d[1]!, lastDigit, 0, 0]
+    product = [0, 0, d[2]!, d[3]!, d[4]!]
   } else if (lastDigit === 3) {
     // NS + d1 d2 d3 00000 d4 d5 + check
-    manufacturer = [d[0]!, d[1]!, d[2]!, 0, 0];
-    product = [0, 0, 0, d[3]!, d[4]!];
+    manufacturer = [d[0]!, d[1]!, d[2]!, 0, 0]
+    product = [0, 0, 0, d[3]!, d[4]!]
   } else if (lastDigit === 4) {
     // NS + d1 d2 d3 d4 00000 d5 + check
-    manufacturer = [d[0]!, d[1]!, d[2]!, d[3]!, 0];
-    product = [0, 0, 0, 0, d[4]!];
+    manufacturer = [d[0]!, d[1]!, d[2]!, d[3]!, 0]
+    product = [0, 0, 0, 0, d[4]!]
   } else {
     // lastDigit 5-9: NS + d1 d2 d3 d4 d5 0000 (lastDigit) + check
-    manufacturer = [d[0]!, d[1]!, d[2]!, d[3]!, d[4]!];
-    product = [0, 0, 0, 0, lastDigit];
+    manufacturer = [d[0]!, d[1]!, d[2]!, d[3]!, d[4]!]
+    product = [0, 0, 0, 0, lastDigit]
   }
 
-  return [numberSystem, ...manufacturer, ...product];
+  return [numberSystem, ...manufacturer, ...product]
 }
 
 /**
@@ -119,67 +119,67 @@ function expandUPCE(numberSystem: number, middleDigits: number[]): number[] {
  * @returns bars (widths) and guard positions
  */
 export function encodeUPCA(text: string): { bars: number[]; guards: number[] } {
-  const digits = text.replace(/\D/g, "").split("").map(Number);
+  const digits = text.replace(/\D/g, "").split("").map(Number)
 
   if (digits.length === 11) {
-    digits.push(calculateCheckDigit(digits));
+    digits.push(calculateCheckDigit(digits))
   } else if (digits.length === 12) {
-    const expected = calculateCheckDigit(digits.slice(0, 11));
+    const expected = calculateCheckDigit(digits.slice(0, 11))
     if (digits[11] !== expected) {
       throw new InvalidInputError(
         `UPC-A check digit mismatch: expected ${expected}, got ${digits[11]}`,
-      );
+      )
     }
   } else {
-    throw new InvalidInputError("UPC-A requires 11 or 12 digits");
+    throw new InvalidInputError("UPC-A requires 11 or 12 digits")
   }
 
-  const bars: number[] = [];
-  const guards: number[] = [];
+  const bars: number[] = []
+  const guards: number[] = []
 
   // Start guard
-  let pos = 0;
-  guards.push(pos);
+  let pos = 0
+  guards.push(pos)
   for (const w of GUARD_START) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
   // Left 6 digits (all L encoding)
   for (let i = 0; i < 6; i++) {
-    const digit = digits[i]!;
-    const pattern = L_PATTERNS[digit]!;
+    const digit = digits[i]!
+    const pattern = L_PATTERNS[digit]!
     for (const w of pattern) {
-      bars.push(w);
-      pos++;
+      bars.push(w)
+      pos++
     }
   }
 
   // Center guard
-  guards.push(pos);
+  guards.push(pos)
   for (const w of GUARD_CENTER) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
   // Right 6 digits (all R encoding)
   for (let i = 0; i < 6; i++) {
-    const digit = digits[i + 6]!;
-    const pattern = R_PATTERNS[digit]!;
+    const digit = digits[i + 6]!
+    const pattern = R_PATTERNS[digit]!
     for (const w of pattern) {
-      bars.push(w);
-      pos++;
+      bars.push(w)
+      pos++
     }
   }
 
   // End guard
-  guards.push(pos);
+  guards.push(pos)
   for (const w of GUARD_END) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
-  return { bars, guards };
+  return { bars, guards }
 }
 
 /**
@@ -196,94 +196,94 @@ export function encodeUPCA(text: string): { bars: number[]; guards: number[] } {
  * @returns bars (widths) and guard positions
  */
 export function encodeUPCE(text: string): { bars: number[]; guards: number[] } {
-  const raw = text.replace(/\D/g, "").split("").map(Number);
+  const raw = text.replace(/\D/g, "").split("").map(Number)
 
-  let numberSystem: number;
-  let middleDigits: number[];
-  let checkDigit: number;
+  let numberSystem: number
+  let middleDigits: number[]
+  let checkDigit: number
 
   if (raw.length === 6) {
     // 6 digits: NS=0, auto-calculate check
-    numberSystem = 0;
-    middleDigits = raw;
-    const expanded = expandUPCE(numberSystem, middleDigits);
-    checkDigit = calculateCheckDigit(expanded);
+    numberSystem = 0
+    middleDigits = raw
+    const expanded = expandUPCE(numberSystem, middleDigits)
+    checkDigit = calculateCheckDigit(expanded)
   } else if (raw.length === 7) {
     // 7 digits: ambiguous — if first digit is 0 or 1, treat as NS + 6 middle
     // otherwise treat as 6 middle + check (NS=0)
     if (raw[0] === 0 || raw[0] === 1) {
-      numberSystem = raw[0]!;
-      middleDigits = raw.slice(1);
-      const expanded = expandUPCE(numberSystem, middleDigits);
-      checkDigit = calculateCheckDigit(expanded);
+      numberSystem = raw[0]!
+      middleDigits = raw.slice(1)
+      const expanded = expandUPCE(numberSystem, middleDigits)
+      checkDigit = calculateCheckDigit(expanded)
     } else {
-      numberSystem = 0;
-      middleDigits = raw.slice(0, 6);
-      const expanded = expandUPCE(numberSystem, middleDigits);
-      checkDigit = calculateCheckDigit(expanded);
-      const provided = raw[6]!;
+      numberSystem = 0
+      middleDigits = raw.slice(0, 6)
+      const expanded = expandUPCE(numberSystem, middleDigits)
+      checkDigit = calculateCheckDigit(expanded)
+      const provided = raw[6]!
       if (provided !== checkDigit) {
         throw new InvalidInputError(
           `UPC-E check digit mismatch: expected ${checkDigit}, got ${provided}`,
-        );
+        )
       }
     }
   } else if (raw.length === 8) {
     // 8 digits: NS + 6 middle + check
-    numberSystem = raw[0]!;
+    numberSystem = raw[0]!
     if (numberSystem !== 0 && numberSystem !== 1) {
-      throw new InvalidInputError(`UPC-E number system must be 0 or 1, got ${numberSystem}`);
+      throw new InvalidInputError(`UPC-E number system must be 0 or 1, got ${numberSystem}`)
     }
-    middleDigits = raw.slice(1, 7);
-    const expanded = expandUPCE(numberSystem, middleDigits);
-    checkDigit = calculateCheckDigit(expanded);
-    const provided = raw[7]!;
+    middleDigits = raw.slice(1, 7)
+    const expanded = expandUPCE(numberSystem, middleDigits)
+    checkDigit = calculateCheckDigit(expanded)
+    const provided = raw[7]!
     if (provided !== checkDigit) {
       throw new InvalidInputError(
         `UPC-E check digit mismatch: expected ${checkDigit}, got ${provided}`,
-      );
+      )
     }
   } else {
-    throw new InvalidInputError("UPC-E requires 6, 7, or 8 digits");
+    throw new InvalidInputError("UPC-E requires 6, 7, or 8 digits")
   }
 
   // Determine parity pattern based on number system and check digit
-  let parityPattern: number[];
+  let parityPattern: number[]
   if (numberSystem === 0) {
-    parityPattern = UPCE_PARITY_NS0[checkDigit]!;
+    parityPattern = UPCE_PARITY_NS0[checkDigit]!
   } else {
     // Number system 1: invert the parity (E <-> O)
-    parityPattern = UPCE_PARITY_NS0[checkDigit]!.map((p) => (p === 0 ? 1 : 0));
+    parityPattern = UPCE_PARITY_NS0[checkDigit]!.map((p) => (p === 0 ? 1 : 0))
   }
 
-  const bars: number[] = [];
-  const guards: number[] = [];
+  const bars: number[] = []
+  const guards: number[] = []
 
   // Start guard
-  let pos = 0;
-  guards.push(pos);
+  let pos = 0
+  guards.push(pos)
   for (const w of GUARD_START) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
   // 6 data digits encoded with odd/even parity
   for (let i = 0; i < 6; i++) {
-    const digit = middleDigits[i]!;
+    const digit = middleDigits[i]!
     // 1 = even parity (G_PATTERNS), 0 = odd parity (L_PATTERNS)
-    const pattern = parityPattern[i] === 1 ? G_PATTERNS[digit]! : L_PATTERNS[digit]!;
+    const pattern = parityPattern[i] === 1 ? G_PATTERNS[digit]! : L_PATTERNS[digit]!
     for (const w of pattern) {
-      bars.push(w);
-      pos++;
+      bars.push(w)
+      pos++
     }
   }
 
   // End guard (special 6-module UPC-E end guard)
-  guards.push(pos);
+  guards.push(pos)
   for (const w of GUARD_END_UPCE) {
-    bars.push(w);
-    pos++;
+    bars.push(w)
+    pos++
   }
 
-  return { bars, guards };
+  return { bars, guards }
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,37 +1,37 @@
 // Runtime globals available in Node.js 16+ and all modern browsers
 declare class TextEncoder {
-  encode(input?: string): Uint8Array;
+  encode(input?: string): Uint8Array
 }
 
-declare function btoa(data: string): string;
-declare function atob(data: string): string;
+declare function btoa(data: string): string
+declare function atob(data: string): string
 
 // Node.js globals for CLI
 declare var process: {
-  argv: string[];
-  stdout: { write(s: string | Uint8Array): boolean };
-  stderr: { write(s: string | Uint8Array): boolean };
-  exit(code?: number): never;
-  exitCode?: number;
-};
+  argv: string[]
+  stdout: { write(s: string | Uint8Array): boolean }
+  stderr: { write(s: string | Uint8Array): boolean }
+  exit(code?: number): never
+  exitCode?: number
+}
 
 declare module "node:fs" {
-  export function writeFileSync(path: string, data: string | Uint8Array, encoding?: string): void;
-  export function readFileSync(path: string, encoding: string): string;
-  export function readFileSync(path: string): Uint8Array;
-  export function mkdtempSync(prefix: string): string;
-  export function rmSync(path: string, options?: { recursive?: boolean; force?: boolean }): void;
+  export function writeFileSync(path: string, data: string | Uint8Array, encoding?: string): void
+  export function readFileSync(path: string, encoding: string): string
+  export function readFileSync(path: string): Uint8Array
+  export function mkdtempSync(prefix: string): string
+  export function rmSync(path: string, options?: { recursive?: boolean; force?: boolean }): void
 }
 
 declare module "node:os" {
-  export function tmpdir(): string;
+  export function tmpdir(): string
 }
 
 declare module "node:url" {
-  export function fileURLToPath(url: string | URL): string;
+  export function fileURLToPath(url: string | URL): string
 }
 
 declare module "node:path" {
-  export function dirname(path: string): string;
-  export function join(...paths: string[]): string;
+  export function dirname(path: string): string
+  export function join(...paths: string[]): string
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,17 +3,17 @@
  */
 
 export class EtiketError extends Error {
-  override name = "EtiketError";
+  override name = "EtiketError"
 }
 
 export class InvalidInputError extends EtiketError {
-  override name = "InvalidInputError";
+  override name = "InvalidInputError"
 }
 
 export class CapacityError extends EtiketError {
-  override name = "CapacityError";
+  override name = "CapacityError"
 }
 
 export class CheckDigitError extends EtiketError {
-  override name = "CheckDigitError";
+  override name = "CheckDigitError"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@
  */
 
 // --- High-level API ---
-export { barcode, barcodeDataURI, barcodeBase64, encodeBars } from "./_barcode";
-export { qrcode, qrcodeTerminal, qrcodeDataURI, qrcodeBase64 } from "./_qrcode";
+export { barcode, barcodeDataURI, barcodeBase64, encodeBars } from "./_barcode"
+export { qrcode, qrcodeTerminal, qrcodeDataURI, qrcodeBase64 } from "./_qrcode"
 export {
   datamatrix,
   gs1datamatrix,
@@ -27,10 +27,10 @@ export {
   codablockf,
   code16k,
   jabcode,
-} from "./_2d";
-export { postal, postalDataURI, postalBase64, encodePostal } from "./_postal";
-export type { PostalType, PostalEncodingOptions, PostalOptions } from "./_postal";
-export { encode } from "./_encode";
+} from "./_2d"
+export { postal, postalDataURI, postalBase64, encodePostal } from "./_postal"
+export type { PostalType, PostalEncodingOptions, PostalOptions } from "./_postal"
+export { encode } from "./_encode"
 export {
   wifi,
   url,
@@ -43,7 +43,7 @@ export {
   event,
   swissQR,
   gs1DigitalLink,
-} from "./_helpers";
+} from "./_helpers"
 
 // --- Types ---
 export type {
@@ -56,9 +56,9 @@ export type {
   Encode1DResult,
   Encode2DResult,
   EncodePostalResult,
-} from "./_types";
-export type { BarcodeSVGOptions, QRCodeSVGOptions } from "./renderers/svg/types";
-export type { QRCodeOptions } from "./encoders/qr/types";
+} from "./_types"
+export type { BarcodeSVGOptions, QRCodeSVGOptions } from "./renderers/svg/types"
+export type { QRCodeOptions } from "./encoders/qr/types"
 export type {
   DotType,
   GradientOptions,
@@ -68,71 +68,66 @@ export type {
   LogoOptions,
   MeasurementUnit,
   SVGAccessibilityOptions,
-} from "./renderers/svg/types";
-export type { ErrorCorrectionLevel, EncodingMode } from "./encoders/qr/types";
+} from "./renderers/svg/types"
+export type { ErrorCorrectionLevel, EncodingMode } from "./encoders/qr/types"
 
 // --- Raw encoders ---
-export { encodeCode128 } from "./encoders/code128";
-export type { Code128Charset, Code128Options } from "./encoders/code128";
-export { encodeEAN13, encodeEAN8 } from "./encoders/ean";
-export { encodeQR } from "./encoders/qr/index";
-export { encodeMicroQR } from "./encoders/qr/micro";
-export type { MicroQROptions } from "./encoders/qr/micro";
-export { encodeCode39, encodeCode39Extended } from "./encoders/code39";
-export { encodeCode93, encodeCode93Extended } from "./encoders/code93";
-export { encodeITF, encodeITF14 } from "./encoders/itf";
-export { encodeUPCA, encodeUPCE } from "./encoders/upc";
-export { encodeEAN2, encodeEAN5 } from "./encoders/ean-addon";
-export { encodeCodabar } from "./encoders/codabar";
-export { encodeMSI } from "./encoders/msi";
-export type { MSICheckDigitType } from "./encoders/msi";
-export { encodePharmacode } from "./encoders/pharmacode";
-export { encodeCode11 } from "./encoders/code11";
-export { encodeGS1128 } from "./encoders/gs1-128";
-export { encodeIdentcode, encodeLeitcode } from "./encoders/deutsche-post";
-export { encodePOSTNET, encodePLANET } from "./encoders/postnet";
-export { encodePlessey } from "./encoders/plessey";
-export { encodeGS1Composite } from "./encoders/gs1-composite";
-export type { CompositeType, GS1CompositeResult } from "./encoders/gs1-composite";
+export { encodeCode128 } from "./encoders/code128"
+export type { Code128Charset, Code128Options } from "./encoders/code128"
+export { encodeEAN13, encodeEAN8 } from "./encoders/ean"
+export { encodeQR } from "./encoders/qr/index"
+export { encodeMicroQR } from "./encoders/qr/micro"
+export type { MicroQROptions } from "./encoders/qr/micro"
+export { encodeCode39, encodeCode39Extended } from "./encoders/code39"
+export { encodeCode93, encodeCode93Extended } from "./encoders/code93"
+export { encodeITF, encodeITF14 } from "./encoders/itf"
+export { encodeUPCA, encodeUPCE } from "./encoders/upc"
+export { encodeEAN2, encodeEAN5 } from "./encoders/ean-addon"
+export { encodeCodabar } from "./encoders/codabar"
+export { encodeMSI } from "./encoders/msi"
+export type { MSICheckDigitType } from "./encoders/msi"
+export { encodePharmacode } from "./encoders/pharmacode"
+export { encodeCode11 } from "./encoders/code11"
+export { encodeGS1128 } from "./encoders/gs1-128"
+export { encodeIdentcode, encodeLeitcode } from "./encoders/deutsche-post"
+export { encodePOSTNET, encodePLANET } from "./encoders/postnet"
+export { encodePlessey } from "./encoders/plessey"
+export { encodeGS1Composite } from "./encoders/gs1-composite"
+export type { CompositeType, GS1CompositeResult } from "./encoders/gs1-composite"
 export {
   encodeGS1DataBarOmni,
   encodeGS1DataBarLimited,
   encodeGS1DataBarExpanded,
-} from "./encoders/gs1-databar";
-export {
-  encodeRM4SCC,
-  encodeKIX,
-  encodeAustraliaPost,
-  encodeJapanPost,
-} from "./encoders/fourstate";
-export type { FourState } from "./encoders/fourstate";
-export { encodeIMb } from "./encoders/imb";
-export { encodeCodablockF } from "./encoders/codablock-f";
-export { encodeCode16K } from "./encoders/code16k";
-export { encodeMaxiCode } from "./encoders/maxicode";
-export type { MaxiCodeOptions } from "./encoders/maxicode";
-export { encodeRMQR } from "./encoders/rmqr";
-export type { RMQROptions } from "./encoders/rmqr";
-export { encodeDotCode } from "./encoders/dotcode";
-export { encodeHanXin } from "./encoders/hanxin";
-export type { HanXinOptions } from "./encoders/hanxin";
-export { encodeJABCode, JAB_COLORS_4, JAB_COLORS_8 } from "./encoders/jabcode";
-export type { JABCodeOptions, JABCodeResult } from "./encoders/jabcode";
-export { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index";
-export { encodePDF417 } from "./encoders/pdf417/index";
-export type { PDF417Options } from "./encoders/pdf417/index";
-export { encodeMicroPDF417 } from "./encoders/micropdf417";
-export type { MicroPDF417Options } from "./encoders/micropdf417";
-export { encodeAztec } from "./encoders/aztec/index";
-export type { AztecOptions } from "./encoders/aztec/index";
-export { encodeHIBCPrimary, encodeHIBCSecondary, encodeHIBCConcatenated } from "./encoders/hibc";
+} from "./encoders/gs1-databar"
+export { encodeRM4SCC, encodeKIX, encodeAustraliaPost, encodeJapanPost } from "./encoders/fourstate"
+export type { FourState } from "./encoders/fourstate"
+export { encodeIMb } from "./encoders/imb"
+export { encodeCodablockF } from "./encoders/codablock-f"
+export { encodeCode16K } from "./encoders/code16k"
+export { encodeMaxiCode } from "./encoders/maxicode"
+export type { MaxiCodeOptions } from "./encoders/maxicode"
+export { encodeRMQR } from "./encoders/rmqr"
+export type { RMQROptions } from "./encoders/rmqr"
+export { encodeDotCode } from "./encoders/dotcode"
+export { encodeHanXin } from "./encoders/hanxin"
+export type { HanXinOptions } from "./encoders/hanxin"
+export { encodeJABCode, JAB_COLORS_4, JAB_COLORS_8 } from "./encoders/jabcode"
+export type { JABCodeOptions, JABCodeResult } from "./encoders/jabcode"
+export { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index"
+export { encodePDF417 } from "./encoders/pdf417/index"
+export type { PDF417Options } from "./encoders/pdf417/index"
+export { encodeMicroPDF417 } from "./encoders/micropdf417"
+export type { MicroPDF417Options } from "./encoders/micropdf417"
+export { encodeAztec } from "./encoders/aztec/index"
+export type { AztecOptions } from "./encoders/aztec/index"
+export { encodeHIBCPrimary, encodeHIBCSecondary, encodeHIBCConcatenated } from "./encoders/hibc"
 export {
   encodeISBT128DIN,
   encodeISBT128Component,
   encodeISBT128Expiry,
   encodeISBT128BloodGroup,
   iso7064Mod37_2,
-} from "./encoders/isbt128";
+} from "./encoders/isbt128"
 
 // --- PNG ---
 export {
@@ -166,8 +161,8 @@ export {
   code16kPNGDataURI,
   maxicodePNG,
   maxicodePNGDataURI,
-} from "./_png";
-export type { BarcodePNGOptions, MatrixPNGOptions, PostalPNGOptions } from "./renderers/png/types";
+} from "./_png"
+export type { BarcodePNGOptions, MatrixPNGOptions, PostalPNGOptions } from "./renderers/png/types"
 export {
   renderBarcodeRaster,
   renderMatrixRaster,
@@ -177,25 +172,25 @@ export {
   renderPostalPNG,
   renderMaxiCodeRaster,
   renderMaxiCodePNG,
-} from "./renderers/png/rasterize";
-export type { RasterData } from "./renderers/png/rasterize";
-export { encodePNG } from "./renderers/png/png-encoder";
+} from "./renderers/png/rasterize"
+export type { RasterData } from "./renderers/png/rasterize"
+export { encodePNG } from "./renderers/png/png-encoder"
 
 // --- Renderers ---
-export { renderBarcodeSVG } from "./renderers/svg/barcode";
-export { renderQRCodeSVG } from "./renderers/svg/qr";
-export { renderMatrixSVG, renderMaxiCodeSVG } from "./renderers/svg/matrix";
-export type { MatrixSVGOptions } from "./renderers/svg/matrix";
-export { renderPostalSVG } from "./renderers/svg/postal";
-export type { PostalSVGOptions, PostalBar } from "./renderers/svg/postal";
-export { renderColorMatrixSVG } from "./renderers/svg/color-matrix";
-export type { ColorMatrixSVGOptions } from "./renderers/svg/color-matrix";
-export { renderText } from "./renderers/text";
-export { svgToDataURI, svgToBase64, svgToBase64Raw } from "./renderers/data-uri";
-export { optimizeSVG } from "./renderers/svg/optimize";
+export { renderBarcodeSVG } from "./renderers/svg/barcode"
+export { renderQRCodeSVG } from "./renderers/svg/qr"
+export { renderMatrixSVG, renderMaxiCodeSVG } from "./renderers/svg/matrix"
+export type { MatrixSVGOptions } from "./renderers/svg/matrix"
+export { renderPostalSVG } from "./renderers/svg/postal"
+export type { PostalSVGOptions, PostalBar } from "./renderers/svg/postal"
+export { renderColorMatrixSVG } from "./renderers/svg/color-matrix"
+export type { ColorMatrixSVGOptions } from "./renderers/svg/color-matrix"
+export { renderText } from "./renderers/text"
+export { svgToDataURI, svgToBase64, svgToBase64Raw } from "./renderers/data-uri"
+export { optimizeSVG } from "./renderers/svg/optimize"
 
 // --- Errors ---
-export { EtiketError, InvalidInputError, CapacityError, CheckDigitError } from "./errors";
+export { EtiketError, InvalidInputError, CapacityError, CheckDigitError } from "./errors"
 
 // --- Validators ---
 export {
@@ -204,6 +199,6 @@ export {
   calculateEANCheckDigit,
   verifyEANCheckDigit,
   validateBarcodeInput,
-} from "./validators/barcode";
-export { validateQRInput } from "./validators/qr";
-export type { QRValidationResult } from "./validators/qr";
+} from "./validators/barcode"
+export { validateQRInput } from "./validators/qr"
+export type { QRValidationResult } from "./validators/qr"

--- a/src/pdf417.ts
+++ b/src/pdf417.ts
@@ -2,10 +2,10 @@
  * PDF417-only entry point for tree-shaking
  */
 
-export { pdf417, micropdf417 } from "./_2d";
-export { encodePDF417 } from "./encoders/pdf417/index";
-export type { PDF417Options } from "./encoders/pdf417/index";
-export { encodeMicroPDF417 } from "./encoders/micropdf417";
-export type { MicroPDF417Options } from "./encoders/micropdf417";
-export { renderMatrixSVG } from "./renderers/svg/matrix";
-export type { MatrixSVGOptions } from "./renderers/svg/matrix";
+export { pdf417, micropdf417 } from "./_2d"
+export { encodePDF417 } from "./encoders/pdf417/index"
+export type { PDF417Options } from "./encoders/pdf417/index"
+export { encodeMicroPDF417 } from "./encoders/micropdf417"
+export type { MicroPDF417Options } from "./encoders/micropdf417"
+export { renderMatrixSVG } from "./renderers/svg/matrix"
+export type { MatrixSVGOptions } from "./renderers/svg/matrix"

--- a/src/png.ts
+++ b/src/png.ts
@@ -38,10 +38,10 @@ export {
   code16kPNGDataURI,
   maxicodePNG,
   maxicodePNGDataURI,
-} from "./_png";
-export type { BarcodeEncodingOptions } from "./_types";
-export type { PostalEncodingOptions, PostalType } from "./_postal";
-export type { BarcodePNGOptions, MatrixPNGOptions, PostalPNGOptions } from "./renderers/png/types";
+} from "./_png"
+export type { BarcodeEncodingOptions } from "./_types"
+export type { PostalEncodingOptions, PostalType } from "./_postal"
+export type { BarcodePNGOptions, MatrixPNGOptions, PostalPNGOptions } from "./renderers/png/types"
 export {
   renderBarcodeRaster,
   renderMatrixRaster,
@@ -51,6 +51,6 @@ export {
   renderPostalPNG,
   renderMaxiCodeRaster,
   renderMaxiCodePNG,
-} from "./renderers/png/rasterize";
-export type { RasterData } from "./renderers/png/rasterize";
-export { encodePNG } from "./renderers/png/png-encoder";
+} from "./renderers/png/rasterize"
+export type { RasterData } from "./renderers/png/rasterize"
+export { encodePNG } from "./renderers/png/png-encoder"

--- a/src/postal.ts
+++ b/src/postal.ts
@@ -12,18 +12,13 @@
  * ```
  */
 
-export { postal, postalDataURI, postalBase64, encodePostal } from "./_postal";
-export type { PostalType, PostalEncodingOptions, PostalOptions } from "./_postal";
+export { postal, postalDataURI, postalBase64, encodePostal } from "./_postal"
+export type { PostalType, PostalEncodingOptions, PostalOptions } from "./_postal"
 
-export { encodePOSTNET, encodePLANET } from "./encoders/postnet";
-export {
-  encodeRM4SCC,
-  encodeKIX,
-  encodeAustraliaPost,
-  encodeJapanPost,
-} from "./encoders/fourstate";
-export type { FourState } from "./encoders/fourstate";
-export { encodeIMb } from "./encoders/imb";
+export { encodePOSTNET, encodePLANET } from "./encoders/postnet"
+export { encodeRM4SCC, encodeKIX, encodeAustraliaPost, encodeJapanPost } from "./encoders/fourstate"
+export type { FourState } from "./encoders/fourstate"
+export { encodeIMb } from "./encoders/imb"
 
-export { renderPostalSVG } from "./renderers/svg/postal";
-export type { PostalSVGOptions, PostalBar } from "./renderers/svg/postal";
+export { renderPostalSVG } from "./renderers/svg/postal"
+export type { PostalSVGOptions, PostalBar } from "./renderers/svg/postal"

--- a/src/qr.ts
+++ b/src/qr.ts
@@ -7,18 +7,18 @@
  * ```
  */
 
-export { qrcode, qrcodeTerminal, qrcodeDataURI, qrcodeBase64 } from "./_qrcode";
-export { microqr, rmqr } from "./_2d";
-export type { QRCodeSVGOptions } from "./renderers/svg/types";
-export type { QRCodeOptions, ErrorCorrectionLevel, EncodingMode } from "./encoders/qr/types";
-export type { DotType, GradientOptions, CornerOptions, LogoOptions } from "./renderers/svg/types";
+export { qrcode, qrcodeTerminal, qrcodeDataURI, qrcodeBase64 } from "./_qrcode"
+export { microqr, rmqr } from "./_2d"
+export type { QRCodeSVGOptions } from "./renderers/svg/types"
+export type { QRCodeOptions, ErrorCorrectionLevel, EncodingMode } from "./encoders/qr/types"
+export type { DotType, GradientOptions, CornerOptions, LogoOptions } from "./renderers/svg/types"
 
-export { encodeQR } from "./encoders/qr/index";
-export { encodeMicroQR } from "./encoders/qr/micro";
-export type { MicroQROptions } from "./encoders/qr/micro";
-export { encodeRMQR } from "./encoders/rmqr";
-export type { RMQROptions } from "./encoders/rmqr";
-export { renderQRCodeSVG } from "./renderers/svg/qr";
-export { renderMatrixSVG } from "./renderers/svg/matrix";
-export type { MatrixSVGOptions } from "./renderers/svg/matrix";
-export { renderText } from "./renderers/text";
+export { encodeQR } from "./encoders/qr/index"
+export { encodeMicroQR } from "./encoders/qr/micro"
+export type { MicroQROptions } from "./encoders/qr/micro"
+export { encodeRMQR } from "./encoders/rmqr"
+export type { RMQROptions } from "./encoders/rmqr"
+export { renderQRCodeSVG } from "./renderers/svg/qr"
+export { renderMatrixSVG } from "./renderers/svg/matrix"
+export type { MatrixSVGOptions } from "./renderers/svg/matrix"
+export { renderText } from "./renderers/text"

--- a/src/renderers/data-uri.ts
+++ b/src/renderers/data-uri.ts
@@ -16,9 +16,9 @@ export function svgToDataURI(svg: string): string {
     .replace(/{/g, "%7B")
     .replace(/}/g, "%7D")
     .replace(/</g, "%3C")
-    .replace(/>/g, "%3E");
+    .replace(/>/g, "%3E")
 
-  return `data:image/svg+xml,${encoded}`;
+  return `data:image/svg+xml,${encoded}`
 }
 
 /**
@@ -26,25 +26,25 @@ export function svgToDataURI(svg: string): string {
  * Replaces the deprecated unescape(encodeURIComponent(…)) pattern.
  */
 function utf8ToBinary(str: string): string {
-  const bytes = new TextEncoder().encode(str);
-  let binary = "";
+  const bytes = new TextEncoder().encode(str)
+  let binary = ""
   for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
+    binary += String.fromCharCode(byte)
   }
-  return binary;
+  return binary
 }
 
 /**
  * Convert SVG string to base64 data URI
  */
 export function svgToBase64(svg: string): string {
-  const base64 = btoa(utf8ToBinary(svg));
-  return `data:image/svg+xml;base64,${base64}`;
+  const base64 = btoa(utf8ToBinary(svg))
+  return `data:image/svg+xml;base64,${base64}`
 }
 
 /**
  * Convert SVG string to a plain base64 string (no data URI prefix)
  */
 export function svgToBase64Raw(svg: string): string {
-  return btoa(utf8ToBinary(svg));
+  return btoa(utf8ToBinary(svg))
 }

--- a/src/renderers/png/adler32.ts
+++ b/src/renderers/png/adler32.ts
@@ -3,11 +3,11 @@
  */
 
 export function adler32(data: Uint8Array): number {
-  let a = 1;
-  let b = 0;
+  let a = 1
+  let b = 0
   for (let i = 0; i < data.length; i++) {
-    a = (a + data[i]!) % 65521;
-    b = (b + a) % 65521;
+    a = (a + data[i]!) % 65521
+    b = (b + a) % 65521
   }
-  return ((b << 16) | a) >>> 0;
+  return ((b << 16) | a) >>> 0
 }

--- a/src/renderers/png/crc32.ts
+++ b/src/renderers/png/crc32.ts
@@ -3,21 +3,21 @@
  */
 
 const TABLE = /* @__PURE__ */ (() => {
-  const t = new Uint32Array(256);
+  const t = new Uint32Array(256)
   for (let n = 0; n < 256; n++) {
-    let c = n;
+    let c = n
     for (let k = 0; k < 8; k++) {
-      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
     }
-    t[n] = c;
+    t[n] = c
   }
-  return t;
-})();
+  return t
+})()
 
 export function crc32(data: Uint8Array): number {
-  let crc = 0xffffffff;
+  let crc = 0xffffffff
   for (let i = 0; i < data.length; i++) {
-    crc = TABLE[(crc ^ data[i]!) & 0xff]! ^ (crc >>> 8);
+    crc = TABLE[(crc ^ data[i]!) & 0xff]! ^ (crc >>> 8)
   }
-  return (crc ^ 0xffffffff) >>> 0;
+  return (crc ^ 0xffffffff) >>> 0
 }

--- a/src/renderers/png/deflate.ts
+++ b/src/renderers/png/deflate.ts
@@ -3,52 +3,52 @@
  * Wrapped in zlib format for PNG IDAT chunks
  */
 
-import { adler32 } from "./adler32";
+import { adler32 } from "./adler32"
 
 /**
  * DEFLATE stored blocks (no compression). Returns raw DEFLATE bitstream.
  */
 export function deflateRaw(data: Uint8Array): Uint8Array {
-  const MAX_BLOCK = 65535;
-  const numBlocks = Math.ceil(data.length / MAX_BLOCK) || 1;
-  const out = new Uint8Array(numBlocks * 5 + data.length);
-  let pos = 0;
-  let offset = 0;
+  const MAX_BLOCK = 65535
+  const numBlocks = Math.ceil(data.length / MAX_BLOCK) || 1
+  const out = new Uint8Array(numBlocks * 5 + data.length)
+  let pos = 0
+  let offset = 0
 
   while (offset < data.length || pos === 0) {
-    const remaining = data.length - offset;
-    const blockLen = Math.min(remaining, MAX_BLOCK);
-    const isFinal = offset + blockLen >= data.length;
+    const remaining = data.length - offset
+    const blockLen = Math.min(remaining, MAX_BLOCK)
+    const isFinal = offset + blockLen >= data.length
 
-    out[pos++] = isFinal ? 0x01 : 0x00;
-    out[pos++] = blockLen & 0xff;
-    out[pos++] = (blockLen >> 8) & 0xff;
-    out[pos++] = ~blockLen & 0xff;
-    out[pos++] = (~blockLen >> 8) & 0xff;
-    out.set(data.subarray(offset, offset + blockLen), pos);
-    pos += blockLen;
-    offset += blockLen;
+    out[pos++] = isFinal ? 0x01 : 0x00
+    out[pos++] = blockLen & 0xff
+    out[pos++] = (blockLen >> 8) & 0xff
+    out[pos++] = ~blockLen & 0xff
+    out[pos++] = (~blockLen >> 8) & 0xff
+    out.set(data.subarray(offset, offset + blockLen), pos)
+    pos += blockLen
+    offset += blockLen
   }
 
-  return out.subarray(0, pos);
+  return out.subarray(0, pos)
 }
 
 /**
  * Zlib-wrapped DEFLATE (what PNG IDAT chunks expect).
  */
 export function zlibCompress(data: Uint8Array): Uint8Array {
-  const deflated = deflateRaw(data);
-  const checksum = adler32(data);
+  const deflated = deflateRaw(data)
+  const checksum = adler32(data)
 
-  const out = new Uint8Array(2 + deflated.length + 4);
-  out[0] = 0x78; // CMF
-  out[1] = 0x01; // FLG
-  out.set(deflated, 2);
-  const adlerOffset = 2 + deflated.length;
-  out[adlerOffset] = (checksum >> 24) & 0xff;
-  out[adlerOffset + 1] = (checksum >> 16) & 0xff;
-  out[adlerOffset + 2] = (checksum >> 8) & 0xff;
-  out[adlerOffset + 3] = checksum & 0xff;
+  const out = new Uint8Array(2 + deflated.length + 4)
+  out[0] = 0x78 // CMF
+  out[1] = 0x01 // FLG
+  out.set(deflated, 2)
+  const adlerOffset = 2 + deflated.length
+  out[adlerOffset] = (checksum >> 24) & 0xff
+  out[adlerOffset + 1] = (checksum >> 16) & 0xff
+  out[adlerOffset + 2] = (checksum >> 8) & 0xff
+  out[adlerOffset + 3] = checksum & 0xff
 
-  return out;
+  return out
 }

--- a/src/renderers/png/png-encoder.ts
+++ b/src/renderers/png/png-encoder.ts
@@ -3,10 +3,10 @@
  * Supports indexed color (2-entry palette for barcode/QR) and true color (RGBA)
  */
 
-import { crc32 } from "./crc32";
-import { zlibCompress } from "./deflate";
+import { crc32 } from "./crc32"
+import { zlibCompress } from "./deflate"
 
-const PNG_SIGNATURE = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+const PNG_SIGNATURE = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
 
 function createChunk(type: string, data: Uint8Array): Uint8Array {
   const typeBytes = new Uint8Array([
@@ -14,19 +14,19 @@ function createChunk(type: string, data: Uint8Array): Uint8Array {
     type.charCodeAt(1),
     type.charCodeAt(2),
     type.charCodeAt(3),
-  ]);
-  const chunk = new Uint8Array(4 + 4 + data.length + 4);
-  const view = new DataView(chunk.buffer);
+  ])
+  const chunk = new Uint8Array(4 + 4 + data.length + 4)
+  const view = new DataView(chunk.buffer)
 
-  view.setUint32(0, data.length);
-  chunk.set(typeBytes, 4);
-  chunk.set(data, 8);
-  const crcData = new Uint8Array(4 + data.length);
-  crcData.set(typeBytes, 0);
-  crcData.set(data, 4);
-  view.setUint32(8 + data.length, crc32(crcData));
+  view.setUint32(0, data.length)
+  chunk.set(typeBytes, 4)
+  chunk.set(data, 8)
+  const crcData = new Uint8Array(4 + data.length)
+  crcData.set(typeBytes, 0)
+  crcData.set(data, 4)
+  view.setUint32(8 + data.length, crc32(crcData))
 
-  return chunk;
+  return chunk
 }
 
 /**
@@ -40,64 +40,64 @@ export function encodePNG(
   bg: [number, number, number],
   useUpFilter = false,
 ): Uint8Array {
-  const ihdrData = new Uint8Array(13);
-  const ihdrView = new DataView(ihdrData.buffer);
-  ihdrView.setUint32(0, width);
-  ihdrView.setUint32(4, height);
-  ihdrData[8] = 8; // bit depth
-  ihdrData[9] = 3; // color type: indexed
-  ihdrData[10] = 0;
-  ihdrData[11] = 0;
-  ihdrData[12] = 0;
+  const ihdrData = new Uint8Array(13)
+  const ihdrView = new DataView(ihdrData.buffer)
+  ihdrView.setUint32(0, width)
+  ihdrView.setUint32(4, height)
+  ihdrData[8] = 8 // bit depth
+  ihdrData[9] = 3 // color type: indexed
+  ihdrData[10] = 0
+  ihdrData[11] = 0
+  ihdrData[12] = 0
 
-  const plteData = new Uint8Array(6);
-  plteData[0] = bg[0];
-  plteData[1] = bg[1];
-  plteData[2] = bg[2];
-  plteData[3] = fg[0];
-  plteData[4] = fg[1];
-  plteData[5] = fg[2];
+  const plteData = new Uint8Array(6)
+  plteData[0] = bg[0]
+  plteData[1] = bg[1]
+  plteData[2] = bg[2]
+  plteData[3] = fg[0]
+  plteData[4] = fg[1]
+  plteData[5] = fg[2]
 
-  const rawSize = height * (1 + width);
-  const rawData = new Uint8Array(rawSize);
-  let pos = 0;
+  const rawSize = height * (1 + width)
+  const rawData = new Uint8Array(rawSize)
+  let pos = 0
 
   for (let y = 0; y < height; y++) {
-    const row = rows[y]!;
+    const row = rows[y]!
     if (useUpFilter && y > 0) {
-      const prevRow = rows[y - 1]!;
-      rawData[pos++] = 2;
+      const prevRow = rows[y - 1]!
+      rawData[pos++] = 2
       for (let x = 0; x < width; x++) {
-        rawData[pos++] = (row[x]! - prevRow[x]!) & 0xff;
+        rawData[pos++] = (row[x]! - prevRow[x]!) & 0xff
       }
     } else {
-      rawData[pos++] = 0;
-      rawData.set(row.subarray(0, width), pos);
-      pos += width;
+      rawData[pos++] = 0
+      rawData.set(row.subarray(0, width), pos)
+      pos += width
     }
   }
 
-  const compressed = zlibCompress(rawData);
+  const compressed = zlibCompress(rawData)
 
-  const ihdr = createChunk("IHDR", ihdrData);
-  const plte = createChunk("PLTE", plteData);
-  const idat = createChunk("IDAT", compressed);
-  const iend = createChunk("IEND", new Uint8Array(0));
+  const ihdr = createChunk("IHDR", ihdrData)
+  const plte = createChunk("PLTE", plteData)
+  const idat = createChunk("IDAT", compressed)
+  const iend = createChunk("IEND", new Uint8Array(0))
 
-  const totalLength = PNG_SIGNATURE.length + ihdr.length + plte.length + idat.length + iend.length;
-  const png = new Uint8Array(totalLength);
-  let offset = 0;
-  png.set(PNG_SIGNATURE, offset);
-  offset += PNG_SIGNATURE.length;
-  png.set(ihdr, offset);
-  offset += ihdr.length;
-  png.set(plte, offset);
-  offset += plte.length;
-  png.set(idat, offset);
-  offset += idat.length;
-  png.set(iend, offset);
+  const totalLength = PNG_SIGNATURE.length + ihdr.length + plte.length + idat.length + iend.length
+  const png = new Uint8Array(totalLength)
+  let offset = 0
+  png.set(PNG_SIGNATURE, offset)
+  offset += PNG_SIGNATURE.length
+  png.set(ihdr, offset)
+  offset += ihdr.length
+  png.set(plte, offset)
+  offset += plte.length
+  png.set(idat, offset)
+  offset += idat.length
+  png.set(iend, offset)
 
-  return png;
+  return png
 }
 
 /**
@@ -107,43 +107,43 @@ export function encodePNG(
  * @param rgba RGBA pixel data, length must be width * height * 4
  */
 export function encodeTrueColorPNG(width: number, height: number, rgba: Uint8Array): Uint8Array {
-  const ihdrData = new Uint8Array(13);
-  const ihdrView = new DataView(ihdrData.buffer);
-  ihdrView.setUint32(0, width);
-  ihdrView.setUint32(4, height);
-  ihdrData[8] = 8; // bit depth
-  ihdrData[9] = 6; // color type: RGBA
-  ihdrData[10] = 0; // compression
-  ihdrData[11] = 0; // filter
-  ihdrData[12] = 0; // interlace
+  const ihdrData = new Uint8Array(13)
+  const ihdrView = new DataView(ihdrData.buffer)
+  ihdrView.setUint32(0, width)
+  ihdrView.setUint32(4, height)
+  ihdrData[8] = 8 // bit depth
+  ihdrData[9] = 6 // color type: RGBA
+  ihdrData[10] = 0 // compression
+  ihdrData[11] = 0 // filter
+  ihdrData[12] = 0 // interlace
 
-  const stride = width * 4;
-  const rawSize = height * (1 + stride);
-  const rawData = new Uint8Array(rawSize);
-  let pos = 0;
+  const stride = width * 4
+  const rawSize = height * (1 + stride)
+  const rawData = new Uint8Array(rawSize)
+  let pos = 0
 
   for (let y = 0; y < height; y++) {
-    rawData[pos++] = 0; // filter: none
-    rawData.set(rgba.subarray(y * stride, y * stride + stride), pos);
-    pos += stride;
+    rawData[pos++] = 0 // filter: none
+    rawData.set(rgba.subarray(y * stride, y * stride + stride), pos)
+    pos += stride
   }
 
-  const compressed = zlibCompress(rawData);
+  const compressed = zlibCompress(rawData)
 
-  const ihdr = createChunk("IHDR", ihdrData);
-  const idat = createChunk("IDAT", compressed);
-  const iend = createChunk("IEND", new Uint8Array(0));
+  const ihdr = createChunk("IHDR", ihdrData)
+  const idat = createChunk("IDAT", compressed)
+  const iend = createChunk("IEND", new Uint8Array(0))
 
-  const totalLength = PNG_SIGNATURE.length + ihdr.length + idat.length + iend.length;
-  const png = new Uint8Array(totalLength);
-  let offset = 0;
-  png.set(PNG_SIGNATURE, offset);
-  offset += PNG_SIGNATURE.length;
-  png.set(ihdr, offset);
-  offset += ihdr.length;
-  png.set(idat, offset);
-  offset += idat.length;
-  png.set(iend, offset);
+  const totalLength = PNG_SIGNATURE.length + ihdr.length + idat.length + iend.length
+  const png = new Uint8Array(totalLength)
+  let offset = 0
+  png.set(PNG_SIGNATURE, offset)
+  offset += PNG_SIGNATURE.length
+  png.set(ihdr, offset)
+  offset += ihdr.length
+  png.set(idat, offset)
+  offset += idat.length
+  png.set(iend, offset)
 
-  return png;
+  return png
 }

--- a/src/renderers/png/rasterize.ts
+++ b/src/renderers/png/rasterize.ts
@@ -2,67 +2,67 @@
  * Rasterize barcode bars and 2D matrices to PNG pixel data
  */
 
-import { encodePNG } from "./png-encoder";
-import { parseHexColor } from "./types";
-import type { BarcodePNGOptions, MatrixPNGOptions, PostalPNGOptions } from "./types";
-import type { PostalBar } from "../svg/postal";
+import { encodePNG } from "./png-encoder"
+import { parseHexColor } from "./types"
+import type { BarcodePNGOptions, MatrixPNGOptions, PostalPNGOptions } from "./types"
+import type { PostalBar } from "../svg/postal"
 
 /**
  * Raster data result with raw pixel rows
  */
 export interface RasterData {
   /** Image width in pixels */
-  width: number;
+  width: number
   /** Image height in pixels */
-  height: number;
+  height: number
   /** Pixel rows — each Uint8Array where 0 = background, 1 = foreground */
-  rows: Uint8Array[];
+  rows: Uint8Array[]
 }
 
 /**
  * Rasterize a 1D barcode bar pattern to raw pixel rows
  */
 export function renderBarcodeRaster(bars: number[], options: BarcodePNGOptions = {}): RasterData {
-  const { scale = 2, height = 80, margin = 10 } = options;
+  const { scale = 2, height = 80, margin = 10 } = options
 
-  let totalBarWidth = 0;
+  let totalBarWidth = 0
   for (let i = 0; i < bars.length; i++) {
-    totalBarWidth += bars[i]! * scale;
+    totalBarWidth += bars[i]! * scale
   }
 
-  const width = totalBarWidth + margin * 2;
-  const totalHeight = height + margin * 2;
+  const width = totalBarWidth + margin * 2
+  const totalHeight = height + margin * 2
 
-  const barRow = new Uint8Array(width);
-  let x = margin;
+  const barRow = new Uint8Array(width)
+  let x = margin
   for (let i = 0; i < bars.length; i++) {
-    const w = bars[i]! * scale;
+    const w = bars[i]! * scale
     if (i % 2 === 0) {
       for (let px = 0; px < w; px++) {
-        if (x + px < width) barRow[x + px] = 1;
+        if (x + px < width) barRow[x + px] = 1
       }
     }
-    x += w;
+    x += w
   }
 
-  const marginRow = new Uint8Array(width);
-  const rows: Uint8Array[] = [];
-  for (let y = 0; y < margin; y++) rows.push(marginRow);
-  for (let y = 0; y < height; y++) rows.push(barRow);
-  for (let y = 0; y < margin; y++) rows.push(marginRow);
+  const marginRow = new Uint8Array(width)
+  const rows: Uint8Array[] = []
+  for (let y = 0; y < margin; y++) rows.push(marginRow)
+  for (let y = 0; y < height; y++) rows.push(barRow)
+  for (let y = 0; y < margin; y++) rows.push(marginRow)
 
-  return { width, height: totalHeight, rows };
+  return { width, height: totalHeight, rows }
 }
 
 /**
  * Render a 1D barcode bar pattern as PNG
  */
 export function renderBarcodePNG(bars: number[], options: BarcodePNGOptions = {}): Uint8Array {
-  const { color = "#000000", background = "#ffffff" } = options;
-  const fg = parseHexColor(color);
-  const bg = parseHexColor(background);
-  const { width, height, rows } = renderBarcodeRaster(bars, options);
-  return encodePNG(width, height, rows, fg, bg, false);
+  const { color = "#000000", background = "#ffffff" } = options
+  const fg = parseHexColor(color)
+  const bg = parseHexColor(background)
+  const { width, height, rows } = renderBarcodeRaster(bars, options)
+  return encodePNG(width, height, rows, fg, bg, false)
 }
 
 /**
@@ -73,43 +73,43 @@ export function renderPostalRaster(
   bars: readonly PostalBar[],
   options: PostalPNGOptions = {},
 ): RasterData {
-  const { scale = 2, height = 40, margin = 10, trackerRatio = 1 / 3, shortRatio = 0.4 } = options;
-  const pitch = options.pitch ?? scale * 2;
+  const { scale = 2, height = 40, margin = 10, trackerRatio = 1 / 3, shortRatio = 0.4 } = options
+  const pitch = options.pitch ?? scale * 2
 
-  const fourState = bars.some((b) => typeof b === "string");
-  const symbolWidth = bars.length > 0 ? (bars.length - 1) * pitch + scale : 0;
-  const width = symbolWidth + margin * 2;
-  const totalHeight = height + margin * 2;
+  const fourState = bars.some((b) => typeof b === "string")
+  const symbolWidth = bars.length > 0 ? (bars.length - 1) * pitch + scale : 0
+  const width = symbolWidth + margin * 2
+  const totalHeight = height + margin * 2
 
-  const rows: Uint8Array[] = [];
-  for (let y = 0; y < totalHeight; y++) rows.push(new Uint8Array(width));
+  const rows: Uint8Array[] = []
+  for (let y = 0; y < totalHeight; y++) rows.push(new Uint8Array(width))
 
-  const side = (1 - trackerRatio) / 2;
+  const side = (1 - trackerRatio) / 2
   for (let i = 0; i < bars.length; i++) {
-    const bar = bars[i]!;
-    let top: number;
-    let bottom: number;
+    const bar = bars[i]!
+    let top: number
+    let bottom: number
     if (fourState) {
       // T = centre band, A = centre + up, D = centre + down, F = full height
-      top = bar === "A" || bar === "F" ? 0 : side;
-      bottom = bar === "D" || bar === "F" ? 1 : side + trackerRatio;
+      top = bar === "A" || bar === "F" ? 0 : side
+      bottom = bar === "D" || bar === "F" ? 1 : side + trackerRatio
     } else {
-      top = bar ? 0 : 1 - shortRatio;
-      bottom = 1;
+      top = bar ? 0 : 1 - shortRatio
+      bottom = 1
     }
 
-    const x0 = margin + i * pitch;
-    const y0 = margin + Math.round(top * height);
-    const y1 = margin + Math.round(bottom * height);
+    const x0 = margin + i * pitch
+    const y0 = margin + Math.round(top * height)
+    const y1 = margin + Math.round(bottom * height)
     for (let y = y0; y < y1; y++) {
-      const row = rows[y]!;
+      const row = rows[y]!
       for (let px = 0; px < scale; px++) {
-        if (x0 + px < width) row[x0 + px] = 1;
+        if (x0 + px < width) row[x0 + px] = 1
       }
     }
   }
 
-  return { width, height: totalHeight, rows };
+  return { width, height: totalHeight, rows }
 }
 
 /**
@@ -119,11 +119,11 @@ export function renderPostalPNG(
   bars: readonly PostalBar[],
   options: PostalPNGOptions = {},
 ): Uint8Array {
-  const { color = "#000000", background = "#ffffff" } = options;
-  const fg = parseHexColor(color);
-  const bg = parseHexColor(background);
-  const { width, height, rows } = renderPostalRaster(bars, options);
-  return encodePNG(width, height, rows, fg, bg, false);
+  const { color = "#000000", background = "#ffffff" } = options
+  const fg = parseHexColor(color)
+  const bg = parseHexColor(background)
+  const { width, height, rows } = renderPostalRaster(bars, options)
+  return encodePNG(width, height, rows, fg, bg, false)
 }
 
 /**
@@ -133,35 +133,35 @@ export function renderMatrixRaster(
   matrix: boolean[][],
   options: MatrixPNGOptions = {},
 ): RasterData {
-  const { moduleSize = 10, margin = 4 } = options;
+  const { moduleSize = 10, margin = 4 } = options
 
-  const matRows = matrix.length;
-  const matCols = matRows > 0 ? matrix[0]!.length : 0;
+  const matRows = matrix.length
+  const matCols = matRows > 0 ? matrix[0]!.length : 0
 
-  const width = (matCols + margin * 2) * moduleSize;
-  const height = (matRows + margin * 2) * moduleSize;
+  const width = (matCols + margin * 2) * moduleSize
+  const height = (matRows + margin * 2) * moduleSize
 
-  const marginRow = new Uint8Array(width);
-  const rows: Uint8Array[] = [];
-  const marginPixels = margin * moduleSize;
-  for (let y = 0; y < marginPixels; y++) rows.push(marginRow);
+  const marginRow = new Uint8Array(width)
+  const rows: Uint8Array[] = []
+  const marginPixels = margin * moduleSize
+  for (let y = 0; y < marginPixels; y++) rows.push(marginRow)
 
   for (let r = 0; r < matRows; r++) {
-    const row = new Uint8Array(width);
+    const row = new Uint8Array(width)
     for (let c = 0; c < matCols; c++) {
       if (matrix[r]![c]) {
-        const startX = (margin + c) * moduleSize;
+        const startX = (margin + c) * moduleSize
         for (let px = 0; px < moduleSize; px++) {
-          row[startX + px] = 1;
+          row[startX + px] = 1
         }
       }
     }
-    for (let y = 0; y < moduleSize; y++) rows.push(row);
+    for (let y = 0; y < moduleSize; y++) rows.push(row)
   }
 
-  for (let y = 0; y < marginPixels; y++) rows.push(marginRow);
+  for (let y = 0; y < marginPixels; y++) rows.push(marginRow)
 
-  return { width, height, rows };
+  return { width, height, rows }
 }
 
 /**
@@ -176,66 +176,66 @@ export function renderMaxiCodeRaster(
   matrix: boolean[][],
   options: MatrixPNGOptions = {},
 ): RasterData {
-  const { moduleSize = 10, margin = 2 } = options;
+  const { moduleSize = 10, margin = 2 } = options
 
-  const rows = matrix.length;
-  const cols = matrix[0]?.length ?? 0;
-  const pitch = moduleSize;
-  const rowPitch = pitch * 0.866; // sqrt(3)/2
-  const radius = pitch * 0.55; // discs just touch, as in the SVG renderer
-  const pad = pitch * margin;
+  const rows = matrix.length
+  const cols = matrix[0]?.length ?? 0
+  const pitch = moduleSize
+  const rowPitch = pitch * 0.866 // sqrt(3)/2
+  const radius = pitch * 0.55 // discs just touch, as in the SVG renderer
+  const pad = pitch * margin
 
-  const width = Math.round(cols * pitch + pitch / 2 + pad * 2);
-  const height = Math.round(rows * rowPitch + pad * 2);
+  const width = Math.round(cols * pitch + pitch / 2 + pad * 2)
+  const height = Math.round(rows * rowPitch + pad * 2)
 
-  const pixels: Uint8Array[] = [];
-  for (let y = 0; y < height; y++) pixels.push(new Uint8Array(width));
+  const pixels: Uint8Array[] = []
+  for (let y = 0; y < height; y++) pixels.push(new Uint8Array(width))
 
-  const r2 = radius * radius;
+  const r2 = radius * radius
   for (let row = 0; row < rows; row++) {
     for (let col = 0; col < cols; col++) {
-      if (!matrix[row]![col]) continue;
-      const xOffset = row % 2 === 1 ? pitch / 2 : 0;
-      const cx = pad + col * pitch + pitch / 2 + xOffset;
-      const cy = pad + row * rowPitch + rowPitch / 2;
+      if (!matrix[row]![col]) continue
+      const xOffset = row % 2 === 1 ? pitch / 2 : 0
+      const cx = pad + col * pitch + pitch / 2 + xOffset
+      const cy = pad + row * rowPitch + rowPitch / 2
 
-      const minY = Math.max(0, Math.floor(cy - radius));
-      const maxY = Math.min(height - 1, Math.ceil(cy + radius));
-      const minX = Math.max(0, Math.floor(cx - radius));
-      const maxX = Math.min(width - 1, Math.ceil(cx + radius));
+      const minY = Math.max(0, Math.floor(cy - radius))
+      const maxY = Math.min(height - 1, Math.ceil(cy + radius))
+      const minX = Math.max(0, Math.floor(cx - radius))
+      const maxX = Math.min(width - 1, Math.ceil(cx + radius))
 
       for (let y = minY; y <= maxY; y++) {
-        const dy = y + 0.5 - cy;
-        const pixelRow = pixels[y]!;
+        const dy = y + 0.5 - cy
+        const pixelRow = pixels[y]!
         for (let x = minX; x <= maxX; x++) {
-          const dx = x + 0.5 - cx;
-          if (dx * dx + dy * dy <= r2) pixelRow[x] = 1;
+          const dx = x + 0.5 - cx
+          if (dx * dx + dy * dy <= r2) pixelRow[x] = 1
         }
       }
     }
   }
 
-  return { width, height, rows: pixels };
+  return { width, height, rows: pixels }
 }
 
 /**
  * Render a MaxiCode symbol as PNG
  */
 export function renderMaxiCodePNG(matrix: boolean[][], options: MatrixPNGOptions = {}): Uint8Array {
-  const { color = "#000000", background = "#ffffff" } = options;
-  const fg = parseHexColor(color);
-  const bg = parseHexColor(background);
-  const { width, height, rows } = renderMaxiCodeRaster(matrix, options);
-  return encodePNG(width, height, rows, fg, bg, true);
+  const { color = "#000000", background = "#ffffff" } = options
+  const fg = parseHexColor(color)
+  const bg = parseHexColor(background)
+  const { width, height, rows } = renderMaxiCodeRaster(matrix, options)
+  return encodePNG(width, height, rows, fg, bg, true)
 }
 
 /**
  * Render a 2D matrix (QR, DataMatrix, Aztec, PDF417) as PNG
  */
 export function renderMatrixPNG(matrix: boolean[][], options: MatrixPNGOptions = {}): Uint8Array {
-  const { color = "#000000", background = "#ffffff" } = options;
-  const fg = parseHexColor(color);
-  const bg = parseHexColor(background);
-  const { width, height, rows } = renderMatrixRaster(matrix, options);
-  return encodePNG(width, height, rows, fg, bg, true);
+  const { color = "#000000", background = "#ffffff" } = options
+  const fg = parseHexColor(color)
+  const bg = parseHexColor(background)
+  const { width, height, rows } = renderMatrixRaster(matrix, options)
+  return encodePNG(width, height, rows, fg, bg, true)
 }

--- a/src/renderers/png/types.ts
+++ b/src/renderers/png/types.ts
@@ -4,45 +4,45 @@
 
 export interface BarcodePNGOptions {
   /** Pixels per bar unit width (default: 2) */
-  scale?: number;
+  scale?: number
   /** Image height in pixels (default: 80) */
-  height?: number;
+  height?: number
   /** Quiet zone in pixels (default: 10) */
-  margin?: number;
+  margin?: number
   /** Foreground color as hex string (default: "#000000") */
-  color?: string;
+  color?: string
   /** Background color as hex string (default: "#ffffff") */
-  background?: string;
+  background?: string
 }
 
 export interface PostalPNGOptions {
   /** Bar width in pixels (default: 2) */
-  scale?: number;
+  scale?: number
   /** Centre-to-centre distance between bars in pixels (default: scale * 2) */
-  pitch?: number;
+  pitch?: number
   /** Full-bar height in pixels (default: 40) */
-  height?: number;
+  height?: number
   /** Quiet zone in pixels (default: 10) */
-  margin?: number;
+  margin?: number
   /** Centre tracker band height as a fraction of total height, 4-state (default: 1/3) */
-  trackerRatio?: number;
+  trackerRatio?: number
   /** Short bar height as a fraction of total height, POSTNET/PLANET (default: 0.4) */
-  shortRatio?: number;
+  shortRatio?: number
   /** Foreground color as hex string (default: "#000000") */
-  color?: string;
+  color?: string
   /** Background color as hex string (default: "#ffffff") */
-  background?: string;
+  background?: string
 }
 
 export interface MatrixPNGOptions {
   /** Pixels per module (default: 10) */
-  moduleSize?: number;
+  moduleSize?: number
   /** Quiet zone in modules (default: 4) */
-  margin?: number;
+  margin?: number
   /** Foreground color as hex string (default: "#000000") */
-  color?: string;
+  color?: string
   /** Background color as hex string (default: "#ffffff") */
-  background?: string;
+  background?: string
 }
 
 /**
@@ -50,16 +50,16 @@ export interface MatrixPNGOptions {
  * Supports "#RGB", "#RRGGBB", "RGB", "RRGGBB".
  */
 export function parseHexColor(hex: string): [number, number, number] {
-  let h = hex.startsWith("#") ? hex.slice(1) : hex;
+  let h = hex.startsWith("#") ? hex.slice(1) : hex
   if (h.length === 3) {
-    h = h[0]! + h[0]! + h[1]! + h[1]! + h[2]! + h[2]!;
+    h = h[0]! + h[0]! + h[1]! + h[1]! + h[2]! + h[2]!
   }
   if (h.length !== 6) {
-    throw new Error(`Invalid hex color: ${hex}`);
+    throw new Error(`Invalid hex color: ${hex}`)
   }
-  const n = Number.parseInt(h, 16);
+  const n = Number.parseInt(h, 16)
   if (Number.isNaN(n)) {
-    throw new Error(`Invalid hex color: ${hex}`);
+    throw new Error(`Invalid hex color: ${hex}`)
   }
-  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff]
 }

--- a/src/renderers/svg/barcode.ts
+++ b/src/renderers/svg/barcode.ts
@@ -2,8 +2,8 @@
  * 1D Barcode SVG renderer (enhanced)
  */
 
-import type { BarcodeSVGOptions } from "./types";
-import { escapeAttr, escapeXml } from "./utils";
+import type { BarcodeSVGOptions } from "./types"
+import { escapeAttr, escapeXml } from "./utils"
 
 /**
  * Render 1D barcode bars as SVG string
@@ -30,134 +30,134 @@ export function renderBarcodeSVG(bars: number[], options: BarcodeSVGOptions = {}
     role = "img",
     title,
     desc,
-  } = options;
-  const u = unit === "px" ? "" : unit;
+  } = options
+  const u = unit === "px" ? "" : unit
 
-  const mTop = options.marginTop ?? margin;
-  const mBottom = options.marginBottom ?? margin;
-  const mLeft = options.marginLeft ?? margin;
-  const mRight = options.marginRight ?? margin;
+  const mTop = options.marginTop ?? margin
+  const mBottom = options.marginBottom ?? margin
+  const mLeft = options.marginLeft ?? margin
+  const mRight = options.marginRight ?? margin
 
   // Calculate total width from bar widths
-  let totalUnits = 0;
-  for (const w of bars) totalUnits += w;
+  let totalUnits = 0
+  for (const w of bars) totalUnits += w
 
-  const barcodeWidth = totalUnits * barWidth;
-  const textHeight = showText ? fontSize + 8 : 0;
-  const bearerHeight = bearerBars ? bearerBarWidth * 2 : 0;
+  const barcodeWidth = totalUnits * barWidth
+  const textHeight = showText ? fontSize + 8 : 0
+  const bearerHeight = bearerBars ? bearerBarWidth * 2 : 0
 
-  const contentWidth = barcodeWidth + mLeft + mRight;
-  const contentHeight = height + mTop + mBottom + textHeight + bearerHeight;
+  const contentWidth = barcodeWidth + mLeft + mRight
+  const contentHeight = height + mTop + mBottom + textHeight + bearerHeight
 
   // For rotation, swap dimensions
-  const svgWidth = rotation === 90 || rotation === 270 ? contentHeight : contentWidth;
-  const svgHeight = rotation === 90 || rotation === 270 ? contentWidth : contentHeight;
+  const svgWidth = rotation === 90 || rotation === 270 ? contentHeight : contentWidth
+  const svgHeight = rotation === 90 || rotation === 270 ? contentWidth : contentHeight
 
   // Build SVG opening tag with accessibility attributes
-  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}${u}" height="${svgHeight}${u}" role="${escapeAttr(role)}"`;
+  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}${u}" height="${svgHeight}${u}" role="${escapeAttr(role)}"`
   if (ariaLabel) {
-    svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`;
+    svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`
   }
-  svgOpen += ">";
+  svgOpen += ">"
 
-  const parts: string[] = [svgOpen];
+  const parts: string[] = [svgOpen]
 
   // Accessibility title and desc elements
   if (title) {
-    parts.push(`<title>${escapeXml(title)}</title>`);
+    parts.push(`<title>${escapeXml(title)}</title>`)
   }
   if (desc) {
-    parts.push(`<desc>${escapeXml(desc)}</desc>`);
+    parts.push(`<desc>${escapeXml(desc)}</desc>`)
   }
 
   if (background !== "transparent") {
-    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`);
+    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`)
   }
 
   // Apply rotation transform
   if (rotation !== 0) {
-    const cx = svgWidth / 2;
-    const cy = svgHeight / 2;
+    const cx = svgWidth / 2
+    const cy = svgHeight / 2
     parts.push(
       `<g transform="rotate(${rotation},${cx},${cy}) translate(${(svgWidth - contentWidth) / 2},${(svgHeight - contentHeight) / 2})">`,
-    );
+    )
   }
 
-  const textIsTop = textPosition === "top";
-  const textOffset = textIsTop ? textHeight : 0;
-  const barTop = mTop + (bearerBars ? bearerBarWidth : 0) + textOffset;
-  const barHeight = height;
+  const textIsTop = textPosition === "top"
+  const textOffset = textIsTop ? textHeight : 0
+  const barTop = mTop + (bearerBars ? bearerBarWidth : 0) + textOffset
+  const barHeight = height
 
   // Bearer bars (top and bottom, for ITF-14)
   if (bearerBars) {
-    const bbTop = mTop + textOffset;
+    const bbTop = mTop + textOffset
     parts.push(
       `<rect x="${mLeft}" y="${bbTop}" width="${barcodeWidth}" height="${bearerBarWidth}" fill="${escapeAttr(color)}"/>`,
-    );
+    )
     parts.push(
       `<rect x="${mLeft}" y="${barTop + barHeight}" width="${barcodeWidth}" height="${bearerBarWidth}" fill="${escapeAttr(color)}"/>`,
-    );
+    )
     parts.push(
       `<rect x="${mLeft}" y="${bbTop}" width="${bearerBarWidth}" height="${barHeight + bearerHeight}" fill="${escapeAttr(color)}"/>`,
-    );
+    )
     parts.push(
       `<rect x="${mLeft + barcodeWidth - bearerBarWidth}" y="${bbTop}" width="${bearerBarWidth}" height="${barHeight + bearerHeight}" fill="${escapeAttr(color)}"/>`,
-    );
+    )
   }
 
   // Draw bars
-  let x = mLeft;
-  let isBar = true;
-  const halfGap = barGap / 2;
+  let x = mLeft
+  let isBar = true
+  const halfGap = barGap / 2
   for (const w of bars) {
-    const barPixelWidth = w * barWidth;
+    const barPixelWidth = w * barWidth
     if (isBar) {
-      const gappedWidth = barPixelWidth - barGap;
+      const gappedWidth = barPixelWidth - barGap
       if (gappedWidth > 0) {
         parts.push(
           `<rect x="${x + halfGap}" y="${barTop}" width="${gappedWidth}" height="${barHeight}" fill="${escapeAttr(color)}"/>`,
-        );
+        )
       }
     }
-    x += barPixelWidth;
-    isBar = !isBar;
+    x += barPixelWidth
+    isBar = !isBar
   }
 
   // Text
   if (showText && text) {
-    let textY: number;
+    let textY: number
     if (textIsTop) {
-      textY = mTop + fontSize;
+      textY = mTop + fontSize
     } else {
-      textY = barTop + barHeight + (bearerBars ? bearerBarWidth : 0) + fontSize + 4;
+      textY = barTop + barHeight + (bearerBars ? bearerBarWidth : 0) + fontSize + 4
     }
 
-    let textX: number;
-    let anchor: string;
+    let textX: number
+    let anchor: string
 
     switch (textAlign) {
       case "left":
-        textX = mLeft;
-        anchor = "start";
-        break;
+        textX = mLeft
+        anchor = "start"
+        break
       case "right":
-        textX = contentWidth - mRight;
-        anchor = "end";
-        break;
+        textX = contentWidth - mRight
+        anchor = "end"
+        break
       default:
-        textX = contentWidth / 2;
-        anchor = "middle";
+        textX = contentWidth / 2
+        anchor = "middle"
     }
 
     parts.push(
       `<text x="${textX}" y="${textY}" text-anchor="${anchor}" font-family="${escapeAttr(fontFamily)}" font-size="${fontSize}" fill="${escapeAttr(color)}">${escapeXml(text)}</text>`,
-    );
+    )
   }
 
   if (rotation !== 0) {
-    parts.push("</g>");
+    parts.push("</g>")
   }
 
-  parts.push("</svg>");
-  return parts.join("");
+  parts.push("</svg>")
+  return parts.join("")
 }

--- a/src/renderers/svg/color-matrix.ts
+++ b/src/renderers/svg/color-matrix.ts
@@ -5,12 +5,12 @@
  * such as JAB Code, where each module carries more than one bit of data.
  */
 
-import type { MatrixSVGOptions } from "./matrix";
-import { escapeAttr, escapeXml } from "./utils";
+import type { MatrixSVGOptions } from "./matrix"
+import { escapeAttr, escapeXml } from "./utils"
 
 export interface ColorMatrixSVGOptions extends MatrixSVGOptions {
   /** Color palette indexed by module value. Overrides the encoder's palette. */
-  palette?: readonly string[];
+  palette?: readonly string[]
 }
 
 /**
@@ -33,47 +33,47 @@ export function renderColorMatrixSVG(
     role = "img",
     title,
     desc,
-  } = options;
-  const colors = options.palette ?? palette;
+  } = options
+  const colors = options.palette ?? palette
 
-  const rowCount = matrix.length;
-  const colCount = matrix[0]?.length ?? 0;
-  const maxDim = Math.max(rowCount, colCount);
-  const moduleSize = size / (maxDim + margin * 2);
-  const moduleHeight = moduleSize * rowHeight;
+  const rowCount = matrix.length
+  const colCount = matrix[0]?.length ?? 0
+  const maxDim = Math.max(rowCount, colCount)
+  const moduleSize = size / (maxDim + margin * 2)
+  const moduleHeight = moduleSize * rowHeight
 
-  const svgWidth = (colCount + margin * 2) * moduleSize;
-  const svgHeight = rowCount * moduleHeight + margin * 2 * moduleSize;
+  const svgWidth = (colCount + margin * 2) * moduleSize
+  const svgHeight = rowCount * moduleHeight + margin * 2 * moduleSize
 
-  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}" height="${svgHeight}" role="${escapeAttr(role)}"`;
-  if (ariaLabel) svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`;
-  svgOpen += ">";
+  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}" height="${svgHeight}" role="${escapeAttr(role)}"`
+  if (ariaLabel) svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`
+  svgOpen += ">"
 
-  const parts: string[] = [svgOpen];
-  if (title) parts.push(`<title>${escapeXml(title)}</title>`);
-  if (desc) parts.push(`<desc>${escapeXml(desc)}</desc>`);
+  const parts: string[] = [svgOpen]
+  if (title) parts.push(`<title>${escapeXml(title)}</title>`)
+  if (desc) parts.push(`<desc>${escapeXml(desc)}</desc>`)
   if (background !== "transparent") {
-    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`);
+    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`)
   }
 
   // Group modules by palette index so each color needs only one path element.
-  const byColor = new Map<number, string[]>();
+  const byColor = new Map<number, string[]>()
   for (let r = 0; r < rowCount; r++) {
     for (let c = 0; c < colCount; c++) {
-      const value = matrix[r]![c] ?? 0;
-      const x = (c + margin) * moduleSize;
-      const y = margin * moduleSize + r * moduleHeight;
-      const segments = byColor.get(value) ?? [];
-      segments.push(`M${x},${y}h${moduleSize}v${moduleHeight}h-${moduleSize}z`);
-      byColor.set(value, segments);
+      const value = matrix[r]![c] ?? 0
+      const x = (c + margin) * moduleSize
+      const y = margin * moduleSize + r * moduleHeight
+      const segments = byColor.get(value) ?? []
+      segments.push(`M${x},${y}h${moduleSize}v${moduleHeight}h-${moduleSize}z`)
+      byColor.set(value, segments)
     }
   }
 
   for (const [value, segments] of [...byColor.entries()].sort((a, b) => a[0] - b[0])) {
-    const fill = colors[value] ?? "#000";
-    parts.push(`<path d="${segments.join("")}" fill="${escapeAttr(fill)}"/>`);
+    const fill = colors[value] ?? "#000"
+    parts.push(`<path d="${segments.join("")}" fill="${escapeAttr(fill)}"/>`)
   }
 
-  parts.push("</svg>");
-  return parts.join("");
+  parts.push("</svg>")
+  return parts.join("")
 }

--- a/src/renderers/svg/gradient.ts
+++ b/src/renderers/svg/gradient.ts
@@ -2,57 +2,57 @@
  * SVG gradient generation
  */
 
-import type { GradientOptions, LinearGradientOptions, RadialGradientOptions } from "./types";
-import { escapeAttr } from "./utils";
+import type { GradientOptions, LinearGradientOptions, RadialGradientOptions } from "./types"
+import { escapeAttr } from "./utils"
 
-let gradientCounter = 0;
+let gradientCounter = 0
 
 /** Generate a unique gradient ID */
 function nextGradientId(): string {
-  return `etiket-grad-${gradientCounter++}`;
+  return `etiket-grad-${gradientCounter++}`
 }
 
 /** Reset gradient counter (for testing) */
 export function resetGradientCounter(): void {
-  gradientCounter = 0;
+  gradientCounter = 0
 }
 
 /** Check if a color value is a gradient */
 export function isGradient(color: string | GradientOptions | undefined): color is GradientOptions {
-  return typeof color === "object" && color !== null && "type" in color;
+  return typeof color === "object" && color !== null && "type" in color
 }
 
 /** Generate gradient SVG definition and return the gradient ID */
 export function generateGradientDef(options: GradientOptions): { id: string; svg: string } {
-  const id = nextGradientId();
+  const id = nextGradientId()
 
   if (options.type === "linear") {
-    return { id, svg: generateLinearGradient(id, options) };
+    return { id, svg: generateLinearGradient(id, options) }
   } else {
-    return { id, svg: generateRadialGradient(id, options) };
+    return { id, svg: generateRadialGradient(id, options) }
   }
 }
 
 function generateLinearGradient(id: string, options: LinearGradientOptions): string {
-  const rotation = options.rotation ?? 0;
+  const rotation = options.rotation ?? 0
   // Convert rotation to x1,y1,x2,y2
-  const rad = (rotation * Math.PI) / 180;
-  const x1 = Math.round((50 - Math.sin(rad) * 50) * 100) / 100;
-  const y1 = Math.round((50 + Math.cos(rad) * 50) * 100) / 100;
-  const x2 = Math.round((50 + Math.sin(rad) * 50) * 100) / 100;
-  const y2 = Math.round((50 - Math.cos(rad) * 50) * 100) / 100;
+  const rad = (rotation * Math.PI) / 180
+  const x1 = Math.round((50 - Math.sin(rad) * 50) * 100) / 100
+  const y1 = Math.round((50 + Math.cos(rad) * 50) * 100) / 100
+  const x2 = Math.round((50 + Math.sin(rad) * 50) * 100) / 100
+  const y2 = Math.round((50 - Math.cos(rad) * 50) * 100) / 100
 
   const stops = options.stops
     .map((s) => `<stop offset="${s.offset * 100}%" stop-color="${escapeAttr(s.color)}"/>`)
-    .join("");
+    .join("")
 
-  return `<linearGradient id="${id}" x1="${x1}%" y1="${y1}%" x2="${x2}%" y2="${y2}%">${stops}</linearGradient>`;
+  return `<linearGradient id="${id}" x1="${x1}%" y1="${y1}%" x2="${x2}%" y2="${y2}%">${stops}</linearGradient>`
 }
 
 function generateRadialGradient(id: string, options: RadialGradientOptions): string {
   const stops = options.stops
     .map((s) => `<stop offset="${s.offset * 100}%" stop-color="${escapeAttr(s.color)}"/>`)
-    .join("");
+    .join("")
 
-  return `<radialGradient id="${id}" cx="50%" cy="50%" r="50%">${stops}</radialGradient>`;
+  return `<radialGradient id="${id}" cx="50%" cy="50%" r="50%">${stops}</radialGradient>`
 }

--- a/src/renderers/svg/ico.ts
+++ b/src/renderers/svg/ico.ts
@@ -3,15 +3,15 @@
  * Handles both PNG-embedded (modern) and BMP-based (legacy) ICO entries
  */
 
-import { encodeTrueColorPNG } from "../png/png-encoder";
+import { encodeTrueColorPNG } from "../png/png-encoder"
 
-const PNG_SIGNATURE = 0x89504e47;
+const PNG_SIGNATURE = 0x89504e47
 
 interface ICOEntry {
-  width: number;
-  height: number;
-  size: number;
-  offset: number;
+  width: number
+  height: number
+  size: number
+  offset: number
 }
 
 /**
@@ -19,41 +19,41 @@ interface ICOEntry {
  * Selects the largest entry and converts it to PNG.
  */
 export function icoToPngDataURI(icoData: Uint8Array): string {
-  const view = new DataView(icoData.buffer, icoData.byteOffset, icoData.byteLength);
+  const view = new DataView(icoData.buffer, icoData.byteOffset, icoData.byteLength)
 
   // Validate ICO header
-  const reserved = view.getUint16(0, true);
-  const type = view.getUint16(2, true);
-  const count = view.getUint16(4, true);
+  const reserved = view.getUint16(0, true)
+  const type = view.getUint16(2, true)
+  const count = view.getUint16(4, true)
 
   if (reserved !== 0 || (type !== 1 && type !== 2) || count === 0) {
-    throw new Error("Invalid ICO file");
+    throw new Error("Invalid ICO file")
   }
 
   // Read directory entries and pick the largest
-  let best: ICOEntry | undefined;
+  let best: ICOEntry | undefined
   for (let i = 0; i < count; i++) {
-    const off = 6 + i * 16;
-    const w = view.getUint8(off) || 256;
-    const h = view.getUint8(off + 1) || 256;
-    const size = view.getUint32(off + 8, true);
-    const dataOffset = view.getUint32(off + 12, true);
-    const pixels = w * h;
+    const off = 6 + i * 16
+    const w = view.getUint8(off) || 256
+    const h = view.getUint8(off + 1) || 256
+    const size = view.getUint32(off + 8, true)
+    const dataOffset = view.getUint32(off + 12, true)
+    const pixels = w * h
     if (!best || pixels > best.width * best.height) {
-      best = { width: w, height: h, size, offset: dataOffset };
+      best = { width: w, height: h, size, offset: dataOffset }
     }
   }
 
-  const entry = best!;
-  const entryData = icoData.subarray(entry.offset, entry.offset + entry.size);
+  const entry = best!
+  const entryData = icoData.subarray(entry.offset, entry.offset + entry.size)
 
   // Check if entry contains embedded PNG
   if (entryData.length >= 4 && view.getUint32(entry.offset) === PNG_SIGNATURE) {
-    return `data:image/png;base64,${uint8ToBase64(entryData)}`;
+    return `data:image/png;base64,${uint8ToBase64(entryData)}`
   }
 
   // Otherwise parse as BMP DIB
-  return dibToPngDataURI(entryData, entry.width, entry.height);
+  return dibToPngDataURI(entryData, entry.width, entry.height)
 }
 
 /**
@@ -61,43 +61,43 @@ export function icoToPngDataURI(icoData: Uint8Array): string {
  * ICO stores BMPs without the BITMAPFILEHEADER — just BITMAPINFOHEADER + pixels.
  */
 function dibToPngDataURI(dib: Uint8Array, entryW: number, entryH: number): string {
-  const view = new DataView(dib.buffer, dib.byteOffset, dib.byteLength);
+  const view = new DataView(dib.buffer, dib.byteOffset, dib.byteLength)
 
-  const headerSize = view.getUint32(0, true);
-  const bmpWidth = view.getInt32(4, true);
+  const headerSize = view.getUint32(0, true)
+  const bmpWidth = view.getInt32(4, true)
   // ICO DIB height is doubled (includes AND mask), use entry width/height
-  const width = bmpWidth || entryW;
-  const height = entryH;
-  const bpp = view.getUint16(14, true);
-  const compression = view.getUint32(16, true);
+  const width = bmpWidth || entryW
+  const height = entryH
+  const bpp = view.getUint16(14, true)
+  const compression = view.getUint32(16, true)
 
   if (compression !== 0 && compression !== 3) {
-    throw new Error(`Unsupported BMP compression: ${compression}`);
+    throw new Error(`Unsupported BMP compression: ${compression}`)
   }
 
-  const rgba = new Uint8Array(width * height * 4);
+  const rgba = new Uint8Array(width * height * 4)
 
   if (bpp === 32) {
-    decode32bpp(dib, headerSize, width, height, rgba);
+    decode32bpp(dib, headerSize, width, height, rgba)
   } else if (bpp === 24) {
-    decode24bpp(dib, headerSize, width, height, rgba);
+    decode24bpp(dib, headerSize, width, height, rgba)
   } else if (bpp <= 8) {
-    decodeIndexed(dib, headerSize, width, height, bpp, rgba);
+    decodeIndexed(dib, headerSize, width, height, bpp, rgba)
   } else {
-    throw new Error(`Unsupported BMP bit depth: ${bpp}`);
+    throw new Error(`Unsupported BMP bit depth: ${bpp}`)
   }
 
   // Apply AND mask if present (transparency for < 32bpp)
   if (bpp < 32) {
-    const pixelDataSize = getPixelDataSize(width, height, bpp, dib, headerSize);
-    const andMaskOffset = headerSize + getColorTableSize(dib, headerSize, bpp) + pixelDataSize;
+    const pixelDataSize = getPixelDataSize(width, height, bpp, dib, headerSize)
+    const andMaskOffset = headerSize + getColorTableSize(dib, headerSize, bpp) + pixelDataSize
     if (andMaskOffset < dib.length) {
-      applyAndMask(dib, andMaskOffset, width, height, rgba);
+      applyAndMask(dib, andMaskOffset, width, height, rgba)
     }
   }
 
-  const png = encodeTrueColorPNG(width, height, rgba);
-  return `data:image/png;base64,${uint8ToBase64(png)}`;
+  const png = encodeTrueColorPNG(width, height, rgba)
+  return `data:image/png;base64,${uint8ToBase64(png)}`
 }
 
 function decode32bpp(
@@ -107,20 +107,20 @@ function decode32bpp(
   height: number,
   rgba: Uint8Array,
 ): void {
-  const offset = headerSize;
-  const stride = width * 4;
+  const offset = headerSize
+  const stride = width * 4
 
   for (let y = 0; y < height; y++) {
     // BMP rows are bottom-up
-    const srcRow = offset + (height - 1 - y) * stride;
-    const dstRow = y * width * 4;
+    const srcRow = offset + (height - 1 - y) * stride
+    const dstRow = y * width * 4
     for (let x = 0; x < width; x++) {
-      const si = srcRow + x * 4;
-      const di = dstRow + x * 4;
-      rgba[di] = dib[si + 2]!; // R (BMP is BGRA)
-      rgba[di + 1] = dib[si + 1]!; // G
-      rgba[di + 2] = dib[si]!; // B
-      rgba[di + 3] = dib[si + 3]!; // A
+      const si = srcRow + x * 4
+      const di = dstRow + x * 4
+      rgba[di] = dib[si + 2]! // R (BMP is BGRA)
+      rgba[di + 1] = dib[si + 1]! // G
+      rgba[di + 2] = dib[si]! // B
+      rgba[di + 3] = dib[si + 3]! // A
     }
   }
 }
@@ -132,20 +132,20 @@ function decode24bpp(
   height: number,
   rgba: Uint8Array,
 ): void {
-  const colorTableSize = getColorTableSize(dib, headerSize, 24);
-  const offset = headerSize + colorTableSize;
-  const rowStride = Math.ceil((width * 3) / 4) * 4; // rows are 4-byte aligned
+  const colorTableSize = getColorTableSize(dib, headerSize, 24)
+  const offset = headerSize + colorTableSize
+  const rowStride = Math.ceil((width * 3) / 4) * 4 // rows are 4-byte aligned
 
   for (let y = 0; y < height; y++) {
-    const srcRow = offset + (height - 1 - y) * rowStride;
-    const dstRow = y * width * 4;
+    const srcRow = offset + (height - 1 - y) * rowStride
+    const dstRow = y * width * 4
     for (let x = 0; x < width; x++) {
-      const si = srcRow + x * 3;
-      const di = dstRow + x * 4;
-      rgba[di] = dib[si + 2]!; // R
-      rgba[di + 1] = dib[si + 1]!; // G
-      rgba[di + 2] = dib[si]!; // B
-      rgba[di + 3] = 255; // A (opaque, AND mask applied separately)
+      const si = srcRow + x * 3
+      const di = dstRow + x * 4
+      rgba[di] = dib[si + 2]! // R
+      rgba[di + 1] = dib[si + 1]! // G
+      rgba[di + 2] = dib[si]! // B
+      rgba[di + 3] = 255 // A (opaque, AND mask applied separately)
     }
   }
 }
@@ -158,44 +158,44 @@ function decodeIndexed(
   bpp: number,
   rgba: Uint8Array,
 ): void {
-  const colorTableSize = getColorTableSize(dib, headerSize, bpp);
-  const colorTable = dib.subarray(headerSize, headerSize + colorTableSize);
-  const pixelOffset = headerSize + colorTableSize;
-  const rowStride = Math.ceil((width * bpp) / 32) * 4;
+  const colorTableSize = getColorTableSize(dib, headerSize, bpp)
+  const colorTable = dib.subarray(headerSize, headerSize + colorTableSize)
+  const pixelOffset = headerSize + colorTableSize
+  const rowStride = Math.ceil((width * bpp) / 32) * 4
 
   for (let y = 0; y < height; y++) {
-    const srcRow = pixelOffset + (height - 1 - y) * rowStride;
-    const dstRow = y * width * 4;
+    const srcRow = pixelOffset + (height - 1 - y) * rowStride
+    const dstRow = y * width * 4
 
     for (let x = 0; x < width; x++) {
-      let idx: number;
+      let idx: number
       if (bpp === 8) {
-        idx = dib[srcRow + x]!;
+        idx = dib[srcRow + x]!
       } else if (bpp === 4) {
-        const byte = dib[srcRow + (x >> 1)]!;
-        idx = x & 1 ? byte & 0x0f : (byte >> 4) & 0x0f;
+        const byte = dib[srcRow + (x >> 1)]!
+        idx = x & 1 ? byte & 0x0f : (byte >> 4) & 0x0f
       } else {
         // 1bpp
-        const byte = dib[srcRow + (x >> 3)]!;
-        idx = (byte >> (7 - (x & 7))) & 1;
+        const byte = dib[srcRow + (x >> 3)]!
+        idx = (byte >> (7 - (x & 7))) & 1
       }
 
-      const ci = idx * 4; // color table entries are BGRA (4 bytes each)
-      const di = dstRow + x * 4;
-      rgba[di] = colorTable[ci + 2]!; // R
-      rgba[di + 1] = colorTable[ci + 1]!; // G
-      rgba[di + 2] = colorTable[ci]!; // B
-      rgba[di + 3] = 255; // A
+      const ci = idx * 4 // color table entries are BGRA (4 bytes each)
+      const di = dstRow + x * 4
+      rgba[di] = colorTable[ci + 2]! // R
+      rgba[di + 1] = colorTable[ci + 1]! // G
+      rgba[di + 2] = colorTable[ci]! // B
+      rgba[di + 3] = 255 // A
     }
   }
 }
 
 function getColorTableSize(dib: Uint8Array, headerSize: number, bpp: number): number {
-  if (bpp >= 16) return 0;
-  const view = new DataView(dib.buffer, dib.byteOffset, dib.byteLength);
-  const colorsUsed = headerSize >= 36 ? view.getUint32(32, true) : 0;
-  const count = colorsUsed || 1 << bpp;
-  return count * 4;
+  if (bpp >= 16) return 0
+  const view = new DataView(dib.buffer, dib.byteOffset, dib.byteLength)
+  const colorsUsed = headerSize >= 36 ? view.getUint32(32, true) : 0
+  const count = colorsUsed || 1 << bpp
+  return count * 4
 }
 
 function getPixelDataSize(
@@ -205,8 +205,8 @@ function getPixelDataSize(
   _dib: Uint8Array,
   _headerSize: number,
 ): number {
-  const rowStride = Math.ceil((width * bpp) / 32) * 4;
-  return rowStride * height;
+  const rowStride = Math.ceil((width * bpp) / 32) * 4
+  return rowStride * height
 }
 
 function applyAndMask(
@@ -216,27 +216,27 @@ function applyAndMask(
   height: number,
   rgba: Uint8Array,
 ): void {
-  const maskStride = Math.ceil(width / 32) * 4;
+  const maskStride = Math.ceil(width / 32) * 4
 
   for (let y = 0; y < height; y++) {
-    const srcRow = maskOffset + (height - 1 - y) * maskStride;
-    const dstRow = y * width * 4;
+    const srcRow = maskOffset + (height - 1 - y) * maskStride
+    const dstRow = y * width * 4
 
     for (let x = 0; x < width; x++) {
-      const byteIdx = srcRow + (x >> 3);
-      if (byteIdx >= dib.length) return;
-      const bit = (dib[byteIdx]! >> (7 - (x & 7))) & 1;
+      const byteIdx = srcRow + (x >> 3)
+      if (byteIdx >= dib.length) return
+      const bit = (dib[byteIdx]! >> (7 - (x & 7))) & 1
       if (bit === 1) {
-        rgba[dstRow + x * 4 + 3] = 0; // transparent
+        rgba[dstRow + x * 4 + 3] = 0 // transparent
       }
     }
   }
 }
 
 function uint8ToBase64(data: Uint8Array): string {
-  let binary = "";
+  let binary = ""
   for (let i = 0; i < data.length; i++) {
-    binary += String.fromCharCode(data[i]!);
+    binary += String.fromCharCode(data[i]!)
   }
-  return btoa(binary);
+  return btoa(binary)
 }

--- a/src/renderers/svg/logo.ts
+++ b/src/renderers/svg/logo.ts
@@ -3,18 +3,18 @@
  * Calculates which modules to hide and generates the logo SVG element
  */
 
-import { InvalidInputError } from "../../errors";
-import type { LogoOptions } from "./types";
-import { escapeAttr } from "./utils";
-import { icoToPngDataURI } from "./ico";
+import { InvalidInputError } from "../../errors"
+import type { LogoOptions } from "./types"
+import { escapeAttr } from "./utils"
+import { icoToPngDataURI } from "./ico"
 
-const SVG_DANGEROUS_PATTERN = /<script[\s>]|javascript:|on[a-z]+\s*=|<foreignObject[\s>]/i;
+const SVG_DANGEROUS_PATTERN = /<script[\s>]|javascript:|on[a-z]+\s*=|<foreignObject[\s>]/i
 
 export interface LogoPlacement {
   /** SVG element string for the logo */
-  svg: string;
+  svg: string
   /** Set of module coordinates to hide: `${row},${col}` */
-  hiddenModules: Set<string>;
+  hiddenModules: Set<string>
 }
 
 /**
@@ -26,40 +26,40 @@ export function calculateLogoPlacement(
   moduleSize: number,
   margin: number,
 ): LogoPlacement {
-  const logoSize = options.size ?? 0.3;
-  const logoMargin = options.margin ?? 0;
-  const hideBackground = options.hideBackgroundDots ?? true;
+  const logoSize = options.size ?? 0.3
+  const logoMargin = options.margin ?? 0
+  const hideBackground = options.hideBackgroundDots ?? true
 
   // Logo dimensions in pixels
-  const totalSize = moduleCount * moduleSize;
-  const logoPixelSize = totalSize * logoSize;
-  const logoX = margin * moduleSize + (totalSize - logoPixelSize) / 2;
-  const logoY = margin * moduleSize + (totalSize - logoPixelSize) / 2;
+  const totalSize = moduleCount * moduleSize
+  const logoPixelSize = totalSize * logoSize
+  const logoX = margin * moduleSize + (totalSize - logoPixelSize) / 2
+  const logoY = margin * moduleSize + (totalSize - logoPixelSize) / 2
 
   // Calculate hidden modules
-  const hiddenModules = new Set<string>();
+  const hiddenModules = new Set<string>()
 
   if (hideBackground) {
     const startModule = Math.floor(
       (moduleCount - moduleCount * logoSize) / 2 - logoMargin / moduleSize,
-    );
+    )
     const endModule = Math.ceil(
       (moduleCount + moduleCount * logoSize) / 2 + logoMargin / moduleSize,
-    );
+    )
 
     for (let r = Math.max(0, startModule); r < Math.min(moduleCount, endModule); r++) {
       for (let c = Math.max(0, startModule); c < Math.min(moduleCount, endModule); c++) {
-        hiddenModules.add(`${r},${c}`);
+        hiddenModules.add(`${r},${c}`)
       }
     }
   }
 
   // Generate logo SVG
-  let svg = "";
+  let svg = ""
 
   if (options.backgroundColor) {
-    const bgPad = logoMargin;
-    svg += `<rect x="${logoX - bgPad}" y="${logoY - bgPad}" width="${logoPixelSize + 2 * bgPad}" height="${logoPixelSize + 2 * bgPad}" fill="${escapeAttr(options.backgroundColor)}" rx="4"/>`;
+    const bgPad = logoMargin
+    svg += `<rect x="${logoX - bgPad}" y="${logoY - bgPad}" width="${logoPixelSize + 2 * bgPad}" height="${logoPixelSize + 2 * bgPad}" fill="${escapeAttr(options.backgroundColor)}" rx="4"/>`
   }
 
   if (options.svg) {
@@ -67,36 +67,36 @@ export function calculateLogoPlacement(
     if (SVG_DANGEROUS_PATTERN.test(options.svg)) {
       throw new InvalidInputError(
         "logo.svg contains potentially dangerous content (script, event handlers, or foreignObject)",
-      );
+      )
     }
-    svg += `<svg x="${logoX}" y="${logoY}" width="${logoPixelSize}" height="${logoPixelSize}" viewBox="0 0 1 1">`;
-    svg += `<g transform="scale(${1})">${options.svg}</g></svg>`;
+    svg += `<svg x="${logoX}" y="${logoY}" width="${logoPixelSize}" height="${logoPixelSize}" viewBox="0 0 1 1">`
+    svg += `<g transform="scale(${1})">${options.svg}</g></svg>`
   } else if (options.path) {
     // SVG path data — assumes 100x100 coordinate space
-    svg += `<path d="${escapeAttr(options.path)}" transform="translate(${logoX},${logoY}) scale(${logoPixelSize / 100})" fill="currentColor"/>`;
+    svg += `<path d="${escapeAttr(options.path)}" transform="translate(${logoX},${logoY}) scale(${logoPixelSize / 100})" fill="currentColor"/>`
   } else if (options.imageUrl) {
     // External image URL or data URI — embedded via SVG <image> element
     if (!/^(https?:|data:image\/)/i.test(options.imageUrl)) {
-      throw new InvalidInputError("imageUrl must use https:, http:, or data:image/ scheme");
+      throw new InvalidInputError("imageUrl must use https:, http:, or data:image/ scheme")
     }
     // Auto-convert ICO/BMP data URIs to PNG (SVG <image> only supports PNG, JPEG, GIF, SVG)
     const icoMatch = options.imageUrl.match(
       /^data:image\/(x-icon|vnd\.microsoft\.icon);base64,(.+)$/i,
-    );
-    let imageUrl = options.imageUrl;
+    )
+    let imageUrl = options.imageUrl
     if (icoMatch) {
-      const binary = atob(icoMatch[2]!);
-      const bytes = new Uint8Array(binary.length);
-      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-      imageUrl = icoToPngDataURI(bytes);
+      const binary = atob(icoMatch[2]!)
+      const bytes = new Uint8Array(binary.length)
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+      imageUrl = icoToPngDataURI(bytes)
     }
-    const imgW = options.imageWidth ?? logoPixelSize;
-    const imgH = options.imageHeight ?? logoPixelSize;
+    const imgW = options.imageWidth ?? logoPixelSize
+    const imgH = options.imageHeight ?? logoPixelSize
     // Center the image within the logo area
-    const imgX = logoX + (logoPixelSize - imgW) / 2;
-    const imgY = logoY + (logoPixelSize - imgH) / 2;
-    svg += `<image href="${escapeAttr(imageUrl)}" x="${imgX}" y="${imgY}" width="${imgW}" height="${imgH}"/>`;
+    const imgX = logoX + (logoPixelSize - imgW) / 2
+    const imgY = logoY + (logoPixelSize - imgH) / 2
+    svg += `<image href="${escapeAttr(imageUrl)}" x="${imgX}" y="${imgY}" width="${imgW}" height="${imgH}"/>`
   }
 
-  return { svg, hiddenModules };
+  return { svg, hiddenModules }
 }

--- a/src/renderers/svg/matrix.ts
+++ b/src/renderers/svg/matrix.ts
@@ -3,20 +3,20 @@
  * Used for Data Matrix, Aztec, and other 2D codes
  */
 
-import type { SVGAccessibilityOptions } from "./types";
-import { escapeAttr, escapeXml } from "./utils";
+import type { SVGAccessibilityOptions } from "./types"
+import { escapeAttr, escapeXml } from "./utils"
 
 export interface MatrixSVGOptions extends SVGAccessibilityOptions {
-  size?: number;
-  color?: string;
-  background?: string;
-  margin?: number; // in modules
+  size?: number
+  color?: string
+  background?: string
+  margin?: number // in modules
   /**
    * Height of each matrix row as a multiple of the module width. Default 1
    * (square modules). Stacked linear symbologies such as Code 16K,
    * Codablock-F, PDF417 and MicroPDF417 use taller rows.
    */
-  rowHeight?: number;
+  rowHeight?: number
 }
 
 /**
@@ -33,58 +33,58 @@ export function renderMatrixSVG(matrix: boolean[][], options: MatrixSVGOptions =
     role = "img",
     title,
     desc,
-  } = options;
+  } = options
 
-  const rowCount = matrix.length;
-  const colCount = matrix[0]?.length ?? 0;
-  const maxDim = Math.max(rowCount, colCount);
-  const totalModules = maxDim + margin * 2;
-  const moduleSize = size / totalModules;
-  const moduleHeight = moduleSize * rowHeight;
+  const rowCount = matrix.length
+  const colCount = matrix[0]?.length ?? 0
+  const maxDim = Math.max(rowCount, colCount)
+  const totalModules = maxDim + margin * 2
+  const moduleSize = size / totalModules
+  const moduleHeight = moduleSize * rowHeight
 
   // For rectangular matrices, compute actual SVG dimensions
-  const svgWidth = (colCount + margin * 2) * moduleSize;
-  const svgHeight = rowCount * moduleHeight + margin * 2 * moduleSize;
+  const svgWidth = (colCount + margin * 2) * moduleSize
+  const svgHeight = rowCount * moduleHeight + margin * 2 * moduleSize
 
   // Build SVG opening tag with accessibility attributes
-  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}" height="${svgHeight}" role="${escapeAttr(role)}"`;
+  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}" height="${svgHeight}" role="${escapeAttr(role)}"`
   if (ariaLabel) {
-    svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`;
+    svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`
   }
-  svgOpen += ">";
+  svgOpen += ">"
 
-  const parts: string[] = [svgOpen];
+  const parts: string[] = [svgOpen]
 
   // Accessibility title and desc elements
   if (title) {
-    parts.push(`<title>${escapeXml(title)}</title>`);
+    parts.push(`<title>${escapeXml(title)}</title>`)
   }
   if (desc) {
-    parts.push(`<desc>${escapeXml(desc)}</desc>`);
+    parts.push(`<desc>${escapeXml(desc)}</desc>`)
   }
 
   if (background !== "transparent") {
-    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`);
+    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`)
   }
 
   // Draw modules as a single path
-  const pathParts: string[] = [];
+  const pathParts: string[] = []
   for (let r = 0; r < rowCount; r++) {
     for (let c = 0; c < colCount; c++) {
       if (matrix[r]![c]) {
-        const x = (c + margin) * moduleSize;
-        const y = margin * moduleSize + r * moduleHeight;
-        pathParts.push(`M${x},${y}h${moduleSize}v${moduleHeight}h-${moduleSize}z`);
+        const x = (c + margin) * moduleSize
+        const y = margin * moduleSize + r * moduleHeight
+        pathParts.push(`M${x},${y}h${moduleSize}v${moduleHeight}h-${moduleSize}z`)
       }
     }
   }
 
   if (pathParts.length > 0) {
-    parts.push(`<path d="${pathParts.join("")}" fill="${escapeAttr(color)}"/>`);
+    parts.push(`<path d="${pathParts.join("")}" fill="${escapeAttr(color)}"/>`)
   }
 
-  parts.push("</svg>");
-  return parts.join("");
+  parts.push("</svg>")
+  return parts.join("")
 }
 
 /**
@@ -102,44 +102,44 @@ export function renderMaxiCodeSVG(matrix: boolean[][], options: MatrixSVGOptions
     role = "img",
     title,
     desc,
-  } = options;
+  } = options
 
-  const rows = matrix.length; // 33
-  const cols = matrix[0]?.length ?? 0; // 30
-  const pitch = size / cols; // module-to-module horizontal distance
-  const modH = pitch * 0.866; // sqrt(3)/2 for hex vertical spacing
-  const r = pitch * 0.55; // module radius (0.55 = touching, verified scannable with rxing)
-  const pad = pitch * margin; // quiet zone, in modules
-  const svgW = cols * pitch + pitch / 2 + pad * 2;
-  const svgH = rows * modH + pad * 2;
+  const rows = matrix.length // 33
+  const cols = matrix[0]?.length ?? 0 // 30
+  const pitch = size / cols // module-to-module horizontal distance
+  const modH = pitch * 0.866 // sqrt(3)/2 for hex vertical spacing
+  const r = pitch * 0.55 // module radius (0.55 = touching, verified scannable with rxing)
+  const pad = pitch * margin // quiet zone, in modules
+  const svgW = cols * pitch + pitch / 2 + pad * 2
+  const svgH = rows * modH + pad * 2
 
-  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${Math.round(svgW)} ${Math.round(svgH)}" width="${Math.round(svgW)}" height="${Math.round(svgH)}" role="${escapeAttr(role)}"`;
-  if (ariaLabel) svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`;
-  svgOpen += ">";
+  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${Math.round(svgW)} ${Math.round(svgH)}" width="${Math.round(svgW)}" height="${Math.round(svgH)}" role="${escapeAttr(role)}"`
+  if (ariaLabel) svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`
+  svgOpen += ">"
 
-  const parts: string[] = [svgOpen];
-  if (title) parts.push(`<title>${escapeXml(title)}</title>`);
-  if (desc) parts.push(`<desc>${escapeXml(desc)}</desc>`);
+  const parts: string[] = [svgOpen]
+  if (title) parts.push(`<title>${escapeXml(title)}</title>`)
+  if (desc) parts.push(`<desc>${escapeXml(desc)}</desc>`)
   if (background !== "transparent") {
-    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`);
+    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`)
   }
 
   // Draw hexagonal modules as circles
-  const circles: string[] = [];
+  const circles: string[] = []
   for (let row = 0; row < rows; row++) {
     for (let col = 0; col < cols; col++) {
       if (matrix[row]![col]) {
-        const xOff = row % 2 === 1 ? pitch / 2 : 0;
-        const cx = pad + col * pitch + pitch / 2 + xOff;
-        const cy = pad + row * modH + modH / 2;
+        const xOff = row % 2 === 1 ? pitch / 2 : 0
+        const cx = pad + col * pitch + pitch / 2 + xOff
+        const cy = pad + row * modH + modH / 2
         circles.push(
           `<circle cx="${cx.toFixed(1)}" cy="${cy.toFixed(1)}" r="${r.toFixed(1)}" fill="${escapeAttr(color)}"/>`,
-        );
+        )
       }
     }
   }
-  parts.push(...circles);
+  parts.push(...circles)
 
-  parts.push("</svg>");
-  return parts.join("");
+  parts.push("</svg>")
+  return parts.join("")
 }

--- a/src/renderers/svg/optimize.ts
+++ b/src/renderers/svg/optimize.ts
@@ -12,27 +12,27 @@ export function optimizeSVG(
   svg: string,
   options: {
     /** Decimal precision for numbers (default 2) */
-    precision?: number;
+    precision?: number
     /** Remove width/height attributes for fully responsive SVG */
-    responsive?: boolean;
+    responsive?: boolean
   } = {},
 ): string {
-  const { precision = 2, responsive = false } = options;
+  const { precision = 2, responsive = false } = options
 
-  let result = svg;
+  let result = svg
 
   // Round decimal numbers in path data and attributes
   result = result.replace(/\d+\.\d+/g, (match) => {
-    const num = Number.parseFloat(match);
-    const rounded = Number.parseFloat(num.toFixed(precision));
-    return String(rounded);
-  });
+    const num = Number.parseFloat(match)
+    const rounded = Number.parseFloat(num.toFixed(precision))
+    return String(rounded)
+  })
 
   // Remove width/height for responsive SVG (keep viewBox)
   if (responsive) {
-    result = result.replace(/ width="[^"]*"/, "");
-    result = result.replace(/ height="[^"]*"/, "");
+    result = result.replace(/ width="[^"]*"/, "")
+    result = result.replace(/ height="[^"]*"/, "")
   }
 
-  return result;
+  return result
 }

--- a/src/renderers/svg/postal.ts
+++ b/src/renderers/svg/postal.ts
@@ -14,50 +14,50 @@
  * information is what carries the data — hence this dedicated renderer.
  */
 
-import type { FourState } from "../../encoders/fourstate";
-import type { MeasurementUnit, SVGAccessibilityOptions } from "./types";
-import { escapeAttr, escapeXml } from "./utils";
+import type { FourState } from "../../encoders/fourstate"
+import type { MeasurementUnit, SVGAccessibilityOptions } from "./types"
+import { escapeAttr, escapeXml } from "./utils"
 
 export interface PostalSVGOptions extends SVGAccessibilityOptions {
   /** Total symbol height in units (full-bar height). Default 40. */
-  height?: number;
+  height?: number
   /** Width of a single bar in units. Default 2. */
-  barWidth?: number;
+  barWidth?: number
   /** Centre-to-centre distance between bars in units. Default barWidth * 2. */
-  pitch?: number;
+  pitch?: number
   /** Bar color. Default "#000". */
-  color?: string;
+  color?: string
   /** Background color, or "transparent" to omit the background rect. Default "#fff". */
-  background?: string;
+  background?: string
   /** Measurement unit for width/height attributes. Default "px". */
-  unit?: MeasurementUnit;
+  unit?: MeasurementUnit
   /** Margin on all sides in units. Default 10. */
-  margin?: number;
-  marginTop?: number;
-  marginBottom?: number;
-  marginLeft?: number;
-  marginRight?: number;
+  margin?: number
+  marginTop?: number
+  marginBottom?: number
+  marginLeft?: number
+  marginRight?: number
   /**
    * Height of the centre tracker band as a fraction of total height, for
    * 4-state symbols. Default 1/3 (equal ascender / tracker / descender).
    */
-  trackerRatio?: number;
+  trackerRatio?: number
   /**
    * Height of a short bar as a fraction of total height, for 2-state
    * POSTNET/PLANET symbols. Default 0.4 (USPS spec: 0.050in of 0.125in).
    */
-  shortRatio?: number;
+  shortRatio?: number
   /** Render human-readable text below the symbol. Default false. */
-  showText?: boolean;
-  text?: string;
-  fontSize?: number;
-  fontFamily?: string;
+  showText?: boolean
+  text?: string
+  fontSize?: number
+  fontFamily?: string
 }
 
 /** Vertical extents of a bar, as fractions from the top of the symbol. */
 interface BarExtent {
-  top: number;
-  bottom: number;
+  top: number
+  bottom: number
 }
 
 /**
@@ -65,34 +65,34 @@ interface BarExtent {
  * height flag — non-zero for tall, `0` for short — as produced by
  * `encodePOSTNET` / `encodePLANET`.
  */
-export type PostalBar = FourState | number;
+export type PostalBar = FourState | number
 
-const FOUR_STATE = new Set<string>(["T", "A", "D", "F"]);
+const FOUR_STATE = new Set<string>(["T", "A", "D", "F"])
 
 /** True when the bar array uses 4-state letters rather than 2-state heights. */
 function isFourState(bars: readonly PostalBar[]): bars is FourState[] {
-  return bars.some((b) => typeof b === "string" && FOUR_STATE.has(b));
+  return bars.some((b) => typeof b === "string" && FOUR_STATE.has(b))
 }
 
 function fourStateExtent(bar: FourState, trackerRatio: number): BarExtent {
   // Equal-thirds layout by default: the tracker occupies the centre band and
   // ascenders/descenders extend into the remaining space above/below it.
-  const side = (1 - trackerRatio) / 2;
+  const side = (1 - trackerRatio) / 2
   switch (bar) {
     case "T":
-      return { top: side, bottom: side + trackerRatio };
+      return { top: side, bottom: side + trackerRatio }
     case "A":
-      return { top: 0, bottom: side + trackerRatio };
+      return { top: 0, bottom: side + trackerRatio }
     case "D":
-      return { top: side, bottom: 1 };
+      return { top: side, bottom: 1 }
     case "F":
-      return { top: 0, bottom: 1 };
+      return { top: 0, bottom: 1 }
   }
 }
 
 function twoStateExtent(bar: PostalBar, shortRatio: number): BarExtent {
   // Tall and short bars share a baseline; short bars rise `shortRatio` from it.
-  return bar ? { top: 0, bottom: 1 } : { top: 1 - shortRatio, bottom: 1 };
+  return bar ? { top: 0, bottom: 1 } : { top: 1 - shortRatio, bottom: 1 }
 }
 
 /**
@@ -123,63 +123,63 @@ export function renderPostalSVG(
     role = "img",
     title,
     desc,
-  } = options;
+  } = options
 
-  const pitch = options.pitch ?? barWidth * 2;
-  const u = unit === "px" ? "" : unit;
+  const pitch = options.pitch ?? barWidth * 2
+  const u = unit === "px" ? "" : unit
 
-  const mTop = options.marginTop ?? margin;
-  const mBottom = options.marginBottom ?? margin;
-  const mLeft = options.marginLeft ?? margin;
-  const mRight = options.marginRight ?? margin;
+  const mTop = options.marginTop ?? margin
+  const mBottom = options.marginBottom ?? margin
+  const mLeft = options.marginLeft ?? margin
+  const mRight = options.marginRight ?? margin
 
-  const fourState = isFourState(bars);
+  const fourState = isFourState(bars)
   // Bars are laid out on `pitch` centres; the final bar only needs its own width.
-  const symbolWidth = bars.length > 0 ? (bars.length - 1) * pitch + barWidth : 0;
-  const textHeight = showText && text ? fontSize + 8 : 0;
+  const symbolWidth = bars.length > 0 ? (bars.length - 1) * pitch + barWidth : 0
+  const textHeight = showText && text ? fontSize + 8 : 0
 
-  const svgWidth = symbolWidth + mLeft + mRight;
-  const svgHeight = height + mTop + mBottom + textHeight;
+  const svgWidth = symbolWidth + mLeft + mRight
+  const svgHeight = height + mTop + mBottom + textHeight
 
-  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}${u}" height="${svgHeight}${u}" role="${escapeAttr(role)}"`;
-  if (ariaLabel) svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`;
-  svgOpen += ">";
+  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}${u}" height="${svgHeight}${u}" role="${escapeAttr(role)}"`
+  if (ariaLabel) svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`
+  svgOpen += ">"
 
-  const parts: string[] = [svgOpen];
-  if (title) parts.push(`<title>${escapeXml(title)}</title>`);
-  if (desc) parts.push(`<desc>${escapeXml(desc)}</desc>`);
+  const parts: string[] = [svgOpen]
+  if (title) parts.push(`<title>${escapeXml(title)}</title>`)
+  if (desc) parts.push(`<desc>${escapeXml(desc)}</desc>`)
   if (background !== "transparent") {
-    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`);
+    parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background)}"/>`)
   }
 
-  const pathParts: string[] = [];
+  const pathParts: string[] = []
   for (let i = 0; i < bars.length; i++) {
-    const bar = bars[i]!;
+    const bar = bars[i]!
     const extent = fourState
       ? fourStateExtent(bar as FourState, trackerRatio)
-      : twoStateExtent(bar, shortRatio);
-    const x = mLeft + i * pitch;
-    const y = mTop + extent.top * height;
-    const h = (extent.bottom - extent.top) * height;
-    pathParts.push(`M${round(x)},${round(y)}h${round(barWidth)}v${round(h)}h-${round(barWidth)}z`);
+      : twoStateExtent(bar, shortRatio)
+    const x = mLeft + i * pitch
+    const y = mTop + extent.top * height
+    const h = (extent.bottom - extent.top) * height
+    pathParts.push(`M${round(x)},${round(y)}h${round(barWidth)}v${round(h)}h-${round(barWidth)}z`)
   }
 
   if (pathParts.length > 0) {
-    parts.push(`<path d="${pathParts.join("")}" fill="${escapeAttr(color)}"/>`);
+    parts.push(`<path d="${pathParts.join("")}" fill="${escapeAttr(color)}"/>`)
   }
 
   if (showText && text) {
-    const textY = mTop + height + fontSize + 4;
+    const textY = mTop + height + fontSize + 4
     parts.push(
       `<text x="${round(svgWidth / 2)}" y="${round(textY)}" text-anchor="middle" font-family="${escapeAttr(fontFamily)}" font-size="${fontSize}" fill="${escapeAttr(color)}">${escapeXml(text)}</text>`,
-    );
+    )
   }
 
-  parts.push("</svg>");
-  return parts.join("");
+  parts.push("</svg>")
+  return parts.join("")
 }
 
 /** Trim floating point noise from coordinates. */
 function round(n: number): number {
-  return Math.round(n * 1000) / 1000;
+  return Math.round(n * 1000) / 1000
 }

--- a/src/renderers/svg/qr.ts
+++ b/src/renderers/svg/qr.ts
@@ -2,18 +2,18 @@
  * QR Code SVG renderer with styling support
  */
 
-import type { QRCodeSVGOptions, CornerOptions } from "./types";
-import { getModulePath, getFinderOuterPath, getFinderInnerPath } from "./shapes";
-import { isGradient, generateGradientDef, resetGradientCounter } from "./gradient";
-import { calculateLogoPlacement } from "./logo";
-import { escapeAttr } from "./utils";
+import type { QRCodeSVGOptions, CornerOptions } from "./types"
+import { getModulePath, getFinderOuterPath, getFinderInnerPath } from "./shapes"
+import { isGradient, generateGradientDef, resetGradientCounter } from "./gradient"
+import { calculateLogoPlacement } from "./logo"
+import { escapeAttr } from "./utils"
 
 function escapeXml(str: string): string {
   return str
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
 }
 
 /**
@@ -36,67 +36,67 @@ export function renderQRCodeSVG(matrix: boolean[][], options: QRCodeSVGOptions =
     role = "img",
     title,
     desc,
-  } = options;
+  } = options
 
-  resetGradientCounter();
+  resetGradientCounter()
 
-  const moduleCount = matrix.length;
-  const totalModules = moduleCount + margin * 2;
-  const moduleSize = size / totalModules;
-  const sizeAttr = unit ? `${size}${unit}` : `${size}`;
+  const moduleCount = matrix.length
+  const totalModules = moduleCount + margin * 2
+  const moduleSize = size / totalModules
+  const sizeAttr = unit ? `${size}${unit}` : `${size}`
 
-  const defs: string[] = [];
-  const parts: string[] = [];
+  const defs: string[] = []
+  const parts: string[] = []
 
   if (xmlDeclaration) {
-    parts.push('<?xml version="1.0" encoding="UTF-8"?>');
+    parts.push('<?xml version="1.0" encoding="UTF-8"?>')
   }
 
   // Build SVG opening tag with accessibility attributes
-  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${size} ${size}" width="${sizeAttr}" height="${sizeAttr}" role="${escapeAttr(role)}"`;
+  let svgOpen = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${size} ${size}" width="${sizeAttr}" height="${sizeAttr}" role="${escapeAttr(role)}"`
   if (ariaLabel) {
-    svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`;
+    svgOpen += ` aria-label="${escapeAttr(ariaLabel)}"`
   }
-  svgOpen += ">";
+  svgOpen += ">"
 
-  parts.push(svgOpen);
+  parts.push(svgOpen)
 
   // Accessibility title and desc elements
   if (title) {
-    parts.push(`<title>${escapeXml(title)}</title>`);
+    parts.push(`<title>${escapeXml(title)}</title>`)
   }
   if (desc) {
-    parts.push(`<desc>${escapeXml(desc)}</desc>`);
+    parts.push(`<desc>${escapeXml(desc)}</desc>`)
   }
 
   // Background
   if (background !== "transparent") {
     if (isGradient(background)) {
-      const grad = generateGradientDef(background);
-      defs.push(grad.svg);
-      parts.push(`<rect width="100%" height="100%" fill="url(#${grad.id})"/>`);
+      const grad = generateGradientDef(background)
+      defs.push(grad.svg)
+      parts.push(`<rect width="100%" height="100%" fill="url(#${grad.id})"/>`)
     } else {
-      parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background as string)}"/>`);
+      parts.push(`<rect width="100%" height="100%" fill="${escapeAttr(background as string)}"/>`)
     }
   }
 
   // Resolve module color
-  let moduleColor = "#000";
+  let moduleColor = "#000"
   if (isGradient(color)) {
-    const grad = generateGradientDef(color);
-    defs.push(grad.svg);
-    moduleColor = `url(#${grad.id})`;
+    const grad = generateGradientDef(color)
+    defs.push(grad.svg)
+    moduleColor = `url(#${grad.id})`
   } else {
-    moduleColor = escapeAttr(color as string);
+    moduleColor = escapeAttr(color as string)
   }
 
   // Calculate logo hidden modules
-  let hiddenModules: Set<string> | undefined;
-  let logoSvg = "";
+  let hiddenModules: Set<string> | undefined
+  let logoSvg = ""
   if (logo) {
-    const placement = calculateLogoPlacement(logo, moduleCount, moduleSize, margin);
-    hiddenModules = placement.hiddenModules;
-    logoSvg = placement.svg;
+    const placement = calculateLogoPlacement(logo, moduleCount, moduleSize, margin)
+    hiddenModules = placement.hiddenModules
+    logoSvg = placement.svg
   }
 
   // Determine finder pattern positions
@@ -104,14 +104,14 @@ export function renderQRCodeSVG(matrix: boolean[][], options: QRCodeSVGOptions =
     { row: 0, col: 0, key: "topLeft" as const },
     { row: 0, col: moduleCount - 7, key: "topRight" as const },
     { row: moduleCount - 7, col: 0, key: "bottomLeft" as const },
-  ];
+  ]
 
   // Build finder pattern set for exclusion
-  const finderModules = new Set<string>();
+  const finderModules = new Set<string>()
   for (const fp of finderPositions) {
     for (let r = 0; r < 7; r++) {
       for (let c = 0; c < 7; c++) {
-        finderModules.add(`${fp.row + r},${fp.col + c}`);
+        finderModules.add(`${fp.row + r},${fp.col + c}`)
       }
     }
   }
@@ -119,95 +119,95 @@ export function renderQRCodeSVG(matrix: boolean[][], options: QRCodeSVGOptions =
   // Render finder patterns with custom styling
   if (corners) {
     for (const fp of finderPositions) {
-      const cornerOpts: CornerOptions | undefined = corners[fp.key];
-      const x = (fp.col + margin) * moduleSize;
-      const y = (fp.row + margin) * moduleSize;
+      const cornerOpts: CornerOptions | undefined = corners[fp.key]
+      const x = (fp.col + margin) * moduleSize
+      const y = (fp.row + margin) * moduleSize
 
       // Outer ring
-      const outerShape = cornerOpts?.outerShape ?? "square";
-      let outerColor = moduleColor;
+      const outerShape = cornerOpts?.outerShape ?? "square"
+      let outerColor = moduleColor
       if (cornerOpts?.outerColor) {
         if (isGradient(cornerOpts.outerColor)) {
-          const grad = generateGradientDef(cornerOpts.outerColor);
-          defs.push(grad.svg);
-          outerColor = `url(#${grad.id})`;
+          const grad = generateGradientDef(cornerOpts.outerColor)
+          defs.push(grad.svg)
+          outerColor = `url(#${grad.id})`
         } else {
-          outerColor = escapeAttr(cornerOpts.outerColor);
+          outerColor = escapeAttr(cornerOpts.outerColor)
         }
       }
       parts.push(
         `<path d="${getFinderOuterPath(x, y, moduleSize, outerShape)}" fill="${outerColor}" fill-rule="evenodd"/>`,
-      );
+      )
 
       // Inner square
-      const innerShape = cornerOpts?.innerShape ?? "square";
-      let innerColor = moduleColor;
+      const innerShape = cornerOpts?.innerShape ?? "square"
+      let innerColor = moduleColor
       if (cornerOpts?.innerColor) {
         if (isGradient(cornerOpts.innerColor)) {
-          const grad = generateGradientDef(cornerOpts.innerColor);
-          defs.push(grad.svg);
-          innerColor = `url(#${grad.id})`;
+          const grad = generateGradientDef(cornerOpts.innerColor)
+          defs.push(grad.svg)
+          innerColor = `url(#${grad.id})`
         } else {
-          innerColor = escapeAttr(cornerOpts.innerColor);
+          innerColor = escapeAttr(cornerOpts.innerColor)
         }
       }
       parts.push(
         `<path d="${getFinderInnerPath(x, y, moduleSize, innerShape)}" fill="${innerColor}"/>`,
-      );
+      )
     }
   } else {
     // Default finder patterns (rendered as modules)
-    finderModules.clear(); // Let them be rendered as normal modules
+    finderModules.clear() // Let them be rendered as normal modules
   }
 
   // Render data modules
-  const pathParts: string[] = [];
+  const pathParts: string[] = []
   for (let r = 0; r < moduleCount; r++) {
     for (let c = 0; c < moduleCount; c++) {
-      if (!matrix[r]![c]) continue;
-      if (hiddenModules?.has(`${r},${c}`)) continue;
-      if (finderModules.has(`${r},${c}`)) continue;
+      if (!matrix[r]![c]) continue
+      if (hiddenModules?.has(`${r},${c}`)) continue
+      if (finderModules.has(`${r},${c}`)) continue
 
-      const x = (c + margin) * moduleSize;
-      const y = (r + margin) * moduleSize;
-      pathParts.push(getModulePath(x, y, moduleSize, dotType, dotSize));
+      const x = (c + margin) * moduleSize
+      const y = (r + margin) * moduleSize
+      pathParts.push(getModulePath(x, y, moduleSize, dotType, dotSize))
     }
   }
 
   if (pathParts.length > 0) {
-    parts.push(`<path d="${pathParts.join("")}" fill="${moduleColor}"/>`);
+    parts.push(`<path d="${pathParts.join("")}" fill="${moduleColor}"/>`)
   }
 
   // Add logo
   if (logoSvg) {
-    parts.push(logoSvg);
+    parts.push(logoSvg)
   }
 
   // Circle shape: wrap content in clipPath
   if (shape === "circle") {
-    const cx = size / 2;
-    const cy = size / 2;
-    const r = size / 2;
+    const cx = size / 2
+    const cy = size / 2
+    const r = size / 2
     defs.push(
       `<clipPath id="etiket-circle-clip"><circle cx="${cx}" cy="${cy}" r="${r}"/></clipPath>`,
-    );
+    )
     // Extract all content after the <svg> tag, title, desc, and optional background rect
-    let bgIndex = xmlDeclaration ? 2 : 1;
-    if (title) bgIndex++;
-    if (desc) bgIndex++;
-    const contentStart = background !== "transparent" ? bgIndex + 1 : bgIndex;
-    const content = parts.splice(contentStart);
-    parts.push(`<g clip-path="url(#etiket-circle-clip)">`);
-    parts.push(...content);
-    parts.push("</g>");
+    let bgIndex = xmlDeclaration ? 2 : 1
+    if (title) bgIndex++
+    if (desc) bgIndex++
+    const contentStart = background !== "transparent" ? bgIndex + 1 : bgIndex
+    const content = parts.splice(contentStart)
+    parts.push(`<g clip-path="url(#etiket-circle-clip)">`)
+    parts.push(...content)
+    parts.push("</g>")
   }
 
   // Insert defs right after the <svg> tag (before title/desc/content)
   if (defs.length > 0) {
-    const defsIndex = xmlDeclaration ? 2 : 1;
-    parts.splice(defsIndex, 0, `<defs>${defs.join("")}</defs>`);
+    const defsIndex = xmlDeclaration ? 2 : 1
+    parts.splice(defsIndex, 0, `<defs>${defs.join("")}</defs>`)
   }
 
-  parts.push("</svg>");
-  return parts.join("");
+  parts.push("</svg>")
+  return parts.join("")
 }

--- a/src/renderers/svg/shapes.ts
+++ b/src/renderers/svg/shapes.ts
@@ -3,7 +3,7 @@
  * Each function returns an SVG path data string for a module at (x, y) with given size
  */
 
-import type { DotType } from "./types";
+import type { DotType } from "./types"
 
 /** Generate SVG path for a single module at the given position */
 export function getModulePath(
@@ -13,43 +13,43 @@ export function getModulePath(
   dotType: DotType,
   dotSize: number = 1,
 ): string {
-  const s = size * dotSize;
-  const offset = (size - s) / 2;
+  const s = size * dotSize
+  const offset = (size - s) / 2
 
   switch (dotType) {
     case "square":
-      return squarePath(x + offset, y + offset, s);
+      return squarePath(x + offset, y + offset, s)
     case "rounded":
-      return roundedPath(x + offset, y + offset, s, s * 0.25);
+      return roundedPath(x + offset, y + offset, s, s * 0.25)
     case "dots":
-      return circlePath(x + size / 2, y + size / 2, s / 2);
+      return circlePath(x + size / 2, y + size / 2, s / 2)
     case "diamond":
-      return diamondPath(x + size / 2, y + size / 2, s);
+      return diamondPath(x + size / 2, y + size / 2, s)
     case "classy":
-      return classyPath(x + offset, y + offset, s);
+      return classyPath(x + offset, y + offset, s)
     case "classy-rounded":
-      return classyRoundedPath(x + offset, y + offset, s);
+      return classyRoundedPath(x + offset, y + offset, s)
     case "extra-rounded":
-      return roundedPath(x + offset, y + offset, s, s * 0.5);
+      return roundedPath(x + offset, y + offset, s, s * 0.5)
     case "vertical-line":
-      return verticalLinePath(x + offset, y, size, s);
+      return verticalLinePath(x + offset, y, size, s)
     case "horizontal-line":
-      return horizontalLinePath(x, y + offset, size, s);
+      return horizontalLinePath(x, y + offset, size, s)
     case "small-square":
-      return squarePath(x + size * 0.15, y + size * 0.15, size * 0.7);
+      return squarePath(x + size * 0.15, y + size * 0.15, size * 0.7)
     case "tiny-square":
-      return squarePath(x + size * 0.25, y + size * 0.25, size * 0.5);
+      return squarePath(x + size * 0.25, y + size * 0.25, size * 0.5)
     default:
-      return squarePath(x + offset, y + offset, s);
+      return squarePath(x + offset, y + offset, s)
   }
 }
 
 function squarePath(x: number, y: number, s: number): string {
-  return `M${x},${y}h${s}v${s}h-${s}z`;
+  return `M${x},${y}h${s}v${s}h-${s}z`
 }
 
 function roundedPath(x: number, y: number, s: number, r: number): string {
-  r = Math.min(r, s / 2);
+  r = Math.min(r, s / 2)
   return (
     `M${x + r},${y}` +
     `h${s - 2 * r}` +
@@ -60,29 +60,29 @@ function roundedPath(x: number, y: number, s: number, r: number): string {
     `a${r},${r},0,0,1,-${r},-${r}` +
     `v-${s - 2 * r}` +
     `a${r},${r},0,0,1,${r},-${r}z`
-  );
+  )
 }
 
 function circlePath(cx: number, cy: number, r: number): string {
-  return `M${cx - r},${cy}` + `a${r},${r},0,1,0,${2 * r},0` + `a${r},${r},0,1,0,-${2 * r},0z`;
+  return `M${cx - r},${cy}` + `a${r},${r},0,1,0,${2 * r},0` + `a${r},${r},0,1,0,-${2 * r},0z`
 }
 
 function diamondPath(cx: number, cy: number, s: number): string {
-  const half = s / 2;
-  return `M${cx},${cy - half}` + `l${half},${half}` + `l-${half},${half}` + `l-${half},-${half}z`;
+  const half = s / 2
+  return `M${cx},${cy - half}` + `l${half},${half}` + `l-${half},${half}` + `l-${half},-${half}z`
 }
 
 function classyPath(x: number, y: number, s: number): string {
   // Classy style: square with one rounded corner (top-right)
-  const r = s * 0.35;
+  const r = s * 0.35
   return (
     `M${x},${y}` + `h${s - r}` + `a${r},${r},0,0,1,${r},${r}` + `v${s - r}` + `h-${s}` + `v-${s}z`
-  );
+  )
 }
 
 function classyRoundedPath(x: number, y: number, s: number): string {
   // Classy rounded: rounded corners on top-right and bottom-left
-  const r = s * 0.35;
+  const r = s * 0.35
   return (
     `M${x},${y}` +
     `h${s - r}` +
@@ -91,15 +91,15 @@ function classyRoundedPath(x: number, y: number, s: number): string {
     `a${r},${r},0,0,1,-${r},${r}` +
     `h-${s - r}` +
     `v-${s}z`
-  );
+  )
 }
 
 function verticalLinePath(x: number, y: number, fullSize: number, width: number): string {
-  return `M${x},${y}h${width}v${fullSize}h-${width}z`;
+  return `M${x},${y}h${width}v${fullSize}h-${width}z`
 }
 
 function horizontalLinePath(x: number, y: number, fullSize: number, height: number): string {
-  return `M${x},${y}h${fullSize}v${height}h-${fullSize}z`;
+  return `M${x},${y}h${fullSize}v${height}h-${fullSize}z`
 }
 
 /** Generate SVG path for finder pattern outer ring */
@@ -109,11 +109,11 @@ export function getFinderOuterPath(
   moduleSize: number,
   shape: string = "square",
 ): string {
-  const s = moduleSize * 7;
+  const s = moduleSize * 7
 
   switch (shape) {
     case "rounded": {
-      const r = moduleSize * 1.5;
+      const r = moduleSize * 1.5
       return (
         outerRoundedRect(x, y, s, s, r) +
         innerRoundedRect(
@@ -123,15 +123,15 @@ export function getFinderOuterPath(
           s - 2 * moduleSize,
           r * 0.5,
         )
-      );
+      )
     }
     case "dots": {
-      const r = s / 2;
-      const ri = r - moduleSize;
-      return circlePath(x + r, y + r, r) + circlePath(x + r, y + r, ri);
+      const r = s / 2
+      const ri = r - moduleSize
+      return circlePath(x + r, y + r, r) + circlePath(x + r, y + r, ri)
     }
     case "extra-rounded": {
-      const r = moduleSize * 2.5;
+      const r = moduleSize * 2.5
       return (
         outerRoundedRect(x, y, s, s, r) +
         innerRoundedRect(
@@ -141,10 +141,10 @@ export function getFinderOuterPath(
           s - 2 * moduleSize,
           r * 0.6,
         )
-      );
+      )
     }
     case "classy": {
-      const r = moduleSize * 1.5;
+      const r = moduleSize * 1.5
       // Outer with one rounded corner
       return (
         outerRoundedRect(x, y, s, s, r) +
@@ -155,14 +155,14 @@ export function getFinderOuterPath(
           s - 2 * moduleSize,
           r * 0.5,
         )
-      );
+      )
     }
     default: {
       // Square: outer rect minus inner rect (frame)
       return (
         `M${x},${y}h${s}v${s}h-${s}z` +
         `M${x + moduleSize},${y + moduleSize}v${s - 2 * moduleSize}h${s - 2 * moduleSize}v-${s - 2 * moduleSize}z`
-      );
+      )
     }
   }
 }
@@ -174,17 +174,17 @@ export function getFinderInnerPath(
   moduleSize: number,
   shape: string = "square",
 ): string {
-  const s = moduleSize * 3;
-  const cx = x + moduleSize * 3.5;
-  const cy = y + moduleSize * 3.5;
+  const s = moduleSize * 3
+  const cx = x + moduleSize * 3.5
+  const cy = y + moduleSize * 3.5
 
   switch (shape) {
     case "dots":
-      return circlePath(cx, cy, s / 2);
+      return circlePath(cx, cy, s / 2)
     case "rounded":
-      return roundedPath(x + moduleSize * 2, y + moduleSize * 2, s, moduleSize * 0.75);
+      return roundedPath(x + moduleSize * 2, y + moduleSize * 2, s, moduleSize * 0.75)
     default:
-      return squarePath(x + moduleSize * 2, y + moduleSize * 2, s);
+      return squarePath(x + moduleSize * 2, y + moduleSize * 2, s)
   }
 }
 
@@ -195,10 +195,10 @@ function outerRoundedRect(x: number, y: number, w: number, h: number, r: number)
     `v${h - 2 * r}a${r},${r},0,0,1,-${r},${r}` +
     `h-${w - 2 * r}a${r},${r},0,0,1,-${r},-${r}` +
     `v-${h - 2 * r}a${r},${r},0,0,1,${r},-${r}z`
-  );
+  )
 }
 
 function innerRoundedRect(x: number, y: number, w: number, h: number, r: number): string {
   // Same shape as outerRoundedRect — fill-rule="evenodd" creates the hole regardless of winding
-  return outerRoundedRect(x, y, w, h, r);
+  return outerRoundedRect(x, y, w, h, r)
 }

--- a/src/renderers/svg/types.ts
+++ b/src/renderers/svg/types.ts
@@ -13,105 +13,105 @@ export type DotType =
   | "vertical-line"
   | "horizontal-line"
   | "small-square"
-  | "tiny-square";
+  | "tiny-square"
 
 export interface LinearGradientOptions {
-  type: "linear";
-  rotation?: number;
-  stops: Array<{ offset: number; color: string }>;
+  type: "linear"
+  rotation?: number
+  stops: Array<{ offset: number; color: string }>
 }
 
 export interface RadialGradientOptions {
-  type: "radial";
-  stops: Array<{ offset: number; color: string }>;
+  type: "radial"
+  stops: Array<{ offset: number; color: string }>
 }
 
-export type GradientOptions = LinearGradientOptions | RadialGradientOptions;
+export type GradientOptions = LinearGradientOptions | RadialGradientOptions
 
 export interface CornerOptions {
-  outerShape?: "square" | "rounded" | "dots" | "extra-rounded" | "classy";
-  innerShape?: "square" | "dots" | "rounded";
-  outerColor?: string | GradientOptions;
-  innerColor?: string | GradientOptions;
+  outerShape?: "square" | "rounded" | "dots" | "extra-rounded" | "classy"
+  innerShape?: "square" | "dots" | "rounded"
+  outerColor?: string | GradientOptions
+  innerColor?: string | GradientOptions
 }
 
 export interface LogoOptions {
   /** Inline SVG markup (rendered inside a nested <svg>) */
-  svg?: string;
+  svg?: string
   /** SVG path data (assumes 100x100 coordinate space) */
-  path?: string;
+  path?: string
   /** Image data URI (e.g. "data:image/png;base64,...") or external URL (PNG, JPEG, GIF, SVG only) */
-  imageUrl?: string;
+  imageUrl?: string
   /** Image width in SVG coordinate units (defaults to logo area size if omitted) */
-  imageWidth?: number;
+  imageWidth?: number
   /** Image height in SVG coordinate units (defaults to logo area size if omitted) */
-  imageHeight?: number;
+  imageHeight?: number
   /** Logo size as fraction of QR size (0.1 to 0.5, default 0.3) */
-  size?: number;
+  size?: number
   /** Padding around logo in pixels */
-  margin?: number;
+  margin?: number
   /** Remove QR modules behind the logo (default true) */
-  hideBackgroundDots?: boolean;
+  hideBackgroundDots?: boolean
   /** Background color behind the logo */
-  backgroundColor?: string;
+  backgroundColor?: string
 }
 
 /** Accessibility options for SVG output */
 export interface SVGAccessibilityOptions {
   /** aria-label attribute for the SVG element */
-  ariaLabel?: string;
+  ariaLabel?: string
   /** ARIA role attribute (default: "img") */
-  role?: string;
+  role?: string
   /** Title element added as first child of SVG */
-  title?: string;
+  title?: string
   /** Description element added after title */
-  desc?: string;
+  desc?: string
 }
 
 export interface QRCodeSVGOptions extends SVGAccessibilityOptions {
-  size?: number;
-  margin?: number; // in modules (quiet zone)
+  size?: number
+  margin?: number // in modules (quiet zone)
   /** Measurement unit for size (default 'px'). Affects SVG width/height attributes. */
-  unit?: MeasurementUnit;
-  color?: string | GradientOptions;
-  background?: string | GradientOptions | "transparent";
-  dotType?: DotType;
-  dotSize?: number; // 0.1 to 1, default 1
-  shape?: "square" | "circle"; // overall QR code shape, default 'square'
+  unit?: MeasurementUnit
+  color?: string | GradientOptions
+  background?: string | GradientOptions | "transparent"
+  dotType?: DotType
+  dotSize?: number // 0.1 to 1, default 1
+  shape?: "square" | "circle" // overall QR code shape, default 'square'
   corners?: {
-    topLeft?: CornerOptions;
-    topRight?: CornerOptions;
-    bottomLeft?: CornerOptions;
-  };
-  logo?: LogoOptions;
-  xmlDeclaration?: boolean;
+    topLeft?: CornerOptions
+    topRight?: CornerOptions
+    bottomLeft?: CornerOptions
+  }
+  logo?: LogoOptions
+  xmlDeclaration?: boolean
 }
 
 /** Measurement unit for SVG dimensions */
-export type MeasurementUnit = "px" | "mm" | "in" | "pt" | "cm";
+export type MeasurementUnit = "px" | "mm" | "in" | "pt" | "cm"
 
 export interface BarcodeSVGOptions extends SVGAccessibilityOptions {
-  width?: number;
-  height?: number;
-  barWidth?: number;
+  width?: number
+  height?: number
+  barWidth?: number
   /** Measurement unit for dimensions (default 'px'). Affects SVG width/height attributes. */
-  unit?: MeasurementUnit;
+  unit?: MeasurementUnit
   /** Extra spacing between bars. Each bar is narrowed by barGap/2 on each side. Default 0. */
-  barGap?: number;
-  color?: string;
-  background?: string;
-  showText?: boolean;
-  text?: string;
-  fontSize?: number;
-  fontFamily?: string;
-  margin?: number;
-  marginTop?: number;
-  marginBottom?: number;
-  marginLeft?: number;
-  marginRight?: number;
-  textAlign?: "center" | "left" | "right";
-  textPosition?: "bottom" | "top";
-  rotation?: 0 | 90 | 180 | 270;
-  bearerBars?: boolean;
-  bearerBarWidth?: number;
+  barGap?: number
+  color?: string
+  background?: string
+  showText?: boolean
+  text?: string
+  fontSize?: number
+  fontFamily?: string
+  margin?: number
+  marginTop?: number
+  marginBottom?: number
+  marginLeft?: number
+  marginRight?: number
+  textAlign?: "center" | "left" | "right"
+  textPosition?: "bottom" | "top"
+  rotation?: 0 | 90 | 180 | 270
+  bearerBars?: boolean
+  bearerBarWidth?: number
 }

--- a/src/renderers/svg/utils.ts
+++ b/src/renderers/svg/utils.ts
@@ -5,7 +5,7 @@ export function escapeAttr(value: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
 }
 
 /** Escape a string for use in SVG/XML text content */
@@ -14,5 +14,5 @@ export function escapeXml(value: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
 }

--- a/src/renderers/text.ts
+++ b/src/renderers/text.ts
@@ -5,57 +5,57 @@
 
 export interface TextRenderOptions {
   /** Dark module character (default: '██') */
-  dark?: string;
+  dark?: string
   /** Light module character (default: '  ') */
-  light?: string;
+  light?: string
   /** Use compact mode with half-height blocks (default: true) */
-  compact?: boolean;
+  compact?: boolean
   /** Margin in modules (default: 2) */
-  margin?: number;
+  margin?: number
   /** Invert colors (default: false) */
-  invert?: boolean;
+  invert?: boolean
 }
 
 /**
  * Render a QR code matrix as terminal-printable string
  */
 export function renderText(matrix: boolean[][], options: TextRenderOptions = {}): string {
-  const { compact = true, margin = 2, invert = false } = options;
+  const { compact = true, margin = 2, invert = false } = options
 
-  const size = matrix.length;
+  const size = matrix.length
 
   if (compact) {
-    return renderCompact(matrix, size, margin, invert);
+    return renderCompact(matrix, size, margin, invert)
   }
 
-  const dark = options.dark ?? "██";
-  const light = options.light ?? "  ";
+  const dark = options.dark ?? "██"
+  const light = options.light ?? "  "
 
-  const d = invert ? light : dark;
-  const l = invert ? dark : light;
+  const d = invert ? light : dark
+  const l = invert ? dark : light
 
-  const lines: string[] = [];
+  const lines: string[] = []
 
   // Top margin
   for (let m = 0; m < margin; m++) {
-    lines.push(l.repeat(size + margin * 2));
+    lines.push(l.repeat(size + margin * 2))
   }
 
   for (let r = 0; r < size; r++) {
-    let line = l.repeat(margin);
+    let line = l.repeat(margin)
     for (let c = 0; c < size; c++) {
-      line += matrix[r]![c] ? d : l;
+      line += matrix[r]![c] ? d : l
     }
-    line += l.repeat(margin);
-    lines.push(line);
+    line += l.repeat(margin)
+    lines.push(line)
   }
 
   // Bottom margin
   for (let m = 0; m < margin; m++) {
-    lines.push(l.repeat(size + margin * 2));
+    lines.push(l.repeat(size + margin * 2))
   }
 
-  return lines.join("\n");
+  return lines.join("\n")
 }
 
 /**
@@ -64,28 +64,28 @@ export function renderText(matrix: boolean[][], options: TextRenderOptions = {})
  * ▀ (upper half), ▄ (lower half), █ (full block), ' ' (empty)
  */
 function renderCompact(matrix: boolean[][], size: number, margin: number, invert: boolean): string {
-  const lines: string[] = [];
+  const lines: string[] = []
   // const totalWidth = size + margin * 2;
 
   // Process 2 rows at a time
   for (let r = -margin; r < size + margin; r += 2) {
-    let line = "";
+    let line = ""
     for (let c = -margin; c < size + margin; c++) {
-      const top = getModule(matrix, r, c, size) !== invert;
-      const bottom = getModule(matrix, r + 1, c, size) !== invert;
+      const top = getModule(matrix, r, c, size) !== invert
+      const bottom = getModule(matrix, r + 1, c, size) !== invert
 
-      if (top && bottom) line += "█";
-      else if (top && !bottom) line += "▀";
-      else if (!top && bottom) line += "▄";
-      else line += " ";
+      if (top && bottom) line += "█"
+      else if (top && !bottom) line += "▀"
+      else if (!top && bottom) line += "▄"
+      else line += " "
     }
-    lines.push(line);
+    lines.push(line)
   }
 
-  return lines.join("\n");
+  return lines.join("\n")
 }
 
 function getModule(matrix: boolean[][], r: number, c: number, size: number): boolean {
-  if (r < 0 || r >= size || c < 0 || c >= size) return false;
-  return !!matrix[r]![c];
+  if (r < 0 || r >= size || c < 0 || c >= size) return false
+  return !!matrix[r]![c]
 }

--- a/src/validators/barcode.ts
+++ b/src/validators/barcode.ts
@@ -5,99 +5,99 @@
  * so validation and encoding can never disagree.
  */
 
-import { dpCheckDigit } from "../encoders/deutsche-post";
-import { postnetCheckDigit } from "../encoders/postnet";
+import { dpCheckDigit } from "../encoders/deutsche-post"
+import { postnetCheckDigit } from "../encoders/postnet"
 
 /** Validate and calculate EAN/UPC check digit (modulo 10 weighted) */
 export function calculateEANCheckDigit(digits: number[]): number {
-  let sum = 0;
+  let sum = 0
   for (let i = 0; i < digits.length; i++) {
-    sum += digits[i]! * (i % 2 === 0 ? 1 : 3);
+    sum += digits[i]! * (i % 2 === 0 ? 1 : 3)
   }
-  return (10 - (sum % 10)) % 10;
+  return (10 - (sum % 10)) % 10
 }
 
 /** Verify EAN/UPC check digit */
 export function verifyEANCheckDigit(text: string): boolean {
-  const digits = text.replace(/\D/g, "").split("").map(Number);
-  if (digits.length < 2) return false;
-  const check = digits.pop()!;
-  return calculateEANCheckDigit(digits) === check;
+  const digits = text.replace(/\D/g, "").split("").map(Number)
+  if (digits.length < 2) return false
+  const check = digits.pop()!
+  return calculateEANCheckDigit(digits) === check
 }
 
 /** Validate barcode input for a given type */
 export function validateBarcode(text: string, type: string): { valid: boolean; error?: string } {
   switch (type) {
     case "code128":
-      if (text.length === 0) return { valid: false, error: "Text cannot be empty" };
-      return { valid: true };
+      if (text.length === 0) return { valid: false, error: "Text cannot be empty" }
+      return { valid: true }
 
     case "ean13": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length !== 12 && digits.length !== 13) {
-        return { valid: false, error: "EAN-13 requires 12 or 13 digits" };
+        return { valid: false, error: "EAN-13 requires 12 or 13 digits" }
       }
       if (!/^\d+$/.test(digits)) {
-        return { valid: false, error: "EAN-13 must contain only digits" };
+        return { valid: false, error: "EAN-13 must contain only digits" }
       }
       if (digits.length === 13 && !verifyEANCheckDigit(digits)) {
-        return { valid: false, error: "Invalid EAN-13 check digit" };
+        return { valid: false, error: "Invalid EAN-13 check digit" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "ean8": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length !== 7 && digits.length !== 8) {
-        return { valid: false, error: "EAN-8 requires 7 or 8 digits" };
+        return { valid: false, error: "EAN-8 requires 7 or 8 digits" }
       }
       if (digits.length === 8 && !verifyEANCheckDigit(digits)) {
-        return { valid: false, error: "Invalid EAN-8 check digit" };
+        return { valid: false, error: "Invalid EAN-8 check digit" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "code39": {
-      const valid = /^[0-9A-Z-. $/+%]*$/.test(text);
+      const valid = /^[0-9A-Z-. $/+%]*$/.test(text)
       if (!valid)
-        return { valid: false, error: "Code 39 only accepts 0-9, A-Z, -, ., space, $, /, +, %" };
-      return { valid: true };
+        return { valid: false, error: "Code 39 only accepts 0-9, A-Z, -, ., space, $, /, +, %" }
+      return { valid: true }
     }
 
     case "code93": {
-      const valid = /^[0-9A-Z-. $/+%]*$/.test(text);
+      const valid = /^[0-9A-Z-. $/+%]*$/.test(text)
       if (!valid)
-        return { valid: false, error: "Code 93 only accepts 0-9, A-Z, -, ., space, $, /, +, %" };
-      return { valid: true };
+        return { valid: false, error: "Code 93 only accepts 0-9, A-Z, -, ., space, $, /, +, %" }
+      return { valid: true }
     }
 
     case "itf": {
-      if (!/^\d+$/.test(text)) return { valid: false, error: "ITF only accepts digits" };
-      return { valid: true };
+      if (!/^\d+$/.test(text)) return { valid: false, error: "ITF only accepts digits" }
+      return { valid: true }
     }
 
     case "itf14": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length !== 13 && digits.length !== 14) {
-        return { valid: false, error: "ITF-14 requires 13 or 14 digits" };
+        return { valid: false, error: "ITF-14 requires 13 or 14 digits" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "upca": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length !== 11 && digits.length !== 12) {
-        return { valid: false, error: "UPC-A requires 11 or 12 digits" };
+        return { valid: false, error: "UPC-A requires 11 or 12 digits" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "upce": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length < 6 || digits.length > 8) {
-        return { valid: false, error: "UPC-E requires 6-8 digits" };
+        return { valid: false, error: "UPC-E requires 6-8 digits" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "codabar": {
@@ -105,29 +105,29 @@ export function validateBarcode(text: string, type: string): { valid: boolean; e
         return {
           valid: false,
           error: "Codabar only accepts 0-9, -, $, :, /, ., +, and A-D start/stop",
-        };
+        }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "msi": {
-      if (!/^\d+$/.test(text)) return { valid: false, error: "MSI only accepts digits" };
-      return { valid: true };
+      if (!/^\d+$/.test(text)) return { valid: false, error: "MSI only accepts digits" }
+      return { valid: true }
     }
 
     case "pharmacode": {
-      const num = Number(text);
+      const num = Number(text)
       if (!Number.isInteger(num) || num < 3 || num > 131070) {
-        return { valid: false, error: "Pharmacode requires integer value 3-131070" };
+        return { valid: false, error: "Pharmacode requires integer value 3-131070" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "code11": {
       if (!/^[0-9-]*$/.test(text)) {
-        return { valid: false, error: "Code 11 only accepts 0-9 and dash (-)" };
+        return { valid: false, error: "Code 11 only accepts 0-9 and dash (-)" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "code39ext":
@@ -135,142 +135,142 @@ export function validateBarcode(text: string, type: string): { valid: boolean; e
       // Full ASCII (0-127)
       for (let i = 0; i < text.length; i++) {
         if (text.charCodeAt(i) > 127) {
-          return { valid: false, error: `${type} only accepts ASCII characters (0-127)` };
+          return { valid: false, error: `${type} only accepts ASCII characters (0-127)` }
         }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "ean2": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length !== 2) {
-        return { valid: false, error: "EAN-2 requires exactly 2 digits" };
+        return { valid: false, error: "EAN-2 requires exactly 2 digits" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "ean5": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length !== 5) {
-        return { valid: false, error: "EAN-5 requires exactly 5 digits" };
+        return { valid: false, error: "EAN-5 requires exactly 5 digits" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "gs1-128": {
       if (text.length === 0) {
-        return { valid: false, error: "GS1-128 text cannot be empty" };
+        return { valid: false, error: "GS1-128 text cannot be empty" }
       }
       // Check parenthesized format for valid AI structure
       if (text.includes("(")) {
-        const aiPattern = /\((\d{2,4})\)/;
+        const aiPattern = /\((\d{2,4})\)/
         if (!aiPattern.test(text)) {
-          return { valid: false, error: "GS1-128 has invalid Application Identifier format" };
+          return { valid: false, error: "GS1-128 has invalid Application Identifier format" }
         }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "identcode": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length !== 11 && digits.length !== 12) {
-        return { valid: false, error: "Identcode requires 11 or 12 digits" };
+        return { valid: false, error: "Identcode requires 11 or 12 digits" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "leitcode": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length !== 13 && digits.length !== 14) {
-        return { valid: false, error: "Leitcode requires 13 or 14 digits" };
+        return { valid: false, error: "Leitcode requires 13 or 14 digits" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "postnet": {
-      const digits = text.replace(/[\s-]/g, "");
+      const digits = text.replace(/[\s-]/g, "")
       if (!/^\d+$/.test(digits)) {
-        return { valid: false, error: "POSTNET only accepts digits" };
+        return { valid: false, error: "POSTNET only accepts digits" }
       }
       if (digits.length !== 5 && digits.length !== 9 && digits.length !== 11) {
-        return { valid: false, error: "POSTNET requires 5, 9, or 11 digits" };
+        return { valid: false, error: "POSTNET requires 5, 9, or 11 digits" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "planet": {
-      const digits = text.replace(/[\s-]/g, "");
+      const digits = text.replace(/[\s-]/g, "")
       if (!/^\d+$/.test(digits)) {
-        return { valid: false, error: "PLANET only accepts digits" };
+        return { valid: false, error: "PLANET only accepts digits" }
       }
       if (digits.length !== 11 && digits.length !== 13) {
-        return { valid: false, error: "PLANET requires 11 or 13 digits" };
+        return { valid: false, error: "PLANET requires 11 or 13 digits" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "plessey": {
       if (!/^[0-9A-Fa-f]*$/.test(text)) {
-        return { valid: false, error: "Plessey only accepts hexadecimal digits (0-9, A-F)" };
+        return { valid: false, error: "Plessey only accepts hexadecimal digits (0-9, A-F)" }
       }
       if (text.length === 0) {
-        return { valid: false, error: "Plessey text cannot be empty" };
+        return { valid: false, error: "Plessey text cannot be empty" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "rm4scc":
     case "kix": {
-      const upper = text.toUpperCase().replace(/\s/g, "");
+      const upper = text.toUpperCase().replace(/\s/g, "")
       if (!/^[0-9A-Z]+$/.test(upper)) {
-        return { valid: false, error: `${type} only accepts A-Z and 0-9` };
+        return { valid: false, error: `${type} only accepts A-Z and 0-9` }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "auspost": {
       if (!/^\d{8}$/.test(text.replace(/\s/g, ""))) {
-        return { valid: false, error: "Australia Post requires an 8-digit DPID" };
+        return { valid: false, error: "Australia Post requires an 8-digit DPID" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "jppost": {
-      const zip = text.replace(/-/g, "");
+      const zip = text.replace(/-/g, "")
       if (!/^\d{7}/.test(zip)) {
-        return { valid: false, error: "Japan Post requires a 7-digit postal code" };
+        return { valid: false, error: "Japan Post requires a 7-digit postal code" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "imb": {
-      const digits = text.replace(/[\s-]/g, "");
+      const digits = text.replace(/[\s-]/g, "")
       if (!/^\d{20}$/.test(digits)) {
-        return { valid: false, error: "IMb requires a 20-digit tracking code" };
+        return { valid: false, error: "IMb requires a 20-digit tracking code" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "gs1-databar":
     case "gs1-databar-limited": {
-      const digits = text.replace(/\D/g, "");
+      const digits = text.replace(/\D/g, "")
       if (digits.length < 1 || digits.length > 14) {
-        return { valid: false, error: `${type} requires up to 14 digits` };
+        return { valid: false, error: `${type} requires up to 14 digits` }
       }
       if (type === "gs1-databar-limited" && digits.length === 14 && !/^[01]/.test(digits)) {
         return {
           valid: false,
           error: "GS1 DataBar Limited requires an indicator digit of 0 or 1",
-        };
+        }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "gs1-databar-expanded": {
       if (text.length === 0) {
-        return { valid: false, error: "GS1 DataBar Expanded text cannot be empty" };
+        return { valid: false, error: "GS1 DataBar Expanded text cannot be empty" }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     case "qr":
@@ -287,41 +287,41 @@ export function validateBarcode(text: string, type: string): { valid: boolean; e
     case "codablock-f":
     case "code16k": {
       if (text.length === 0) {
-        return { valid: false, error: `${type} input must not be empty` };
+        return { valid: false, error: `${type} input must not be empty` }
       }
-      return { valid: true };
+      return { valid: true }
     }
 
     default:
-      return { valid: true };
+      return { valid: true }
   }
 }
 
 /** Check if input is valid for a barcode type (boolean convenience) */
 export function isValidInput(text: string, type: string): boolean {
-  return validateBarcode(text, type).valid;
+  return validateBarcode(text, type).valid
 }
 
 /**
  * Calculate ITF-14 check digit (mod 10, weights starting at 3)
  */
 function calculateITF14CheckDigit(digits: number[]): number {
-  let sum = 0;
+  let sum = 0
   for (let i = 0; i < digits.length; i++) {
-    sum += digits[i]! * (i % 2 === 0 ? 3 : 1);
+    sum += digits[i]! * (i % 2 === 0 ? 3 : 1)
   }
-  return (10 - (sum % 10)) % 10;
+  return (10 - (sum % 10)) % 10
 }
 
 /**
  * Calculate UPC-A check digit (mod 10, weights starting at 3)
  */
 function calculateUPCACheckDigit(digits: number[]): number {
-  let sum = 0;
+  let sum = 0
   for (let i = 0; i < digits.length; i++) {
-    sum += digits[i]! * (i % 2 === 0 ? 3 : 1);
+    sum += digits[i]! * (i % 2 === 0 ? 3 : 1)
   }
-  return (10 - (sum % 10)) % 10;
+  return (10 - (sum % 10)) % 10
 }
 
 /**
@@ -334,66 +334,66 @@ export function validateBarcodeInput(
   text: string,
   type: string,
 ): { valid: boolean; error?: string; checkDigit?: number } {
-  const result = validateBarcode(text, type);
+  const result = validateBarcode(text, type)
   if (!result.valid) {
-    return result;
+    return result
   }
 
   // Compute check digit for types that support it
   switch (type) {
     case "ean13": {
-      const digits = text.replace(/\D/g, "").split("").map(Number);
-      const dataDigits = digits.slice(0, 12);
-      const checkDigit = calculateEANCheckDigit(dataDigits);
-      return { valid: true, checkDigit };
+      const digits = text.replace(/\D/g, "").split("").map(Number)
+      const dataDigits = digits.slice(0, 12)
+      const checkDigit = calculateEANCheckDigit(dataDigits)
+      return { valid: true, checkDigit }
     }
 
     case "ean8": {
-      const digits = text.replace(/\D/g, "").split("").map(Number);
-      const dataDigits = digits.slice(0, 7);
-      const checkDigit = calculateEANCheckDigit(dataDigits);
-      return { valid: true, checkDigit };
+      const digits = text.replace(/\D/g, "").split("").map(Number)
+      const dataDigits = digits.slice(0, 7)
+      const checkDigit = calculateEANCheckDigit(dataDigits)
+      return { valid: true, checkDigit }
     }
 
     case "upca": {
-      const digits = text.replace(/\D/g, "").split("").map(Number);
-      const dataDigits = digits.slice(0, 11);
-      const checkDigit = calculateUPCACheckDigit(dataDigits);
-      return { valid: true, checkDigit };
+      const digits = text.replace(/\D/g, "").split("").map(Number)
+      const dataDigits = digits.slice(0, 11)
+      const checkDigit = calculateUPCACheckDigit(dataDigits)
+      return { valid: true, checkDigit }
     }
 
     case "itf14": {
-      const digits = text.replace(/\D/g, "").split("").map(Number);
-      const dataDigits = digits.slice(0, 13);
-      const checkDigit = calculateITF14CheckDigit(dataDigits);
-      return { valid: true, checkDigit };
+      const digits = text.replace(/\D/g, "").split("").map(Number)
+      const dataDigits = digits.slice(0, 13)
+      const checkDigit = calculateITF14CheckDigit(dataDigits)
+      return { valid: true, checkDigit }
     }
 
     case "upce": {
       // UPC-E check digits are defined on the expanded UPC-A form
-      const digits = text.replace(/\D/g, "");
-      const dataDigits = digits.slice(0, 6).split("").map(Number);
-      if (dataDigits.length < 6) return { valid: true };
-      return { valid: true, checkDigit: calculateUPCACheckDigit(dataDigits) };
+      const digits = text.replace(/\D/g, "")
+      const dataDigits = digits.slice(0, 6).split("").map(Number)
+      if (dataDigits.length < 6) return { valid: true }
+      return { valid: true, checkDigit: calculateUPCACheckDigit(dataDigits) }
     }
 
     case "identcode": {
-      const digits = text.replace(/\D/g, "").slice(0, 11);
-      return { valid: true, checkDigit: dpCheckDigit(digits) };
+      const digits = text.replace(/\D/g, "").slice(0, 11)
+      return { valid: true, checkDigit: dpCheckDigit(digits) }
     }
 
     case "leitcode": {
-      const digits = text.replace(/\D/g, "").slice(0, 13);
-      return { valid: true, checkDigit: dpCheckDigit(digits) };
+      const digits = text.replace(/\D/g, "").slice(0, 13)
+      return { valid: true, checkDigit: dpCheckDigit(digits) }
     }
 
     case "postnet":
     case "planet": {
-      const digits = text.replace(/[\s-]/g, "");
-      return { valid: true, checkDigit: postnetCheckDigit(digits) };
+      const digits = text.replace(/[\s-]/g, "")
+      return { valid: true, checkDigit: postnetCheckDigit(digits) }
     }
 
     default:
-      return { valid: true };
+      return { valid: true }
   }
 }

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -8,7 +8,7 @@ export {
   calculateEANCheckDigit,
   verifyEANCheckDigit,
   validateBarcodeInput,
-} from "./barcode";
+} from "./barcode"
 
-export { validateQRInput } from "./qr";
-export type { QRValidationResult } from "./qr";
+export { validateQRInput } from "./qr"
+export type { QRValidationResult } from "./qr"

--- a/src/validators/qr.ts
+++ b/src/validators/qr.ts
@@ -2,9 +2,9 @@
  * QR Code input validation
  */
 
-import type { ErrorCorrectionLevel } from "../encoders/qr/types";
-import { selectVersion } from "../encoders/qr/version";
-import { detectMode } from "../encoders/qr/mode";
+import type { ErrorCorrectionLevel } from "../encoders/qr/types"
+import { selectVersion } from "../encoders/qr/version"
+import { detectMode } from "../encoders/qr/mode"
 
 /** Maximum data capacity by EC level and mode (version 40) */
 const MAX_CAPACITY: Record<ErrorCorrectionLevel, Record<string, number>> = {
@@ -12,19 +12,19 @@ const MAX_CAPACITY: Record<ErrorCorrectionLevel, Record<string, number>> = {
   M: { numeric: 5596, alphanumeric: 3391, byte: 2331 },
   Q: { numeric: 3993, alphanumeric: 2420, byte: 1663 },
   H: { numeric: 3057, alphanumeric: 1852, byte: 1273 },
-};
+}
 
 export interface QRValidationResult {
-  valid: boolean;
-  error?: string;
+  valid: boolean
+  error?: string
   /** Minimum QR version needed (1-40), only when valid */
-  version?: number;
+  version?: number
   /** Detected encoding mode */
-  mode?: "numeric" | "alphanumeric" | "byte";
+  mode?: "numeric" | "alphanumeric" | "byte"
   /** Data length in the detected mode's units */
-  dataLength?: number;
+  dataLength?: number
   /** Maximum capacity for the detected mode and EC level */
-  maxCapacity?: number;
+  maxCapacity?: number
 }
 
 /** Validate QR code input */
@@ -33,21 +33,21 @@ export function validateQRInput(
   ecLevel: ErrorCorrectionLevel = "M",
 ): QRValidationResult {
   if (text.length === 0) {
-    return { valid: false, error: "Text cannot be empty" };
+    return { valid: false, error: "Text cannot be empty" }
   }
 
   // Detect mode
-  const mode = detectMode(text) as "numeric" | "alphanumeric" | "byte";
+  const mode = detectMode(text) as "numeric" | "alphanumeric" | "byte"
 
-  const caps = MAX_CAPACITY[ecLevel];
-  const maxCapacity = caps[mode]!;
+  const caps = MAX_CAPACITY[ecLevel]
+  const maxCapacity = caps[mode]!
 
   // Determine data length in the mode's units
-  let dataLength: number;
+  let dataLength: number
   if (mode === "byte") {
-    dataLength = new TextEncoder().encode(text).length;
+    dataLength = new TextEncoder().encode(text).length
   } else {
-    dataLength = text.length;
+    dataLength = text.length
   }
 
   if (dataLength > maxCapacity) {
@@ -57,13 +57,13 @@ export function validateQRInput(
       mode,
       dataLength,
       maxCapacity,
-    };
+    }
   }
 
   // Use selectVersion to find the minimum QR version
-  let version: number;
+  let version: number
   try {
-    version = selectVersion(text, ecLevel);
+    version = selectVersion(text, ecLevel)
   } catch {
     return {
       valid: false,
@@ -71,7 +71,7 @@ export function validateQRInput(
       mode,
       dataLength,
       maxCapacity,
-    };
+    }
   }
 
   return {
@@ -80,5 +80,5 @@ export function validateQRInput(
     mode,
     dataLength,
     maxCapacity,
-  };
+  }
 }

--- a/test/1d-roundtrip.test.ts
+++ b/test/1d-roundtrip.test.ts
@@ -3,8 +3,8 @@
  * Verifies that generated 1D barcodes are actually scannable
  */
 
-import { describe, expect, it } from "vitest";
-import { readBarcodes } from "zxing-wasm/reader";
+import { describe, expect, it } from "vitest"
+import { readBarcodes } from "zxing-wasm/reader"
 import {
   encodeCode128,
   encodeEAN13,
@@ -15,7 +15,7 @@ import {
   encodeITF,
   encodeCodabar,
   encodeGS1128,
-} from "../src/index";
+} from "../src/index"
 
 /**
  * Convert 1D bar widths to ImageData for zxing-wasm decoding.
@@ -27,131 +27,131 @@ function barsToImageData(
   height = 100,
   margin = 40,
 ): { data: Uint8ClampedArray; width: number; height: number } {
-  let totalModules = 0;
-  for (const w of bars) totalModules += w;
-  const imgWidth = totalModules * barWidth + margin * 2;
-  const imgHeight = height + margin * 2;
-  const data = new Uint8ClampedArray(imgWidth * imgHeight * 4);
-  data.fill(255); // white background
+  let totalModules = 0
+  for (const w of bars) totalModules += w
+  const imgWidth = totalModules * barWidth + margin * 2
+  const imgHeight = height + margin * 2
+  const data = new Uint8ClampedArray(imgWidth * imgHeight * 4)
+  data.fill(255) // white background
 
   // Draw bars
-  let x = margin;
-  let isBar = true;
+  let x = margin
+  let isBar = true
   for (const w of bars) {
     if (isBar) {
-      const barEnd = x + w * barWidth;
+      const barEnd = x + w * barWidth
       for (let py = margin; py < margin + height; py++) {
         for (let px = x; px < barEnd && px < imgWidth; px++) {
-          const idx = (py * imgWidth + px) * 4;
-          data[idx] = 0;
-          data[idx + 1] = 0;
-          data[idx + 2] = 0;
-          data[idx + 3] = 255;
+          const idx = (py * imgWidth + px) * 4
+          data[idx] = 0
+          data[idx + 1] = 0
+          data[idx + 2] = 0
+          data[idx + 3] = 255
         }
       }
     }
-    x += w * barWidth;
-    isBar = !isBar;
+    x += w * barWidth
+    isBar = !isBar
   }
 
-  return { data, width: imgWidth, height: imgHeight };
+  return { data, width: imgWidth, height: imgHeight }
 }
 
 /**
  * Decode a 1D barcode bar-width array using zxing-wasm
  */
 async function decode1D(bars: number[]): Promise<string | null> {
-  const img = barsToImageData(bars);
-  const results = await readBarcodes(img as unknown as ImageData, { tryHarder: true });
-  return results.length > 0 ? results[0]!.text : null;
+  const img = barsToImageData(bars)
+  const results = await readBarcodes(img as unknown as ImageData, { tryHarder: true })
+  return results.length > 0 ? results[0]!.text : null
 }
 
 /**
  * Decode EAN/UPC which returns { bars, guards }
  */
 async function decodeEAN(result: { bars: number[]; guards: number[] }): Promise<string | null> {
-  return decode1D(result.bars);
+  return decode1D(result.bars)
 }
 
 describe("Code 128 round-trip", () => {
   it("decodes uppercase", async () => {
-    expect(await decode1D(encodeCode128("ABC123"))).toBe("ABC123");
-  });
+    expect(await decode1D(encodeCode128("ABC123"))).toBe("ABC123")
+  })
 
   it("decodes lowercase", async () => {
-    expect(await decode1D(encodeCode128("hello"))).toBe("hello");
-  });
+    expect(await decode1D(encodeCode128("hello"))).toBe("hello")
+  })
 
   it("decodes mixed case", async () => {
-    expect(await decode1D(encodeCode128("Hello World"))).toBe("Hello World");
-  });
+    expect(await decode1D(encodeCode128("Hello World"))).toBe("Hello World")
+  })
 
   it("decodes special characters", async () => {
-    expect(await decode1D(encodeCode128("test@example.com"))).toBe("test@example.com");
-  });
+    expect(await decode1D(encodeCode128("test@example.com"))).toBe("test@example.com")
+  })
 
   it("decodes digits-only (Code C)", async () => {
-    expect(await decode1D(encodeCode128("1234567890"))).toBe("1234567890");
-  });
-});
+    expect(await decode1D(encodeCode128("1234567890"))).toBe("1234567890")
+  })
+})
 
 describe("EAN-13 round-trip", () => {
   it("decodes standard EAN-13", async () => {
-    expect(await decodeEAN(encodeEAN13("5901234123457"))).toBe("5901234123457");
-  });
+    expect(await decodeEAN(encodeEAN13("5901234123457"))).toBe("5901234123457")
+  })
 
   it("decodes with auto check digit", async () => {
-    const result = await decodeEAN(encodeEAN13("590123412345"));
-    expect(result).toBe("5901234123457");
-  });
-});
+    const result = await decodeEAN(encodeEAN13("590123412345"))
+    expect(result).toBe("5901234123457")
+  })
+})
 
 describe("EAN-8 round-trip", () => {
   it("decodes standard EAN-8", async () => {
-    expect(await decodeEAN(encodeEAN8("96385074"))).toBe("96385074");
-  });
-});
+    expect(await decodeEAN(encodeEAN8("96385074"))).toBe("96385074")
+  })
+})
 
 describe("UPC-A round-trip", () => {
   it("decodes standard UPC-A", async () => {
-    const result = await decodeEAN(encodeUPCA("012345678905"));
+    const result = await decodeEAN(encodeUPCA("012345678905"))
     // zxing-wasm may decode UPC-A as EAN-13 (with leading 0)
-    expect(result).toMatch(/0?12345678905$/);
-  });
-});
+    expect(result).toMatch(/0?12345678905$/)
+  })
+})
 
 describe("Code 39 round-trip", () => {
   it("decodes uppercase text", async () => {
-    expect(await decode1D(encodeCode39("HELLO"))).toBe("HELLO");
-  });
+    expect(await decode1D(encodeCode39("HELLO"))).toBe("HELLO")
+  })
 
   it("decodes digits", async () => {
-    expect(await decode1D(encodeCode39("12345"))).toBe("12345");
-  });
-});
+    expect(await decode1D(encodeCode39("12345"))).toBe("12345")
+  })
+})
 
 describe("Code 93 round-trip", () => {
   it("decodes text", async () => {
-    expect(await decode1D(encodeCode93("TEST"))).toBe("TEST");
-  });
-});
+    expect(await decode1D(encodeCode93("TEST"))).toBe("TEST")
+  })
+})
 
 describe("ITF round-trip", () => {
   it("decodes even-length digits", async () => {
-    expect(await decode1D(encodeITF("1234567890"))).toBe("1234567890");
-  });
-});
+    expect(await decode1D(encodeITF("1234567890"))).toBe("1234567890")
+  })
+})
 
 describe("Codabar round-trip", () => {
   it("decodes with start/stop", async () => {
-    const result = await decode1D(encodeCodabar("A12345B"));
-    expect(result).toContain("12345");
-  });
-});
+    const result = await decode1D(encodeCodabar("A12345B"))
+    expect(result).toContain("12345")
+  })
+})
 
 describe("GS1-128 round-trip", () => {
   it("decodes AI format", async () => {
-    const result = await decode1D(encodeGS1128("(01)12345678901231"));
-    expect(result).toContain("12345678901231");
-  });
-});
+    const result = await decode1D(encodeGS1128("(01)12345678901231"))
+    expect(result).toContain("12345678901231")
+  })
+})

--- a/test/2d-encoders.test.ts
+++ b/test/2d-encoders.test.ts
@@ -1,100 +1,100 @@
-import { describe, expect, it } from "vitest";
-import { encodeDataMatrix } from "../src/encoders/datamatrix/index";
-import { encodePDF417 } from "../src/encoders/pdf417/index";
-import { encodeAztec } from "../src/encoders/aztec/index";
-import { datamatrix, pdf417, aztec } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { encodeDataMatrix } from "../src/encoders/datamatrix/index"
+import { encodePDF417 } from "../src/encoders/pdf417/index"
+import { encodeAztec } from "../src/encoders/aztec/index"
+import { datamatrix, pdf417, aztec } from "../src/index"
 
 describe("Data Matrix encoder", () => {
   it("encodes short text", () => {
-    const matrix = encodeDataMatrix("Hello");
-    expect(matrix.length).toBeGreaterThan(0);
-    expect(matrix[0]!.length).toBeGreaterThan(0);
-  });
+    const matrix = encodeDataMatrix("Hello")
+    expect(matrix.length).toBeGreaterThan(0)
+    expect(matrix[0]!.length).toBeGreaterThan(0)
+  })
 
   it("produces square or rectangular matrix", () => {
-    const matrix = encodeDataMatrix("Test");
-    expect(matrix.length).toBeGreaterThan(0);
+    const matrix = encodeDataMatrix("Test")
+    expect(matrix.length).toBeGreaterThan(0)
     // Data Matrix can be square or rectangular
-    expect(matrix[0]!.length).toBeGreaterThan(0);
-  });
+    expect(matrix[0]!.length).toBeGreaterThan(0)
+  })
 
   it("matrix contains only boolean values", () => {
-    const matrix = encodeDataMatrix("Data");
+    const matrix = encodeDataMatrix("Data")
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("larger data produces larger matrix", () => {
-    const small = encodeDataMatrix("Hi");
-    const large = encodeDataMatrix("This is a longer text");
-    expect(large.length * large[0]!.length).toBeGreaterThan(small.length * small[0]!.length);
-  });
+    const small = encodeDataMatrix("Hi")
+    const large = encodeDataMatrix("This is a longer text")
+    expect(large.length * large[0]!.length).toBeGreaterThan(small.length * small[0]!.length)
+  })
 
   it("renders to SVG via convenience function", () => {
-    const svg = datamatrix("Hello");
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-  });
-});
+    const svg = datamatrix("Hello")
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+  })
+})
 
 describe("PDF417 encoder", () => {
   it("encodes short text", () => {
-    const result = encodePDF417("Hello");
-    expect(result.matrix.length).toBeGreaterThan(0);
-    expect(result.rows).toBeGreaterThan(0);
-    expect(result.cols).toBeGreaterThan(0);
-  });
+    const result = encodePDF417("Hello")
+    expect(result.matrix.length).toBeGreaterThan(0)
+    expect(result.rows).toBeGreaterThan(0)
+    expect(result.cols).toBeGreaterThan(0)
+  })
 
   it("matrix contains only boolean values", () => {
-    const result = encodePDF417("Test");
+    const result = encodePDF417("Test")
     for (const row of result.matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("renders to SVG via convenience function", () => {
-    const svg = pdf417("Hello World");
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-  });
-});
+    const svg = pdf417("Hello World")
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+  })
+})
 
 describe("Aztec encoder", () => {
   it("encodes short text", () => {
-    const matrix = encodeAztec("Hello");
-    expect(matrix.length).toBeGreaterThan(0);
-    expect(matrix[0]!.length).toBe(matrix.length); // Should be square
-  });
+    const matrix = encodeAztec("Hello")
+    expect(matrix.length).toBeGreaterThan(0)
+    expect(matrix[0]!.length).toBe(matrix.length) // Should be square
+  })
 
   it("produces square matrix", () => {
-    const matrix = encodeAztec("Test data");
-    expect(matrix.length).toBe(matrix[0]!.length);
-  });
+    const matrix = encodeAztec("Test data")
+    expect(matrix.length).toBe(matrix[0]!.length)
+  })
 
   it("matrix contains only boolean values", () => {
-    const matrix = encodeAztec("Data");
+    const matrix = encodeAztec("Data")
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("has bullseye pattern at center", () => {
-    const matrix = encodeAztec("Test");
-    const center = Math.floor(matrix.length / 2);
+    const matrix = encodeAztec("Test")
+    const center = Math.floor(matrix.length / 2)
     // Center module should be dark (bullseye center)
-    expect(matrix[center]![center]).toBe(true);
-  });
+    expect(matrix[center]![center]).toBe(true)
+  })
 
   it("renders to SVG via convenience function", () => {
-    const svg = aztec("Hello World");
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-  });
-});
+    const svg = aztec("Hello World")
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+  })
+})

--- a/test/2d-roundtrip.test.ts
+++ b/test/2d-roundtrip.test.ts
@@ -3,9 +3,9 @@
  * Verifies that generated 2D barcodes are actually scannable
  */
 
-import { describe, expect, it } from "vitest";
-import { readBarcodes } from "zxing-wasm/reader";
-import { encodeQR, encodeMicroQR, encodeDataMatrix, encodePDF417, encodeAztec } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { readBarcodes } from "zxing-wasm/reader"
+import { encodeQR, encodeMicroQR, encodeDataMatrix, encodePDF417, encodeAztec } from "../src/index"
 
 /**
  * Convert a boolean matrix to a grayscale PNG-like ImageData buffer
@@ -16,135 +16,135 @@ function matrixToImageData(
   scale = 6,
   margin = 6,
 ): { data: Uint8ClampedArray; width: number; height: number } {
-  const rows = matrix.length;
-  const cols = matrix[0]?.length ?? 0;
-  const width = (cols + margin * 2) * scale;
-  const height = (rows + margin * 2) * scale;
-  const data = new Uint8ClampedArray(width * height * 4);
+  const rows = matrix.length
+  const cols = matrix[0]?.length ?? 0
+  const width = (cols + margin * 2) * scale
+  const height = (rows + margin * 2) * scale
+  const data = new Uint8ClampedArray(width * height * 4)
 
   // White background
-  data.fill(255);
+  data.fill(255)
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const mr = Math.floor(y / scale) - margin;
-      const mc = Math.floor(x / scale) - margin;
+      const mr = Math.floor(y / scale) - margin
+      const mc = Math.floor(x / scale) - margin
       if (mr >= 0 && mr < rows && mc >= 0 && mc < cols && matrix[mr]![mc]) {
-        const idx = (y * width + x) * 4;
-        data[idx] = 0;
-        data[idx + 1] = 0;
-        data[idx + 2] = 0;
-        data[idx + 3] = 255;
+        const idx = (y * width + x) * 4
+        data[idx] = 0
+        data[idx + 1] = 0
+        data[idx + 2] = 0
+        data[idx + 3] = 255
       }
     }
   }
 
-  return { data, width, height };
+  return { data, width, height }
 }
 
 /**
  * Decode a boolean matrix using zxing-wasm
  */
 async function decodeMatrix(matrix: boolean[][]): Promise<string | null> {
-  const { data, width, height } = matrixToImageData(matrix);
-  const imageData = { data, width, height };
-  const results = await readBarcodes(imageData as ImageData, { tryHarder: true });
-  return results.length > 0 ? results[0]!.text : null;
+  const { data, width, height } = matrixToImageData(matrix)
+  const imageData = { data, width, height }
+  const results = await readBarcodes(imageData as ImageData, { tryHarder: true })
+  return results.length > 0 ? results[0]!.text : null
 }
 
 describe("QR Code round-trip (zxing-wasm)", () => {
   it("decodes simple text", async () => {
-    expect(await decodeMatrix(encodeQR("Hello World"))).toBe("Hello World");
-  });
+    expect(await decodeMatrix(encodeQR("Hello World"))).toBe("Hello World")
+  })
 
   it("decodes URL", async () => {
-    expect(await decodeMatrix(encodeQR("https://example.com"))).toBe("https://example.com");
-  });
+    expect(await decodeMatrix(encodeQR("https://example.com"))).toBe("https://example.com")
+  })
 
   it("decodes with EC level H", async () => {
-    expect(await decodeMatrix(encodeQR("EC-H TEST", { ecLevel: "H" }))).toBe("EC-H TEST");
-  });
+    expect(await decodeMatrix(encodeQR("EC-H TEST", { ecLevel: "H" }))).toBe("EC-H TEST")
+  })
 
   it("decodes version 1", async () => {
-    expect(await decodeMatrix(encodeQR("V1", { version: 1 }))).toBe("V1");
-  });
+    expect(await decodeMatrix(encodeQR("V1", { version: 1 }))).toBe("V1")
+  })
 
   it("decodes version 10", async () => {
-    const text = "VERSION 10 WITH ENOUGH DATA";
-    expect(await decodeMatrix(encodeQR(text, { version: 10 }))).toBe(text);
-  });
+    const text = "VERSION 10 WITH ENOUGH DATA"
+    expect(await decodeMatrix(encodeQR(text, { version: 10 }))).toBe(text)
+  })
 
   it("decodes version 40", async () => {
-    const text = "V40 " + "X".repeat(80);
-    expect(await decodeMatrix(encodeQR(text, { version: 40 }))).toBe(text);
-  });
+    const text = "V40 " + "X".repeat(80)
+    expect(await decodeMatrix(encodeQR(text, { version: 40 }))).toBe(text)
+  })
 
   it("decodes all 8 mask patterns", async () => {
     for (let mask = 0; mask < 8; mask++) {
       const result = await decodeMatrix(
         encodeQR("MASK" + mask, { mask: mask as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 }),
-      );
-      expect(result).toBe("MASK" + mask);
+      )
+      expect(result).toBe("MASK" + mask)
     }
-  });
-});
+  })
+})
 
 describe("Micro QR round-trip (zxing-wasm)", () => {
   it("decodes numeric data", async () => {
-    expect(await decodeMatrix(encodeMicroQR("12345"))).toBe("12345");
-  });
+    expect(await decodeMatrix(encodeMicroQR("12345"))).toBe("12345")
+  })
 
   it("decodes short numeric", async () => {
-    expect(await decodeMatrix(encodeMicroQR("0"))).toBe("0");
-  });
-});
+    expect(await decodeMatrix(encodeMicroQR("0"))).toBe("0")
+  })
+})
 
 describe("Data Matrix round-trip (zxing-wasm)", () => {
   it("decodes simple text", async () => {
-    expect(await decodeMatrix(encodeDataMatrix("Hello World"))).toBe("Hello World");
-  });
+    expect(await decodeMatrix(encodeDataMatrix("Hello World"))).toBe("Hello World")
+  })
 
   it("decodes numeric data", async () => {
-    expect(await decodeMatrix(encodeDataMatrix("1234567890"))).toBe("1234567890");
-  });
+    expect(await decodeMatrix(encodeDataMatrix("1234567890"))).toBe("1234567890")
+  })
 
   it("decodes URL", async () => {
-    expect(await decodeMatrix(encodeDataMatrix("https://example.com"))).toBe("https://example.com");
-  });
+    expect(await decodeMatrix(encodeDataMatrix("https://example.com"))).toBe("https://example.com")
+  })
 
   it("decodes special characters", async () => {
-    expect(await decodeMatrix(encodeDataMatrix("test@example.com"))).toBe("test@example.com");
-  });
-});
+    expect(await decodeMatrix(encodeDataMatrix("test@example.com"))).toBe("test@example.com")
+  })
+})
 
 describe("PDF417 round-trip (zxing-wasm)", () => {
   it("decodes simple text", async () => {
-    const matrix = encodePDF417("Hello World");
-    expect(await decodeMatrix(matrix.matrix)).toBe("Hello World");
-  });
+    const matrix = encodePDF417("Hello World")
+    expect(await decodeMatrix(matrix.matrix)).toBe("Hello World")
+  })
 
   it("decodes numeric data", async () => {
-    const matrix = encodePDF417("1234567890");
-    expect(await decodeMatrix(matrix.matrix)).toBe("1234567890");
-  });
+    const matrix = encodePDF417("1234567890")
+    expect(await decodeMatrix(matrix.matrix)).toBe("1234567890")
+  })
 
   it("decodes longer text", async () => {
-    const text = "The quick brown fox jumps over the lazy dog";
-    const matrix = encodePDF417(text);
-    expect(await decodeMatrix(matrix.matrix)).toBe(text);
-  });
-});
+    const text = "The quick brown fox jumps over the lazy dog"
+    const matrix = encodePDF417(text)
+    expect(await decodeMatrix(matrix.matrix)).toBe(text)
+  })
+})
 
 describe("Aztec round-trip (zxing-wasm)", () => {
   it("decodes simple text", async () => {
-    expect(await decodeMatrix(encodeAztec("Hello World"))).toBe("Hello World");
-  });
+    expect(await decodeMatrix(encodeAztec("Hello World"))).toBe("Hello World")
+  })
 
   it("decodes numeric data", async () => {
-    expect(await decodeMatrix(encodeAztec("1234567890"))).toBe("1234567890");
-  });
+    expect(await decodeMatrix(encodeAztec("1234567890"))).toBe("1234567890")
+  })
 
   it("decodes URL", async () => {
-    expect(await decodeMatrix(encodeAztec("https://example.com"))).toBe("https://example.com");
-  });
-});
+    expect(await decodeMatrix(encodeAztec("https://example.com"))).toBe("https://example.com")
+  })
+})

--- a/test/api-2d-formats.test.ts
+++ b/test/api-2d-formats.test.ts
@@ -5,7 +5,7 @@
  * reach the encoder, and that encoder options never leak into SVG output.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   microqr,
   rmqr,
@@ -19,7 +19,7 @@ import {
   datamatrix,
   pdf417,
   aztec,
-} from "../src/_2d";
+} from "../src/_2d"
 import {
   microqrPNG,
   microqrPNGDataURI,
@@ -37,22 +37,22 @@ import {
   code16kPNGDataURI,
   maxicodePNG,
   maxicodePNGDataURI,
-} from "../src/_png";
-import { renderColorMatrixSVG } from "../src/renderers/svg/color-matrix";
-import { renderMatrixSVG } from "../src/renderers/svg/matrix";
-import { encodeJABCode } from "../src/encoders/jabcode";
-import { encodeMaxiCode } from "../src/encoders/maxicode";
-import { renderMaxiCodeRaster } from "../src/renderers/png/rasterize";
+} from "../src/_png"
+import { renderColorMatrixSVG } from "../src/renderers/svg/color-matrix"
+import { renderMatrixSVG } from "../src/renderers/svg/matrix"
+import { encodeJABCode } from "../src/encoders/jabcode"
+import { encodeMaxiCode } from "../src/encoders/maxicode"
+import { renderMaxiCodeRaster } from "../src/renderers/png/rasterize"
 
-const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10]
 
 function isPNG(data: Uint8Array): boolean {
-  return PNG_SIGNATURE.every((b, i) => data[i] === b);
+  return PNG_SIGNATURE.every((b, i) => data[i] === b)
 }
 
 /** Count the module rects in a matrix SVG path. */
 function countModules(svg: string): number {
-  return (svg.match(/M[\d.-]+,[\d.-]+h/g) ?? []).length;
+  return (svg.match(/M[\d.-]+,[\d.-]+h/g) ?? []).length
 }
 
 describe("2D format SVG API", () => {
@@ -69,201 +69,201 @@ describe("2D format SVG API", () => {
     ["datamatrix", () => datamatrix("DM")],
     ["pdf417", () => pdf417("PDF")],
     ["aztec", () => aztec("AZTEC")],
-  ];
+  ]
 
   for (const [name, render] of cases) {
     it(`${name} produces a well-formed SVG`, () => {
-      const svg = render();
-      expect(svg.startsWith("<svg"), name).toBe(true);
-      expect(svg.endsWith("</svg>"), name).toBe(true);
-      expect(svg, name).toContain('xmlns="http://www.w3.org/2000/svg"');
-      expect(svg, name).toContain("viewBox=");
+      const svg = render()
+      expect(svg.startsWith("<svg"), name).toBe(true)
+      expect(svg.endsWith("</svg>"), name).toBe(true)
+      expect(svg, name).toContain('xmlns="http://www.w3.org/2000/svg"')
+      expect(svg, name).toContain("viewBox=")
       // Every symbol must actually draw something
-      expect(svg.includes("<path") || svg.includes("<circle"), name).toBe(true);
-    });
+      expect(svg.includes("<path") || svg.includes("<circle"), name).toBe(true)
+    })
 
     it(`${name} does not leak encoder options into the SVG`, () => {
-      const svg = render();
-      expect(svg, name).not.toContain("undefined");
-      expect(svg, name).not.toContain("[object Object]");
-      expect(svg, name).not.toContain("NaN");
-    });
+      const svg = render()
+      expect(svg, name).not.toContain("undefined")
+      expect(svg, name).not.toContain("[object Object]")
+      expect(svg, name).not.toContain("NaN")
+    })
   }
-});
+})
 
 describe("microqr()", () => {
   it("honours the version option", () => {
     // M1 is 11x11, M4 is 17x17 — bigger version means a bigger symbol
-    const m1 = microqr("1", { version: 1, size: 110, margin: 0 });
-    const m4 = microqr("1", { version: 4, size: 170, margin: 0 });
-    expect(m1).toContain('viewBox="0 0 110 110"');
-    expect(m4).toContain('viewBox="0 0 170 170"');
-  });
+    const m1 = microqr("1", { version: 1, size: 110, margin: 0 })
+    const m4 = microqr("1", { version: 4, size: 170, margin: 0 })
+    expect(m1).toContain('viewBox="0 0 110 110"')
+    expect(m4).toContain('viewBox="0 0 170 170"')
+  })
 
   it("honours the mask option", () => {
-    expect(microqr("12345", { mask: 0 })).not.toBe(microqr("12345", { mask: 3 }));
-  });
+    expect(microqr("12345", { mask: 0 })).not.toBe(microqr("12345", { mask: 3 }))
+  })
 
   it("applies styling options", () => {
-    const svg = microqr("12345", { color: "#123456", background: "#abcdef" });
-    expect(svg).toContain('fill="#123456"');
-    expect(svg).toContain('fill="#abcdef"');
-  });
-});
+    const svg = microqr("12345", { color: "#123456", background: "#abcdef" })
+    expect(svg).toContain('fill="#123456"')
+    expect(svg).toContain('fill="#abcdef"')
+  })
+})
 
 describe("rmqr()", () => {
   it("produces a rectangular symbol", () => {
-    const svg = rmqr("HELLO", { margin: 0 });
-    const m = /viewBox="0 0 ([\d.]+) ([\d.]+)"/.exec(svg)!;
-    expect(Number(m[1])).toBeGreaterThan(Number(m[2]));
-  });
+    const svg = rmqr("HELLO", { margin: 0 })
+    const m = /viewBox="0 0 ([\d.]+) ([\d.]+)"/.exec(svg)!
+    expect(Number(m[1])).toBeGreaterThan(Number(m[2]))
+  })
 
   it("honours the ecLevel option", () => {
-    expect(rmqr("HELLO", { ecLevel: "M" })).not.toBe(rmqr("HELLO", { ecLevel: "H" }));
-  });
-});
+    expect(rmqr("HELLO", { ecLevel: "M" })).not.toBe(rmqr("HELLO", { ecLevel: "H" }))
+  })
+})
 
 describe("maxicode()", () => {
   it("renders hexagonal modules as circles", () => {
-    const svg = maxicode("TEST");
-    expect(svg).toContain("<circle");
-    expect(svg).not.toContain("<path");
-  });
+    const svg = maxicode("TEST")
+    expect(svg).toContain("<circle")
+    expect(svg).not.toContain("<path")
+  })
 
   it("honours structured carrier message options", () => {
-    const mode2 = maxicode("TEST", { mode: 2, postalCode: "123456789", countryCode: 840 });
-    const mode4 = maxicode("TEST", { mode: 4 });
-    expect(mode2).not.toBe(mode4);
-  });
+    const mode2 = maxicode("TEST", { mode: 2, postalCode: "123456789", countryCode: 840 })
+    const mode4 = maxicode("TEST", { mode: 4 })
+    expect(mode2).not.toBe(mode4)
+  })
 
   it("applies the margin option to the quiet zone", () => {
-    const tight = maxicode("TEST", { margin: 1 });
-    const loose = maxicode("TEST", { margin: 4 });
-    const dim = (svg: string): number => Number(/width="([\d.]+)"/.exec(svg)![1]);
-    expect(dim(loose)).toBeGreaterThan(dim(tight));
-  });
-});
+    const tight = maxicode("TEST", { margin: 1 })
+    const loose = maxicode("TEST", { margin: 4 })
+    const dim = (svg: string): number => Number(/width="([\d.]+)"/.exec(svg)![1])
+    expect(dim(loose)).toBeGreaterThan(dim(tight))
+  })
+})
 
 describe("hanxin()", () => {
   it("honours the ecLevel option", () => {
-    expect(hanxin("HANXIN", { ecLevel: 1 })).not.toBe(hanxin("HANXIN", { ecLevel: 4 }));
-  });
+    expect(hanxin("HANXIN", { ecLevel: 1 })).not.toBe(hanxin("HANXIN", { ecLevel: 4 }))
+  })
 
   it("honours the version option", () => {
     // Version n is (2n + 21) modules square
-    expect(hanxin("HX", { version: 1, size: 230, margin: 0 })).toContain('viewBox="0 0 230 230"');
-    expect(hanxin("HX", { version: 5, margin: 0, size: 310 })).toContain('viewBox="0 0 310 310"');
-  });
+    expect(hanxin("HX", { version: 1, size: 230, margin: 0 })).toContain('viewBox="0 0 230 230"')
+    expect(hanxin("HX", { version: 5, margin: 0, size: 310 })).toContain('viewBox="0 0 310 310"')
+  })
 
   it("scales with the size option", () => {
-    expect(hanxin("HX", { size: 300, margin: 0 })).toContain('viewBox="0 0 300 300"');
-  });
+    expect(hanxin("HX", { size: 300, margin: 0 })).toContain('viewBox="0 0 300 300"')
+  })
 
   it("rejects an out-of-range ecLevel with a clear error", () => {
-    expect(() => hanxin("HX", { ecLevel: 9 as 1 })).toThrow(/EC level must be 1, 2, 3 or 4/);
-  });
+    expect(() => hanxin("HX", { ecLevel: 9 as 1 })).toThrow(/EC level must be 1, 2, 3 or 4/)
+  })
 
   it("rejects an out-of-range version with a clear error", () => {
-    expect(() => hanxin("HX", { version: 0 })).toThrow(/version must be an integer 1-84/);
-    expect(() => hanxin("HX", { version: 85 })).toThrow(/version must be an integer 1-84/);
-  });
-});
+    expect(() => hanxin("HX", { version: 0 })).toThrow(/version must be an integer 1-84/)
+    expect(() => hanxin("HX", { version: 85 })).toThrow(/version must be an integer 1-84/)
+  })
+})
 
 describe("stacked symbologies", () => {
   it("micropdf417 uses taller rows than wide modules", () => {
-    const svg = micropdf417("MICRO", { margin: 0 });
-    const m = /M[\d.-]+,[\d.-]+h([\d.]+)v([\d.]+)h/.exec(svg)!;
-    expect(Number(m[2])).toBeGreaterThan(Number(m[1]));
-  });
+    const svg = micropdf417("MICRO", { margin: 0 })
+    const m = /M[\d.-]+,[\d.-]+h([\d.]+)v([\d.]+)h/.exec(svg)!
+    expect(Number(m[2])).toBeGreaterThan(Number(m[1]))
+  })
 
   it("codablockf uses taller rows than wide modules", () => {
-    const svg = codablockf("CODABLOCK", { margin: 0 });
-    const m = /M[\d.-]+,[\d.-]+h([\d.]+)v([\d.]+)h/.exec(svg)!;
-    expect(Number(m[2])).toBeGreaterThan(Number(m[1]));
-  });
+    const svg = codablockf("CODABLOCK", { margin: 0 })
+    const m = /M[\d.-]+,[\d.-]+h([\d.]+)v([\d.]+)h/.exec(svg)!
+    expect(Number(m[2])).toBeGreaterThan(Number(m[1]))
+  })
 
   it("code16k uses taller rows than wide modules", () => {
-    const svg = code16k("CODE16K", { margin: 0 });
-    const m = /M[\d.-]+,[\d.-]+h([\d.]+)v([\d.]+)h/.exec(svg)!;
-    expect(Number(m[2])).toBeGreaterThan(Number(m[1]));
-  });
+    const svg = code16k("CODE16K", { margin: 0 })
+    const m = /M[\d.-]+,[\d.-]+h([\d.]+)v([\d.]+)h/.exec(svg)!
+    expect(Number(m[2])).toBeGreaterThan(Number(m[1]))
+  })
 
   it("allows rowHeight to be overridden", () => {
-    const svg = code16k("CODE16K", { margin: 0, rowHeight: 1 });
-    const m = /M[\d.-]+,[\d.-]+h([\d.]+)v([\d.]+)h/.exec(svg)!;
-    expect(Number(m[2])).toBeCloseTo(Number(m[1]), 5);
-  });
+    const svg = code16k("CODE16K", { margin: 0, rowHeight: 1 })
+    const m = /M[\d.-]+,[\d.-]+h([\d.]+)v([\d.]+)h/.exec(svg)!
+    expect(Number(m[2])).toBeCloseTo(Number(m[1]), 5)
+  })
 
   it("micropdf417 honours the columns option", () => {
-    expect(micropdf417("MICRO", { columns: 1 })).not.toBe(micropdf417("MICRO", { columns: 4 }));
-  });
+    expect(micropdf417("MICRO", { columns: 1 })).not.toBe(micropdf417("MICRO", { columns: 4 }))
+  })
 
   it("codablockf honours the columns option", () => {
     expect(codablockf("CODABLOCKF TEST", { columns: 8 })).not.toBe(
       codablockf("CODABLOCKF TEST", { columns: 16 }),
-    );
-  });
-});
+    )
+  })
+})
 
 describe("renderMatrixSVG rowHeight", () => {
   const matrix = [
     [true, false],
     [false, true],
-  ];
+  ]
 
   it("defaults to square modules", () => {
-    const svg = renderMatrixSVG(matrix, { size: 100, margin: 0 });
-    expect(svg).toContain('viewBox="0 0 100 100"');
-  });
+    const svg = renderMatrixSVG(matrix, { size: 100, margin: 0 })
+    expect(svg).toContain('viewBox="0 0 100 100"')
+  })
 
   it("stretches rows vertically", () => {
-    const svg = renderMatrixSVG(matrix, { size: 100, margin: 0, rowHeight: 3 });
-    expect(svg).toContain('viewBox="0 0 100 300"');
-  });
+    const svg = renderMatrixSVG(matrix, { size: 100, margin: 0, rowHeight: 3 })
+    expect(svg).toContain('viewBox="0 0 100 300"')
+  })
 
   it("keeps the quiet zone square while stretching rows", () => {
-    const svg = renderMatrixSVG(matrix, { size: 100, margin: 1, rowHeight: 2 });
+    const svg = renderMatrixSVG(matrix, { size: 100, margin: 1, rowHeight: 2 })
     // 4 total module columns → moduleSize 25; height = 2 rows * 50 + 2 * 25
-    expect(svg).toContain('viewBox="0 0 100 150"');
-  });
-});
+    expect(svg).toContain('viewBox="0 0 100 150"')
+  })
+})
 
 describe("jabcode() and renderColorMatrixSVG", () => {
   it("renders one path per distinct palette entry used", () => {
-    const result = encodeJABCode("JAB", { colors: 4 });
-    const used = new Set(result.matrix.flat());
-    const svg = renderColorMatrixSVG(result.matrix, result.palette);
-    expect((svg.match(/<path /g) ?? []).length).toBe(used.size);
-  });
+    const result = encodeJABCode("JAB", { colors: 4 })
+    const used = new Set(result.matrix.flat())
+    const svg = renderColorMatrixSVG(result.matrix, result.palette)
+    expect((svg.match(/<path /g) ?? []).length).toBe(used.size)
+  })
 
   it("uses colors from the encoder palette", () => {
-    const result = encodeJABCode("JAB", { colors: 4 });
-    const svg = renderColorMatrixSVG(result.matrix, result.palette);
+    const result = encodeJABCode("JAB", { colors: 4 })
+    const svg = renderColorMatrixSVG(result.matrix, result.palette)
     for (const color of new Set(result.matrix.flat()).values()) {
-      expect(svg).toContain(`fill="${result.palette[color]}"`);
+      expect(svg).toContain(`fill="${result.palette[color]}"`)
     }
-  });
+  })
 
   it("accepts a palette override", () => {
-    const result = encodeJABCode("JAB", { colors: 4 });
+    const result = encodeJABCode("JAB", { colors: 4 })
     const svg = renderColorMatrixSVG(result.matrix, result.palette, {
       palette: ["#111111", "#222222", "#333333", "#444444"],
-    });
-    expect(svg).toContain('fill="#111111"');
-    expect(svg).not.toContain(`fill="${result.palette[1]}"`);
-  });
+    })
+    expect(svg).toContain('fill="#111111"')
+    expect(svg).not.toContain(`fill="${result.palette[1]}"`)
+  })
 
   it("supports 8-color mode", () => {
-    const four = jabcode("JABCODE TEST", { colors: 4 });
-    const eight = jabcode("JABCODE TEST", { colors: 8 });
-    expect(four).not.toBe(eight);
-  });
+    const four = jabcode("JABCODE TEST", { colors: 4 })
+    const eight = jabcode("JABCODE TEST", { colors: 8 })
+    expect(four).not.toBe(eight)
+  })
 
   it("falls back to black for out-of-range palette indices", () => {
-    const svg = renderColorMatrixSVG([[0, 5]], ["#ff0000"]);
-    expect(svg).toContain('fill="#ff0000"');
-    expect(svg).toContain('fill="#000"');
-  });
+    const svg = renderColorMatrixSVG([[0, 5]], ["#ff0000"])
+    expect(svg).toContain('fill="#ff0000"')
+    expect(svg).toContain('fill="#000"')
+  })
 
   it("supports transparent background and accessibility metadata", () => {
     const svg = renderColorMatrixSVG([[0, 1]], ["#000", "#fff"], {
@@ -271,18 +271,18 @@ describe("jabcode() and renderColorMatrixSVG", () => {
       title: "JAB",
       desc: "Color code",
       ariaLabel: "jab code",
-    });
-    expect(svg).not.toContain("<rect");
-    expect(svg).toContain("<title>JAB</title>");
-    expect(svg).toContain("<desc>Color code</desc>");
-    expect(svg).toContain('aria-label="jab code"');
-  });
+    })
+    expect(svg).not.toContain("<rect")
+    expect(svg).toContain("<title>JAB</title>")
+    expect(svg).toContain("<desc>Color code</desc>")
+    expect(svg).toContain('aria-label="jab code"')
+  })
 
   it("handles an empty matrix", () => {
-    const svg = renderColorMatrixSVG([], []);
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = renderColorMatrixSVG([], [])
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("2D format PNG API", () => {
   const cases: Array<[string, () => Uint8Array, () => string]> = [
@@ -293,121 +293,121 @@ describe("2D format PNG API", () => {
     ["micropdf417", () => micropdf417PNG("MICRO"), () => micropdf417PNGDataURI("MICRO")],
     ["codablockf", () => codablockfPNG("CODABLOCK"), () => codablockfPNGDataURI("CODABLOCK")],
     ["code16k", () => code16kPNG("CODE16K"), () => code16kPNGDataURI("CODE16K")],
-  ];
+  ]
 
   for (const [name, png, dataUri] of cases) {
     it(`${name}PNG emits a valid PNG`, () => {
-      const data = png();
-      expect(isPNG(data), name).toBe(true);
-      expect(data.length, name).toBeGreaterThan(50);
-    });
+      const data = png()
+      expect(isPNG(data), name).toBe(true)
+      expect(data.length, name).toBeGreaterThan(50)
+    })
 
     it(`${name}PNGDataURI emits a PNG data URI`, () => {
-      expect(dataUri(), name).toMatch(/^data:image\/png;base64,/);
-    });
+      expect(dataUri(), name).toMatch(/^data:image\/png;base64,/)
+    })
   }
 
   it("passes encoder options through to PNG output", () => {
-    expect(microqrPNG("12345", { mask: 0 })).not.toEqual(microqrPNG("12345", { mask: 3 }));
+    expect(microqrPNG("12345", { mask: 0 })).not.toEqual(microqrPNG("12345", { mask: 3 }))
     expect(micropdf417PNG("MICRO", { columns: 1 })).not.toEqual(
       micropdf417PNG("MICRO", { columns: 4 }),
-    );
-  });
+    )
+  })
 
   it("applies PNG rendering options", () => {
-    const small = microqrPNG("12345", { moduleSize: 2, margin: 0 });
-    const large = microqrPNG("12345", { moduleSize: 12, margin: 0 });
-    expect(large.length).toBeGreaterThan(small.length);
-  });
-});
+    const small = microqrPNG("12345", { moduleSize: 2, margin: 0 })
+    const large = microqrPNG("12345", { moduleSize: 12, margin: 0 })
+    expect(large.length).toBeGreaterThan(small.length)
+  })
+})
 
 describe("MaxiCode PNG (hexagonal rasterizer)", () => {
   it("emits a valid PNG", () => {
-    expect(isPNG(maxicodePNG("HELLO"))).toBe(true);
-    expect(maxicodePNGDataURI("HELLO")).toMatch(/^data:image\/png;base64,/);
-  });
+    expect(isPNG(maxicodePNG("HELLO"))).toBe(true)
+    expect(maxicodePNGDataURI("HELLO")).toMatch(/^data:image\/png;base64,/)
+  })
 
   it("sizes the raster from the staggered hex grid", () => {
-    const matrix = encodeMaxiCode("HELLO");
-    const raster = renderMaxiCodeRaster(matrix, { moduleSize: 10, margin: 2 });
+    const matrix = encodeMaxiCode("HELLO")
+    const raster = renderMaxiCodeRaster(matrix, { moduleSize: 10, margin: 2 })
     // 30 columns on a 10px pitch, plus a half-module stagger and 2-module margins
-    expect(raster.width).toBe(Math.round(30 * 10 + 5 + 40));
-    expect(raster.height).toBe(Math.round(33 * 8.66 + 40));
-    expect(raster.rows).toHaveLength(raster.height);
-  });
+    expect(raster.width).toBe(Math.round(30 * 10 + 5 + 40))
+    expect(raster.height).toBe(Math.round(33 * 8.66 + 40))
+    expect(raster.rows).toHaveLength(raster.height)
+  })
 
   it("draws discs rather than squares", () => {
     // A single module: the row through its centre must be wider than the
     // topmost row of the same module, which is only true for a disc.
-    const matrix = Array.from({ length: 33 }, () => Array.from({ length: 30 }, () => false));
-    matrix[10]![10] = true;
-    const raster = renderMaxiCodeRaster(matrix, { moduleSize: 20, margin: 1 });
+    const matrix = Array.from({ length: 33 }, () => Array.from({ length: 30 }, () => false))
+    matrix[10]![10] = true
+    const raster = renderMaxiCodeRaster(matrix, { moduleSize: 20, margin: 1 })
 
-    const filledPerRow = raster.rows.map((row) => row.reduce((n, v) => n + v, 0));
-    const widest = Math.max(...filledPerRow);
-    const nonEmpty = filledPerRow.filter((n) => n > 0);
-    expect(nonEmpty.length).toBeGreaterThan(1);
-    expect(Math.min(...nonEmpty)).toBeLessThan(widest);
-  });
+    const filledPerRow = raster.rows.map((row) => row.reduce((n, v) => n + v, 0))
+    const widest = Math.max(...filledPerRow)
+    const nonEmpty = filledPerRow.filter((n) => n > 0)
+    expect(nonEmpty.length).toBeGreaterThan(1)
+    expect(Math.min(...nonEmpty)).toBeLessThan(widest)
+  })
 
   it("staggers odd rows by half a module", () => {
     const left = (rowIndex: number): number => {
-      const matrix = Array.from({ length: 33 }, () => Array.from({ length: 30 }, () => false));
-      matrix[rowIndex]![0] = true;
-      const raster = renderMaxiCodeRaster(matrix, { moduleSize: 20, margin: 1 });
+      const matrix = Array.from({ length: 33 }, () => Array.from({ length: 30 }, () => false))
+      matrix[rowIndex]![0] = true
+      const raster = renderMaxiCodeRaster(matrix, { moduleSize: 20, margin: 1 })
       for (const row of raster.rows) {
-        const idx = row.indexOf(1);
-        if (idx !== -1) return idx;
+        const idx = row.indexOf(1)
+        if (idx !== -1) return idx
       }
-      return -1;
-    };
+      return -1
+    }
     // Row 1 (odd) sits half a module (10px) right of row 0; allow a pixel of
     // slack, since the two discs are rasterized at different vertical centres.
-    expect(left(1) - left(0)).toBeGreaterThanOrEqual(9);
-    expect(left(1) - left(0)).toBeLessThanOrEqual(11);
-  });
+    expect(left(1) - left(0)).toBeGreaterThanOrEqual(9)
+    expect(left(1) - left(0)).toBeLessThanOrEqual(11)
+  })
 
   it("scales with moduleSize", () => {
-    const small = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 4 });
-    const large = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 12 });
-    expect(large.width).toBeGreaterThan(small.width);
-    expect(large.height).toBeGreaterThan(small.height);
-  });
+    const small = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 4 })
+    const large = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 12 })
+    expect(large.width).toBeGreaterThan(small.width)
+    expect(large.height).toBeGreaterThan(small.height)
+  })
 
   it("applies the margin option", () => {
-    const tight = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 10, margin: 0 });
-    const loose = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 10, margin: 4 });
-    expect(loose.width - tight.width).toBe(80);
-  });
+    const tight = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 10, margin: 0 })
+    const loose = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 10, margin: 4 })
+    expect(loose.width - tight.width).toBe(80)
+  })
 
   it("passes encoder options through", () => {
     expect(maxicodePNG("HELLO", { mode: 4 })).not.toEqual(
       maxicodePNG("HELLO", { mode: 2, postalCode: "123456789", countryCode: 840 }),
-    );
-  });
+    )
+  })
 
   it("leaves the quiet zone blank", () => {
-    const raster = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 10, margin: 2 });
-    expect(raster.rows[0]!.every((v) => v === 0)).toBe(true);
-    expect(raster.rows.at(-1)!.every((v) => v === 0)).toBe(true);
-  });
-});
+    const raster = renderMaxiCodeRaster(encodeMaxiCode("HELLO"), { moduleSize: 10, margin: 2 })
+    expect(raster.rows[0]!.every((v) => v === 0)).toBe(true)
+    expect(raster.rows.at(-1)!.every((v) => v === 0)).toBe(true)
+  })
+})
 
 describe("symbol content sanity", () => {
   it("different data produces different symbols", () => {
-    expect(microqr("AAAA")).not.toBe(microqr("BBBB"));
-    expect(dotcode("AAAA")).not.toBe(dotcode("BBBB"));
-    expect(hanxin("AAAA")).not.toBe(hanxin("BBBB"));
-    expect(code16k("AAAA")).not.toBe(code16k("BBBB"));
-    expect(codablockf("AAAA")).not.toBe(codablockf("BBBB"));
-    expect(micropdf417("AAAA")).not.toBe(micropdf417("BBBB"));
-  });
+    expect(microqr("AAAA")).not.toBe(microqr("BBBB"))
+    expect(dotcode("AAAA")).not.toBe(dotcode("BBBB"))
+    expect(hanxin("AAAA")).not.toBe(hanxin("BBBB"))
+    expect(code16k("AAAA")).not.toBe(code16k("BBBB"))
+    expect(codablockf("AAAA")).not.toBe(codablockf("BBBB"))
+    expect(micropdf417("AAAA")).not.toBe(micropdf417("BBBB"))
+  })
 
   it("draws a plausible number of dark modules", () => {
     // A symbol that is all-light or all-dark indicates a broken encoder
     for (const svg of [microqr("12345"), dotcode("DOT"), hanxin("HX"), code16k("C16K")]) {
-      const dark = countModules(svg);
-      expect(dark).toBeGreaterThan(10);
+      const dark = countModules(svg)
+      expect(dark).toBeGreaterThan(10)
     }
-  });
-});
+  })
+})

--- a/test/api-surface.test.ts
+++ b/test/api-surface.test.ts
@@ -6,15 +6,15 @@
  * documentation from drifting away from the code.
  */
 
-import { describe, expect, it } from "vitest";
-import * as etiket from "../src/index";
-import * as barcodeEntry from "../src/barcode";
-import * as postalEntry from "../src/postal";
-import * as qrEntry from "../src/qr";
-import * as datamatrixEntry from "../src/datamatrix";
-import * as pdf417Entry from "../src/pdf417";
-import * as aztecEntry from "../src/aztec";
-import * as pngEntry from "../src/png";
+import { describe, expect, it } from "vitest"
+import * as etiket from "../src/index"
+import * as barcodeEntry from "../src/barcode"
+import * as postalEntry from "../src/postal"
+import * as qrEntry from "../src/qr"
+import * as datamatrixEntry from "../src/datamatrix"
+import * as pdf417Entry from "../src/pdf417"
+import * as aztecEntry from "../src/aztec"
+import * as pngEntry from "../src/png"
 
 const DOCUMENTED_EXPORTS = [
   // 1D
@@ -128,33 +128,33 @@ const DOCUMENTED_EXPORTS = [
   "InvalidInputError",
   "CapacityError",
   "CheckDigitError",
-] as const;
+] as const
 
 describe("public API surface", () => {
   it("exports every documented name", () => {
-    const registry = etiket as unknown as Record<string, unknown>;
-    const missing = DOCUMENTED_EXPORTS.filter((name) => registry[name] === undefined);
-    expect(missing).toEqual([]);
-  });
+    const registry = etiket as unknown as Record<string, unknown>
+    const missing = DOCUMENTED_EXPORTS.filter((name) => registry[name] === undefined)
+    expect(missing).toEqual([])
+  })
 
   it("exposes every documented name as a function or class", () => {
-    const registry = etiket as unknown as Record<string, unknown>;
+    const registry = etiket as unknown as Record<string, unknown>
     for (const name of DOCUMENTED_EXPORTS) {
-      expect(typeof registry[name], name).toBe("function");
+      expect(typeof registry[name], name).toBe("function")
     }
-  });
+  })
 
   it("every *PNG function has a matching *PNGDataURI variant", () => {
-    const registry = etiket as unknown as Record<string, unknown>;
+    const registry = etiket as unknown as Record<string, unknown>
     const pngFns = Object.keys(registry).filter(
       (name) => name.endsWith("PNG") && !name.startsWith("render") && name !== "encodePNG",
-    );
-    expect(pngFns.length).toBeGreaterThan(10);
+    )
+    expect(pngFns.length).toBeGreaterThan(10)
     for (const name of pngFns) {
-      expect(registry[`${name}DataURI`], `${name}DataURI`).toBeTypeOf("function");
+      expect(registry[`${name}DataURI`], `${name}DataURI`).toBeTypeOf("function")
     }
-  });
-});
+  })
+})
 
 describe("sub-path entry points", () => {
   const cases: Array<[string, Record<string, unknown>, string[]]> = [
@@ -216,27 +216,27 @@ describe("sub-path entry points", () => {
         "encodePNG",
       ],
     ],
-  ];
+  ]
 
   for (const [name, mod, expected] of cases) {
     it(`${name} exports its documented surface`, () => {
       for (const key of expected) {
-        expect(mod[key], `${name} → ${key}`).toBeTypeOf("function");
+        expect(mod[key], `${name} → ${key}`).toBeTypeOf("function")
       }
-    });
+    })
   }
 
   it("sub-path exports are the same references as the main entry", () => {
-    const registry = etiket as unknown as Record<string, unknown>;
+    const registry = etiket as unknown as Record<string, unknown>
     for (const [, mod] of cases) {
       for (const [key, value] of Object.entries(mod)) {
-        if (typeof value !== "function") continue;
-        if (registry[key] === undefined) continue;
-        expect(registry[key], key).toBe(value);
+        if (typeof value !== "function") continue
+        if (registry[key] === undefined) continue
+        expect(registry[key], key).toBe(value)
       }
     }
-  });
-});
+  })
+})
 
 describe("documented snippets run", () => {
   const snippets: Array<[string, () => unknown]> = [
@@ -285,10 +285,10 @@ describe("documented snippets run", () => {
     [
       "jabcode custom palette",
       () => {
-        const result = etiket.encodeJABCode("HELLO", { colors: 4 });
+        const result = etiket.encodeJABCode("HELLO", { colors: 4 })
         return etiket.renderColorMatrixSVG(result.matrix, result.palette, {
           palette: ["#000000", "#e63946", "#457b9d", "#f1faee"],
-        });
+        })
       },
     ],
     ["gs1datamatrix", () => etiket.gs1datamatrix("(01)12345678901231")],
@@ -334,7 +334,7 @@ describe("documented snippets run", () => {
     [
       "raster then encodePNG",
       () => {
-        const raster = etiket.renderMatrixRaster(etiket.encodeQR("Hi"), { moduleSize: 4 });
+        const raster = etiket.renderMatrixRaster(etiket.encodeQR("Hi"), { moduleSize: 4 })
         return etiket.encodePNG(
           raster.width,
           raster.height,
@@ -342,7 +342,7 @@ describe("documented snippets run", () => {
           [0, 0, 0],
           [255, 255, 255],
           true,
-        );
+        )
       },
     ],
     [
@@ -357,18 +357,18 @@ describe("documented snippets run", () => {
     ["wifi hidden", () => etiket.wifi("MyNetwork", "password123", { hidden: true })],
     ["vcard", () => etiket.vcard({ firstName: "Ada", lastName: "Lovelace", email: "a@b.c" })],
     ["gs1DigitalLink", () => etiket.gs1DigitalLink({ gtin: "09520123456788", batch: "ABC" })],
-  ];
+  ]
 
   for (const [name, run] of snippets) {
     it(name, () => {
-      const result = run();
-      expect(result, name).toBeDefined();
-      expect(result, name).not.toBeNull();
+      const result = run()
+      expect(result, name).toBeDefined()
+      expect(result, name).not.toBeNull()
       if (typeof result === "string") {
-        expect(result.length, name).toBeGreaterThan(0);
-        expect(result, name).not.toContain("undefined");
-        expect(result, name).not.toContain("NaN");
+        expect(result.length, name).toBeGreaterThan(0)
+        expect(result, name).not.toContain("undefined")
+        expect(result, name).not.toContain("NaN")
       }
-    });
+    })
   }
-});
+})

--- a/test/barcode-roundtrip.test.ts
+++ b/test/barcode-roundtrip.test.ts
@@ -5,7 +5,7 @@
  * Note: Uses a PBM image intermediate since zbar.wasm needs pixel data
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   encodeCode128,
   encodeEAN13,
@@ -22,105 +22,105 @@ import {
   encodeMSI,
   encodeIdentcode,
   encodeLeitcode,
-} from "../src/index";
+} from "../src/index"
 
 describe("1D barcode encoding produces valid bar patterns", () => {
   it("Code 128 encodes valid patterns", () => {
-    const bars = encodeCode128("ABC123");
-    expect(bars.length).toBeGreaterThan(0);
+    const bars = encodeCode128("ABC123")
+    expect(bars.length).toBeGreaterThan(0)
     // All widths should be 1-4
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(4);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(4)
     }
     // Total modules should be consistent (each char = 11 modules + stop = 13)
-    const total = bars.reduce((a, b) => a + b, 0);
-    expect(total % 11).toBeLessThanOrEqual(2); // allow stop pattern remainder
-  });
+    const total = bars.reduce((a, b) => a + b, 0)
+    expect(total % 11).toBeLessThanOrEqual(2) // allow stop pattern remainder
+  })
 
   it("EAN-13 encodes correct total width", () => {
-    const { bars } = encodeEAN13("5901234123457");
-    const total = bars.reduce((a, b) => a + b, 0);
-    expect(total).toBe(95); // EAN-13 is always 95 modules
-  });
+    const { bars } = encodeEAN13("5901234123457")
+    const total = bars.reduce((a, b) => a + b, 0)
+    expect(total).toBe(95) // EAN-13 is always 95 modules
+  })
 
   it("EAN-8 encodes correct total width", () => {
-    const { bars } = encodeEAN8("96385074");
-    const total = bars.reduce((a, b) => a + b, 0);
-    expect(total).toBe(67); // EAN-8 is always 67 modules
-  });
+    const { bars } = encodeEAN8("96385074")
+    const total = bars.reduce((a, b) => a + b, 0)
+    expect(total).toBe(67) // EAN-8 is always 67 modules
+  })
 
   it("UPC-A encodes correct total width", () => {
-    const { bars } = encodeUPCA("012345678905");
-    const total = bars.reduce((a, b) => a + b, 0);
-    expect(total).toBe(95); // UPC-A is always 95 modules
-  });
+    const { bars } = encodeUPCA("012345678905")
+    const total = bars.reduce((a, b) => a + b, 0)
+    expect(total).toBe(95) // UPC-A is always 95 modules
+  })
 
   it("UPC-E encodes correct total width", () => {
-    const { bars } = encodeUPCE("04252614");
-    const total = bars.reduce((a, b) => a + b, 0);
-    expect(total).toBe(51); // UPC-E is always 51 modules
-  });
+    const { bars } = encodeUPCE("04252614")
+    const total = bars.reduce((a, b) => a + b, 0)
+    expect(total).toBe(51) // UPC-E is always 51 modules
+  })
 
   it("Code 39 encodes valid patterns", () => {
-    const bars = encodeCode39("HELLO");
-    expect(bars.length).toBeGreaterThan(0);
+    const bars = encodeCode39("HELLO")
+    expect(bars.length).toBeGreaterThan(0)
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(3);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(3)
     }
-  });
+  })
 
   it("Code 93 encodes valid patterns", () => {
-    const bars = encodeCode93("TEST");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode93("TEST")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("ITF encodes even-length digit pairs", () => {
-    const bars = encodeITF("1234567890");
-    expect(bars.length).toBeGreaterThan(0);
+    const bars = encodeITF("1234567890")
+    expect(bars.length).toBeGreaterThan(0)
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(3);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(3)
     }
-  });
+  })
 
   it("ITF-14 encodes 14 digits", () => {
-    const bars = encodeITF14("1234567890123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeITF14("1234567890123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("Codabar encodes valid patterns", () => {
-    const bars = encodeCodabar("A12345B");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCodabar("A12345B")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("Pharmacode encodes valid range", () => {
-    const bars = encodePharmacode(42);
-    expect(bars.length).toBeGreaterThan(0);
+    const bars = encodePharmacode(42)
+    expect(bars.length).toBeGreaterThan(0)
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(2);
-      expect(w).toBeLessThanOrEqual(4);
+      expect(w).toBeGreaterThanOrEqual(2)
+      expect(w).toBeLessThanOrEqual(4)
     }
-  });
+  })
 
   it("Code 11 encodes with check digits", () => {
-    const bars = encodeCode11("123-45");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode11("123-45")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("MSI encodes with mod10 check", () => {
-    const bars = encodeMSI("1234");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeMSI("1234")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("Identcode encodes 12 digits", () => {
-    const bars = encodeIdentcode("56310243031");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeIdentcode("56310243031")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("Leitcode encodes 14 digits", () => {
-    const bars = encodeLeitcode("2112345678900");
-    expect(bars.length).toBeGreaterThan(0);
-  });
-});
+    const bars = encodeLeitcode("2112345678900")
+    expect(bars.length).toBeGreaterThan(0)
+  })
+})

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -4,67 +4,67 @@
  * a user's terminal.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { runCommand } from "citty";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { main } from "../src/_cli";
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { runCommand } from "citty"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { main } from "../src/_cli"
 
-let dir: string;
-let stdout: string;
-let stdoutBytes: Uint8Array[];
-let originalWrite: (s: string | Uint8Array) => boolean;
+let dir: string
+let stdout: string
+let stdoutBytes: Uint8Array[]
+let originalWrite: (s: string | Uint8Array) => boolean
 
 beforeEach(() => {
-  dir = mkdtempSync(join(tmpdir(), "etiket-cli-"));
-  stdout = "";
-  stdoutBytes = [];
-  originalWrite = process.stdout.write.bind(process.stdout);
+  dir = mkdtempSync(join(tmpdir(), "etiket-cli-"))
+  stdout = ""
+  stdoutBytes = []
+  originalWrite = process.stdout.write.bind(process.stdout)
   process.stdout.write = (chunk: string | Uint8Array): boolean => {
-    if (typeof chunk === "string") stdout += chunk;
-    else stdoutBytes.push(chunk);
-    return true;
-  };
-});
+    if (typeof chunk === "string") stdout += chunk
+    else stdoutBytes.push(chunk)
+    return true
+  }
+})
 
 afterEach(() => {
-  process.stdout.write = originalWrite;
-  rmSync(dir, { recursive: true, force: true });
-});
+  process.stdout.write = originalWrite
+  rmSync(dir, { recursive: true, force: true })
+})
 
 /** Run the CLI with the given argv, returning the text it wrote to a file. */
 async function runToFile(args: string[], filename: string): Promise<string> {
-  const path = join(dir, filename);
-  await runCommand(main, { rawArgs: [...args, "-o", path] });
-  return readFileSync(path, "utf-8");
+  const path = join(dir, filename)
+  await runCommand(main, { rawArgs: [...args, "-o", path] })
+  return readFileSync(path, "utf-8")
 }
 
 /** Run the CLI, returning the raw bytes it wrote to a file. */
 async function runToBytes(args: string[], filename: string): Promise<Uint8Array> {
-  const path = join(dir, filename);
-  await runCommand(main, { rawArgs: [...args, "-o", path] });
-  return readFileSync(path);
+  const path = join(dir, filename)
+  await runCommand(main, { rawArgs: [...args, "-o", path] })
+  return readFileSync(path)
 }
 
 async function runToStdout(args: string[]): Promise<string> {
-  await runCommand(main, { rawArgs: args });
-  return stdout;
+  await runCommand(main, { rawArgs: args })
+  return stdout
 }
 
-const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10]
 
 function expectSVG(text: string, label: string): void {
-  expect(text.startsWith("<svg"), label).toBe(true);
-  expect(text.trimEnd().endsWith("</svg>"), label).toBe(true);
+  expect(text.startsWith("<svg"), label).toBe(true)
+  expect(text.trimEnd().endsWith("</svg>"), label).toBe(true)
   expect(text.includes("<path") || text.includes("<circle") || text.includes("<rect"), label).toBe(
     true,
-  );
+  )
 }
 
 function expectPNG(bytes: Uint8Array, label: string): void {
-  expect(Array.from(bytes.slice(0, 8)), label).toEqual(PNG_SIGNATURE);
-  expect(bytes.length, label).toBeGreaterThan(50);
+  expect(Array.from(bytes.slice(0, 8)), label).toEqual(PNG_SIGNATURE)
+  expect(bytes.length, label).toBeGreaterThan(50)
 }
 
 describe("CLI — SVG output for every subcommand", () => {
@@ -87,14 +87,14 @@ describe("CLI — SVG output for every subcommand", () => {
     ["wifi", ["wifi", "MyNet", "secret"]],
     ["contact", ["contact", "Ada Lovelace"]],
     ["link", ["link", "https://example.com"]],
-  ];
+  ]
 
   for (const [name, args] of cases) {
     it(`${name} writes an SVG file`, async () => {
-      expectSVG(await runToFile(args, `${name}.svg`), name);
-    });
+      expectSVG(await runToFile(args, `${name}.svg`), name)
+    })
   }
-});
+})
 
 describe("CLI — PNG output", () => {
   const cases: Array<[string, string[]]> = [
@@ -112,81 +112,81 @@ describe("CLI — PNG output", () => {
     ["codablockf", ["codablockf", "HELLO"]],
     ["code16k", ["code16k", "HELLO"]],
     ["maxicode", ["maxicode", "HELLO"]],
-  ];
+  ]
 
   for (const [name, args] of cases) {
     it(`${name} writes a PNG when the output file ends in .png`, async () => {
-      expectPNG(await runToBytes(args, `${name}.png`), name);
-    });
+      expectPNG(await runToBytes(args, `${name}.png`), name)
+    })
   }
 
   it("honours the explicit --png flag", async () => {
-    const path = join(dir, "explicit.out");
-    await runCommand(main, { rawArgs: ["qr", "HELLO", "--png", "-o", path] });
-    expectPNG(readFileSync(path), "explicit --png");
-  });
+    const path = join(dir, "explicit.out")
+    await runCommand(main, { rawArgs: ["qr", "HELLO", "--png", "-o", path] })
+    expectPNG(readFileSync(path), "explicit --png")
+  })
 
   it("reports an error for formats without PNG support", async () => {
     // JAB Code is polychrome; the palette-indexed matrix has no PNG path yet
-    const before = process.exitCode;
-    await runCommand(main, { rawArgs: ["jabcode", "HELLO", "--png"] });
-    expect(process.exitCode).toBe(1);
-    process.exitCode = before;
-  });
-});
+    const before = process.exitCode
+    await runCommand(main, { rawArgs: ["jabcode", "HELLO", "--png"] })
+    expect(process.exitCode).toBe(1)
+    process.exitCode = before
+  })
+})
 
 describe("CLI — barcode options", () => {
   it("supports the type option", async () => {
-    const ean = await runToFile(["barcode", "4006381333931", "--type", "ean13"], "ean.svg");
-    expectSVG(ean, "ean13");
-    const c128 = await runToFile(["barcode", "4006381333931"], "c128.svg");
-    expect(ean).not.toBe(c128);
-  });
+    const ean = await runToFile(["barcode", "4006381333931", "--type", "ean13"], "ean.svg")
+    expectSVG(ean, "ean13")
+    const c128 = await runToFile(["barcode", "4006381333931"], "c128.svg")
+    expect(ean).not.toBe(c128)
+  })
 
   it("supports the code39 check digit flag", async () => {
-    const plain = await runToFile(["barcode", "HELLO", "--type", "code39"], "c39.svg");
+    const plain = await runToFile(["barcode", "HELLO", "--type", "code39"], "c39.svg")
     const checked = await runToFile(
       ["barcode", "HELLO", "--type", "code39", "--code39-check-digit"],
       "c39c.svg",
-    );
-    expect(plain).not.toBe(checked);
-  });
+    )
+    expect(plain).not.toBe(checked)
+  })
 
   it("supports the MSI check digit option", async () => {
     const a = await runToFile(
       ["barcode", "1234", "--type", "msi", "--msi-check-digit", "mod10"],
       "msi10.svg",
-    );
+    )
     const b = await runToFile(
       ["barcode", "1234", "--type", "msi", "--msi-check-digit", "mod11"],
       "msi11.svg",
-    );
-    expect(a).not.toBe(b);
-  });
+    )
+    expect(a).not.toBe(b)
+  })
 
   it("supports the code128 charset option", async () => {
-    const svg = await runToFile(["barcode", "123456", "--code128-charset", "C"], "c128c.svg");
-    expectSVG(svg, "charset C");
-  });
+    const svg = await runToFile(["barcode", "123456", "--code128-charset", "C"], "c128c.svg")
+    expectSVG(svg, "charset C")
+  })
 
   it("renders human-readable text", async () => {
-    const svg = await runToFile(["barcode", "HELLO", "--show-text"], "text.svg");
-    expect(svg).toContain("<text");
-    expect(svg).toContain("HELLO");
-  });
+    const svg = await runToFile(["barcode", "HELLO", "--show-text"], "text.svg")
+    expect(svg).toContain("<text")
+    expect(svg).toContain("HELLO")
+  })
 
   it("applies color options", async () => {
-    const svg = await runToFile(["barcode", "HELLO", "--color", "#ff0000"], "color.svg");
-    expect(svg).toContain('fill="#ff0000"');
-  });
+    const svg = await runToFile(["barcode", "HELLO", "--color", "#ff0000"], "color.svg")
+    expect(svg).toContain('fill="#ff0000"')
+  })
 
   it("renders POSTNET through the postal renderer", async () => {
     // Height-modulated: the symbol must contain both tall and short bars
-    const svg = await runToFile(["barcode", "12345", "--type", "postnet"], "pn.svg");
-    const heights = new Set([...svg.matchAll(/v([\d.]+)h-/g)].map((m) => m[1]));
-    expect(heights.size).toBe(2);
-  });
-});
+    const svg = await runToFile(["barcode", "12345", "--type", "postnet"], "pn.svg")
+    const heights = new Set([...svg.matchAll(/v([\d.]+)h-/g)].map((m) => m[1]))
+    expect(heights.size).toBe(2)
+  })
+})
 
 describe("CLI — postal options", () => {
   it("supports every postal type", async () => {
@@ -198,97 +198,91 @@ describe("CLI — postal options", () => {
       ["auspost", ["postal", "12345678", "--type", "auspost"]],
       ["jppost", ["postal", "1234567", "--type", "jppost"]],
       ["imb", ["postal", "01234567094987654321", "--type", "imb"]],
-    ];
+    ]
     for (const [name, args] of cases) {
-      expectSVG(await runToFile(args, `${name}.svg`), name);
+      expectSVG(await runToFile(args, `${name}.svg`), name)
     }
-  });
+  })
 
   it("passes the Australia Post FCC", async () => {
-    const a = await runToFile(
-      ["postal", "12345678", "--type", "auspost", "--fcc", "11"],
-      "a11.svg",
-    );
-    const b = await runToFile(
-      ["postal", "12345678", "--type", "auspost", "--fcc", "59"],
-      "a59.svg",
-    );
-    expect(a).not.toBe(b);
-  });
+    const a = await runToFile(["postal", "12345678", "--type", "auspost", "--fcc", "11"], "a11.svg")
+    const b = await runToFile(["postal", "12345678", "--type", "auspost", "--fcc", "59"], "a59.svg")
+    expect(a).not.toBe(b)
+  })
 
   it("passes the IMb routing code", async () => {
-    const a = await runToFile(["postal", "01234567094987654321", "--type", "imb"], "i1.svg");
+    const a = await runToFile(["postal", "01234567094987654321", "--type", "imb"], "i1.svg")
     const b = await runToFile(
       ["postal", "01234567094987654321", "--type", "imb", "--routing-code", "01234567891"],
       "i2.svg",
-    );
-    expect(a).not.toBe(b);
-  });
-});
+    )
+    expect(a).not.toBe(b)
+  })
+})
 
 describe("CLI — 2D options", () => {
   it("datamatrix --gs1 differs from plain", async () => {
-    const plain = await runToFile(["datamatrix", "(01)12345678901231"], "dm.svg");
-    const gs1 = await runToFile(["datamatrix", "(01)12345678901231", "--gs1"], "gs1.svg");
-    expect(plain).not.toBe(gs1);
-  });
+    const plain = await runToFile(["datamatrix", "(01)12345678901231"], "dm.svg")
+    const gs1 = await runToFile(["datamatrix", "(01)12345678901231", "--gs1"], "gs1.svg")
+    expect(plain).not.toBe(gs1)
+  })
 
   it("qr honours the ec option", async () => {
-    const l = await runToFile(["qr", "HELLO", "--ec", "L"], "l.svg");
-    const h = await runToFile(["qr", "HELLO", "--ec", "H"], "h.svg");
-    expect(l).not.toBe(h);
-  });
+    const l = await runToFile(["qr", "HELLO", "--ec", "L"], "l.svg")
+    const h = await runToFile(["qr", "HELLO", "--ec", "H"], "h.svg")
+    expect(l).not.toBe(h)
+  })
 
   it("qr honours dot styling", async () => {
-    const square = await runToFile(["qr", "HELLO"], "square.svg");
-    const dots = await runToFile(["qr", "HELLO", "--dot-type", "dots"], "dots.svg");
-    expect(dots).not.toBe(square);
+    const square = await runToFile(["qr", "HELLO"], "square.svg")
+    const dots = await runToFile(["qr", "HELLO", "--dot-type", "dots"], "dots.svg")
+    expect(dots).not.toBe(square)
     // Round dot types are emitted as arc segments in the module path
-    expect(dots).toContain("a");
-  });
+    expect(dots).toContain("a")
+  })
 
   it("qr --terminal prints to the console", async () => {
-    await runCommand(main, { rawArgs: ["qr", "HI", "--terminal"] });
+    await runCommand(main, { rawArgs: ["qr", "HI", "--terminal"] })
     // consola writes the block output; nothing should be written to a file
-    expect(true).toBe(true);
-  });
+    expect(true).toBe(true)
+  })
 
   it("pdf417 honours columns", async () => {
-    const a = await runToFile(["pdf417", "HELLO", "--columns", "2"], "p2.svg");
-    const b = await runToFile(["pdf417", "HELLO", "--columns", "5"], "p5.svg");
-    expect(a).not.toBe(b);
-  });
+    const a = await runToFile(["pdf417", "HELLO", "--columns", "2"], "p2.svg")
+    const b = await runToFile(["pdf417", "HELLO", "--columns", "5"], "p5.svg")
+    expect(a).not.toBe(b)
+  })
 
   it("aztec honours layers", async () => {
-    const a = await runToFile(["aztec", "HELLO", "--layers", "2"], "a2.svg");
-    const b = await runToFile(["aztec", "HELLO", "--layers", "4"], "a4.svg");
-    expect(a).not.toBe(b);
-  });
+    const a = await runToFile(["aztec", "HELLO", "--layers", "2"], "a2.svg")
+    const b = await runToFile(["aztec", "HELLO", "--layers", "4"], "a4.svg")
+    expect(a).not.toBe(b)
+  })
 
   it("respects the size option", async () => {
-    const svg = await runToFile(["datamatrix", "HELLO", "--size", "500", "--margin", "0"], "s.svg");
-    expect(svg).toContain('viewBox="0 0 500 500"');
-  });
-});
+    const svg = await runToFile(["datamatrix", "HELLO", "--size", "500", "--margin", "0"], "s.svg")
+    expect(svg).toContain('viewBox="0 0 500 500"')
+  })
+})
 
 describe("CLI — helper commands", () => {
   it("wifi encodes network details", async () => {
-    const a = await runToFile(["wifi", "Net", "pass"], "w1.svg");
-    const b = await runToFile(["wifi", "Net", "pass", "--encryption", "WEP"], "w2.svg");
-    expect(a).not.toBe(b);
-  });
+    const a = await runToFile(["wifi", "Net", "pass"], "w1.svg")
+    const b = await runToFile(["wifi", "Net", "pass", "--encryption", "WEP"], "w2.svg")
+    expect(a).not.toBe(b)
+  })
 
   it("wifi supports hidden networks", async () => {
-    const a = await runToFile(["wifi", "Net", "pass"], "w3.svg");
-    const b = await runToFile(["wifi", "Net", "pass", "--hidden"], "w4.svg");
-    expect(a).not.toBe(b);
-  });
+    const a = await runToFile(["wifi", "Net", "pass"], "w3.svg")
+    const b = await runToFile(["wifi", "Net", "pass", "--hidden"], "w4.svg")
+    expect(a).not.toBe(b)
+  })
 
   it("contact encodes vCard fields", async () => {
-    const a = await runToFile(["contact", "Ada Lovelace"], "c1.svg");
-    const b = await runToFile(["contact", "Ada Lovelace", "--phone", "555"], "c2.svg");
-    expect(a).not.toBe(b);
-  });
+    const a = await runToFile(["contact", "Ada Lovelace"], "c1.svg")
+    const b = await runToFile(["contact", "Ada Lovelace", "--phone", "555"], "c2.svg")
+    expect(a).not.toBe(b)
+  })
 
   it("link supports each kind", async () => {
     for (const [name, args] of [
@@ -298,51 +292,51 @@ describe("CLI — helper commands", () => {
       ["sms", ["link", "5551234", "--kind", "sms", "--body", "hi"]],
       ["geo", ["link", "41.0082,28.9784", "--kind", "geo"]],
     ] as Array<[string, string[]]>) {
-      expectSVG(await runToFile(args, `${name}.svg`), name);
+      expectSVG(await runToFile(args, `${name}.svg`), name)
     }
-  });
+  })
 
   it("link rejects malformed geo coordinates", async () => {
-    const before = process.exitCode;
-    await runCommand(main, { rawArgs: ["link", "not-a-coord", "--kind", "geo"] });
-    expect(process.exitCode).toBe(1);
-    process.exitCode = before;
-  });
-});
+    const before = process.exitCode
+    await runCommand(main, { rawArgs: ["link", "not-a-coord", "--kind", "geo"] })
+    expect(process.exitCode).toBe(1)
+    process.exitCode = before
+  })
+})
 
 describe("CLI — stdout and metadata", () => {
   it("writes to stdout when no output file is given", async () => {
-    const out = await runToStdout(["datamatrix", "HELLO"]);
-    expect(out.startsWith("<svg")).toBe(true);
-  });
+    const out = await runToStdout(["datamatrix", "HELLO"])
+    expect(out.startsWith("<svg")).toBe(true)
+  })
 
   it("list names every symbology family", async () => {
-    await runCommand(main, { rawArgs: ["list"] });
+    await runCommand(main, { rawArgs: ["list"] })
     // list() uses consola, which does not go through process.stdout.write here;
     // the command completing without throwing is the assertion.
-    expect(true).toBe(true);
-  });
+    expect(true).toBe(true)
+  })
 
   it("reports the package version rather than a hardcoded one", () => {
     const pkg = JSON.parse(readFileSync("package.json", "utf-8")) as {
-      version: string;
-    };
-    expect(main.meta).toBeDefined();
-    const meta = main.meta as { version?: string };
-    expect(meta.version).toBe(pkg.version);
-  });
-});
+      version: string
+    }
+    expect(main.meta).toBeDefined()
+    const meta = main.meta as { version?: string }
+    expect(meta.version).toBe(pkg.version)
+  })
+})
 
 describe("CLI — error propagation", () => {
   it("surfaces encoder validation errors", async () => {
     await expect(
       runCommand(main, { rawArgs: ["barcode", "HELLO", "--type", "ean13"] }),
-    ).rejects.toThrow();
-  });
+    ).rejects.toThrow()
+  })
 
   it("surfaces postal validation errors", async () => {
     await expect(
       runCommand(main, { rawArgs: ["postal", "ABCDE", "--type", "postnet"] }),
-    ).rejects.toThrow();
-  });
-});
+    ).rejects.toThrow()
+  })
+})

--- a/test/edge-compat.test.ts
+++ b/test/edge-compat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   barcode,
   qrcode,
@@ -8,7 +8,7 @@ import {
   encodeQR,
   svgToDataURI,
   svgToBase64,
-} from "../src/index";
+} from "../src/index"
 
 /**
  * Edge runtime compatibility tests
@@ -17,42 +17,42 @@ import {
  */
 describe("Edge runtime compatibility", () => {
   it("barcode() uses no Node.js globals", () => {
-    const svg = barcode("Hello");
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("Hello")
+    expect(svg).toContain("<svg")
+  })
 
   it("qrcode() uses no Node.js globals", () => {
-    const svg = qrcode("Hello");
-    expect(svg).toContain("<svg");
-  });
+    const svg = qrcode("Hello")
+    expect(svg).toContain("<svg")
+  })
 
   it("datamatrix() uses no Node.js globals", () => {
-    const svg = datamatrix("Hello");
-    expect(svg).toContain("<svg");
-  });
+    const svg = datamatrix("Hello")
+    expect(svg).toContain("<svg")
+  })
 
   it("pdf417() uses no Node.js globals", () => {
-    const svg = pdf417("Hello");
-    expect(svg).toContain("<svg");
-  });
+    const svg = pdf417("Hello")
+    expect(svg).toContain("<svg")
+  })
 
   it("aztec() uses no Node.js globals", () => {
-    const svg = aztec("Hello");
-    expect(svg).toContain("<svg");
-  });
+    const svg = aztec("Hello")
+    expect(svg).toContain("<svg")
+  })
 
   it("encodeQR() uses only TextEncoder (available in all runtimes)", () => {
-    const matrix = encodeQR("Hello");
-    expect(matrix.length).toBeGreaterThan(0);
-  });
+    const matrix = encodeQR("Hello")
+    expect(matrix.length).toBeGreaterThan(0)
+  })
 
   it("svgToDataURI() uses no Node.js globals", () => {
-    const uri = svgToDataURI("<svg></svg>");
-    expect(uri).toMatch(/^data:image\/svg\+xml,/);
-  });
+    const uri = svgToDataURI("<svg></svg>")
+    expect(uri).toMatch(/^data:image\/svg\+xml,/)
+  })
 
   it("svgToBase64() uses TextEncoder + btoa (available in all runtimes)", () => {
-    const b64 = svgToBase64("<svg></svg>");
-    expect(b64).toMatch(/^data:image\/svg\+xml;base64,/);
-  });
-});
+    const b64 = svgToBase64("<svg></svg>")
+    expect(b64).toMatch(/^data:image\/svg\+xml;base64,/)
+  })
+})

--- a/test/encode-full.test.ts
+++ b/test/encode-full.test.ts
@@ -3,23 +3,23 @@
  * and agreement with the dedicated encoders it dispatches to.
  */
 
-import { describe, expect, it } from "vitest";
-import { encode } from "../src/_encode";
-import { encodeBars } from "../src/_barcode";
-import { encodePostal } from "../src/_postal";
-import { encodeQR } from "../src/encoders/qr/index";
-import { encodeMicroQR } from "../src/encoders/qr/micro";
-import { encodeRMQR } from "../src/encoders/rmqr";
-import { encodeDataMatrix, encodeGS1DataMatrix } from "../src/encoders/datamatrix/index";
-import { encodePDF417 } from "../src/encoders/pdf417/index";
-import { encodeMicroPDF417 } from "../src/encoders/micropdf417";
-import { encodeAztec } from "../src/encoders/aztec/index";
-import { encodeMaxiCode } from "../src/encoders/maxicode";
-import { encodeDotCode } from "../src/encoders/dotcode";
-import { encodeHanXin } from "../src/encoders/hanxin";
-import { encodeCodablockF } from "../src/encoders/codablock-f";
-import { encodeCode16K } from "../src/encoders/code16k";
-import type { EncodeType } from "../src/_types";
+import { describe, expect, it } from "vitest"
+import { encode } from "../src/_encode"
+import { encodeBars } from "../src/_barcode"
+import { encodePostal } from "../src/_postal"
+import { encodeQR } from "../src/encoders/qr/index"
+import { encodeMicroQR } from "../src/encoders/qr/micro"
+import { encodeRMQR } from "../src/encoders/rmqr"
+import { encodeDataMatrix, encodeGS1DataMatrix } from "../src/encoders/datamatrix/index"
+import { encodePDF417 } from "../src/encoders/pdf417/index"
+import { encodeMicroPDF417 } from "../src/encoders/micropdf417"
+import { encodeAztec } from "../src/encoders/aztec/index"
+import { encodeMaxiCode } from "../src/encoders/maxicode"
+import { encodeDotCode } from "../src/encoders/dotcode"
+import { encodeHanXin } from "../src/encoders/hanxin"
+import { encodeCodablockF } from "../src/encoders/codablock-f"
+import { encodeCode16K } from "../src/encoders/code16k"
+import type { EncodeType } from "../src/_types"
 
 /** Valid sample input for every encode type. */
 const SAMPLES: Array<[EncodeType, string]> = [
@@ -70,7 +70,7 @@ const SAMPLES: Array<[EncodeType, string]> = [
   ["hanxin", "HELLO"],
   ["codablock-f", "HELLO"],
   ["code16k", "HELLO"],
-];
+]
 
 const POSTAL_TYPES = new Set<EncodeType>([
   "postnet",
@@ -80,7 +80,7 @@ const POSTAL_TYPES = new Set<EncodeType>([
   "auspost",
   "jppost",
   "imb",
-]);
+])
 
 const TWO_D_TYPES = new Set<EncodeType>([
   "qr",
@@ -96,172 +96,172 @@ const TWO_D_TYPES = new Set<EncodeType>([
   "hanxin",
   "codablock-f",
   "code16k",
-]);
+])
 
 describe("encode() — every supported type", () => {
   for (const [type, sample] of SAMPLES) {
     it(`encodes ${type}`, () => {
-      const result = encode(sample, { type });
+      const result = encode(sample, { type })
 
       if (TWO_D_TYPES.has(type)) {
-        expect(result.type, type).toBe("2d");
-        if (result.type !== "2d") return;
-        expect(result.matrix.length, type).toBeGreaterThan(0);
-        expect(result.matrix[0]!.length, type).toBeGreaterThan(0);
+        expect(result.type, type).toBe("2d")
+        if (result.type !== "2d") return
+        expect(result.matrix.length, type).toBeGreaterThan(0)
+        expect(result.matrix[0]!.length, type).toBeGreaterThan(0)
         for (const row of result.matrix) {
-          expect(row.length, type).toBe(result.matrix[0]!.length);
+          expect(row.length, type).toBe(result.matrix[0]!.length)
         }
         // A symbol that is entirely light or entirely dark is broken
-        const dark = result.matrix.flat().filter(Boolean).length;
-        expect(dark, type).toBeGreaterThan(0);
-        expect(dark, type).toBeLessThan(result.matrix.flat().length);
+        const dark = result.matrix.flat().filter(Boolean).length
+        expect(dark, type).toBeGreaterThan(0)
+        expect(dark, type).toBeLessThan(result.matrix.flat().length)
       } else if (POSTAL_TYPES.has(type)) {
-        expect(result.type, type).toBe("postal");
-        if (result.type !== "postal") return;
-        expect(result.bars.length, type).toBeGreaterThan(0);
+        expect(result.type, type).toBe("postal")
+        if (result.type !== "postal") return
+        expect(result.bars.length, type).toBeGreaterThan(0)
       } else {
-        expect(result.type, type).toBe("1d");
-        if (result.type !== "1d") return;
-        expect(result.bars.length, type).toBeGreaterThan(0);
+        expect(result.type, type).toBe("1d")
+        if (result.type !== "1d") return
+        expect(result.bars.length, type).toBeGreaterThan(0)
         for (const bar of result.bars) {
-          expect(typeof bar, type).toBe("number");
-          expect(bar, type).toBeGreaterThanOrEqual(1);
+          expect(typeof bar, type).toBe("number")
+          expect(bar, type).toBeGreaterThanOrEqual(1)
         }
       }
-    });
+    })
   }
 
   it("covers every declared type in the sample table", () => {
     // Guards against a new EncodeType being added without a test
-    expect(SAMPLES).toHaveLength(44);
-  });
-});
+    expect(SAMPLES).toHaveLength(44)
+  })
+})
 
 describe("encode() agrees with the underlying encoders", () => {
   it("matches encodeBars for 1D types", () => {
     for (const [type, sample] of SAMPLES) {
-      if (TWO_D_TYPES.has(type) || POSTAL_TYPES.has(type)) continue;
-      const result = encode(sample, { type });
-      expect(result.type).toBe("1d");
-      if (result.type !== "1d") continue;
-      expect(result.bars, type).toEqual(encodeBars(sample, { type: type as "code128" }));
+      if (TWO_D_TYPES.has(type) || POSTAL_TYPES.has(type)) continue
+      const result = encode(sample, { type })
+      expect(result.type).toBe("1d")
+      if (result.type !== "1d") continue
+      expect(result.bars, type).toEqual(encodeBars(sample, { type: type as "code128" }))
     }
-  });
+  })
 
   it("matches encodePostal for postal types", () => {
     for (const [type, sample] of SAMPLES) {
-      if (!POSTAL_TYPES.has(type)) continue;
-      const result = encode(sample, { type });
-      expect(result.type).toBe("postal");
-      if (result.type !== "postal") continue;
-      expect(result.bars, type).toEqual(encodePostal(sample, { type: type as "postnet" }));
+      if (!POSTAL_TYPES.has(type)) continue
+      const result = encode(sample, { type })
+      expect(result.type).toBe("postal")
+      if (result.type !== "postal") continue
+      expect(result.bars, type).toEqual(encodePostal(sample, { type: type as "postnet" }))
     }
-  });
+  })
 
   it("matches the 2D encoders", () => {
     expect((encode("HELLO", { type: "qr" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeQR("HELLO"),
-    );
+    )
     expect((encode("12345", { type: "microqr" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeMicroQR("12345"),
-    );
+    )
     expect((encode("HELLO", { type: "rmqr" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeRMQR("HELLO"),
-    );
+    )
     expect((encode("HELLO", { type: "datamatrix" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeDataMatrix("HELLO"),
-    );
+    )
     expect(
       (encode("(01)12345678901231", { type: "gs1-datamatrix" }) as { matrix: boolean[][] }).matrix,
-    ).toEqual(encodeGS1DataMatrix("(01)12345678901231"));
+    ).toEqual(encodeGS1DataMatrix("(01)12345678901231"))
     expect((encode("HELLO", { type: "pdf417" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodePDF417("HELLO").matrix,
-    );
+    )
     expect((encode("HELLO", { type: "micropdf417" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeMicroPDF417("HELLO").matrix,
-    );
+    )
     expect((encode("HELLO", { type: "aztec" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeAztec("HELLO"),
-    );
+    )
     expect((encode("HELLO", { type: "maxicode" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeMaxiCode("HELLO"),
-    );
+    )
     expect((encode("HELLO", { type: "dotcode" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeDotCode("HELLO"),
-    );
+    )
     expect((encode("HELLO", { type: "hanxin" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeHanXin("HELLO"),
-    );
+    )
     expect((encode("HELLO", { type: "codablock-f" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeCodablockF("HELLO").matrix,
-    );
+    )
     expect((encode("HELLO", { type: "code16k" }) as { matrix: boolean[][] }).matrix).toEqual(
       encodeCode16K("HELLO").matrix,
-    );
-  });
-});
+    )
+  })
+})
 
 describe("encode() option passthrough", () => {
   it("passes 1D options that previously only barcode() honoured", () => {
     // code39CheckDigit was silently ignored by the old encode() implementation
-    const plain = encode("HELLO", { type: "code39" });
-    const checked = encode("HELLO", { type: "code39", code39CheckDigit: true });
-    expect(plain).not.toEqual(checked);
+    const plain = encode("HELLO", { type: "code39" })
+    const checked = encode("HELLO", { type: "code39", code39CheckDigit: true })
+    expect(plain).not.toEqual(checked)
     expect((checked as { bars: number[] }).bars).toEqual(
       encodeBars("HELLO", { type: "code39", code39CheckDigit: true }),
-    );
-  });
+    )
+  })
 
   it("passes codabar start/stop characters", () => {
-    const a = encode("123456", { type: "codabar", codabarStart: "A", codabarStop: "B" });
-    const c = encode("123456", { type: "codabar", codabarStart: "C", codabarStop: "D" });
-    expect(a).not.toEqual(c);
-  });
+    const a = encode("123456", { type: "codabar", codabarStart: "A", codabarStop: "B" })
+    const c = encode("123456", { type: "codabar", codabarStart: "C", codabarStop: "D" })
+    expect(a).not.toEqual(c)
+  })
 
   it("passes the MSI check digit option", () => {
-    const mod10 = encode("1234", { type: "msi", msiCheckDigit: "mod10" });
-    const mod11 = encode("1234", { type: "msi", msiCheckDigit: "mod11" });
-    expect(mod10).not.toEqual(mod11);
-  });
+    const mod10 = encode("1234", { type: "msi", msiCheckDigit: "mod10" })
+    const mod11 = encode("1234", { type: "msi", msiCheckDigit: "mod11" })
+    expect(mod10).not.toEqual(mod11)
+  })
 
   it("passes code128 charset", () => {
-    const auto = encode("123456", { type: "code128" });
-    const charsetC = encode("123456", { type: "code128", code128Charset: "C" });
+    const auto = encode("123456", { type: "code128" })
+    const charsetC = encode("123456", { type: "code128", code128Charset: "C" })
     expect((charsetC as { bars: number[] }).bars.length).toBeLessThanOrEqual(
       (auto as { bars: number[] }).bars.length,
-    );
-  });
+    )
+  })
 
   it("passes QR encoder options", () => {
-    const l = encode("HELLO", { type: "qr", qr: { ecLevel: "L" } });
-    const h = encode("HELLO", { type: "qr", qr: { ecLevel: "H" } });
-    expect(l).not.toEqual(h);
-    expect((h as { matrix: boolean[][] }).matrix).toEqual(encodeQR("HELLO", { ecLevel: "H" }));
-  });
+    const l = encode("HELLO", { type: "qr", qr: { ecLevel: "L" } })
+    const h = encode("HELLO", { type: "qr", qr: { ecLevel: "H" } })
+    expect(l).not.toEqual(h)
+    expect((h as { matrix: boolean[][] }).matrix).toEqual(encodeQR("HELLO", { ecLevel: "H" }))
+  })
 
   it("passes Micro QR options", () => {
     expect(encode("12345", { type: "microqr", microqr: { mask: 0 } })).not.toEqual(
       encode("12345", { type: "microqr", microqr: { mask: 3 } }),
-    );
-  });
+    )
+  })
 
   it("passes rMQR options", () => {
     expect(encode("HELLO", { type: "rmqr", rmqr: { ecLevel: "M" } })).not.toEqual(
       encode("HELLO", { type: "rmqr", rmqr: { ecLevel: "H" } }),
-    );
-  });
+    )
+  })
 
   it("passes PDF417 options", () => {
     expect(encode("HELLO", { type: "pdf417", pdf417: { columns: 2 } })).not.toEqual(
       encode("HELLO", { type: "pdf417", pdf417: { columns: 5 } }),
-    );
-  });
+    )
+  })
 
   it("passes MicroPDF417 options", () => {
     expect(encode("HELLO", { type: "micropdf417", micropdf417: { columns: 1 } })).not.toEqual(
       encode("HELLO", { type: "micropdf417", micropdf417: { columns: 4 } }),
-    );
-  });
+    )
+  })
 
   it("passes Aztec options", () => {
     // Aztec fills all spare capacity with EC, so ecPercent only shows up once
@@ -269,18 +269,18 @@ describe("encode() option passthrough", () => {
     const low = encode("HELLO WORLD LONGER DATA STRING HERE 1234567890", {
       type: "aztec",
       aztec: { ecPercent: 5 },
-    }) as { matrix: boolean[][] };
+    }) as { matrix: boolean[][] }
     const high = encode("HELLO WORLD LONGER DATA STRING HERE 1234567890", {
       type: "aztec",
       aztec: { ecPercent: 90 },
-    }) as { matrix: boolean[][] };
-    expect(high.matrix.length).toBeGreaterThan(low.matrix.length);
+    }) as { matrix: boolean[][] }
+    expect(high.matrix.length).toBeGreaterThan(low.matrix.length)
 
     // layers/compact are forwarded too
     expect(encode("HELLO", { type: "aztec", aztec: { layers: 2 } })).not.toEqual(
       encode("HELLO", { type: "aztec", aztec: { layers: 4 } }),
-    );
-  });
+    )
+  })
 
   it("passes MaxiCode options", () => {
     expect(
@@ -288,48 +288,48 @@ describe("encode() option passthrough", () => {
         type: "maxicode",
         maxicode: { mode: 2, postalCode: "123456789", countryCode: 840 },
       }),
-    ).not.toEqual(encode("HELLO", { type: "maxicode", maxicode: { mode: 4 } }));
-  });
+    ).not.toEqual(encode("HELLO", { type: "maxicode", maxicode: { mode: 4 } }))
+  })
 
   it("passes Han Xin options", () => {
     expect(encode("HELLO", { type: "hanxin", hanxin: { ecLevel: 1 } })).not.toEqual(
       encode("HELLO", { type: "hanxin", hanxin: { ecLevel: 4 } }),
-    );
-  });
+    )
+  })
 
   it("passes Codablock-F options", () => {
     expect(
       encode("CODABLOCK TEST", { type: "codablock-f", codablockf: { columns: 8 } }),
-    ).not.toEqual(encode("CODABLOCK TEST", { type: "codablock-f", codablockf: { columns: 16 } }));
-  });
+    ).not.toEqual(encode("CODABLOCK TEST", { type: "codablock-f", codablockf: { columns: 16 } }))
+  })
 
   it("passes the Australia Post format control code", () => {
     expect(encode("12345678", { type: "auspost", fcc: "11" })).not.toEqual(
       encode("12345678", { type: "auspost", fcc: "59" }),
-    );
-  });
+    )
+  })
 
   it("passes the IMb routing code", () => {
     expect(encode("01234567094987654321", { type: "imb", routingCode: "01234567891" })).not.toEqual(
       encode("01234567094987654321", { type: "imb" }),
-    );
-  });
+    )
+  })
 
   it("passes the Japan Post address", () => {
     expect(encode("1234567", { type: "jppost", routingCode: "1-2-3" })).not.toEqual(
       encode("1234567", { type: "jppost" }),
-    );
-  });
-});
+    )
+  })
+})
 
 describe("encode() error handling", () => {
   it("rejects an unsupported type", () => {
-    expect(() => encode("test", { type: "nope" as EncodeType })).toThrow(/Unsupported/);
-  });
+    expect(() => encode("test", { type: "nope" as EncodeType })).toThrow(/Unsupported/)
+  })
 
   it("propagates encoder validation errors", () => {
-    expect(() => encode("HELLO", { type: "ean13" })).toThrow();
-    expect(() => encode("", { type: "qr" })).toThrow();
-    expect(() => encode("ABC", { type: "postnet" })).toThrow();
-  });
-});
+    expect(() => encode("HELLO", { type: "ean13" })).toThrow()
+    expect(() => encode("", { type: "qr" })).toThrow()
+    expect(() => encode("ABC", { type: "postnet" })).toThrow()
+  })
+})

--- a/test/encode.test.ts
+++ b/test/encode.test.ts
@@ -1,134 +1,134 @@
-import { describe, expect, it } from "vitest";
-import { encode } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { encode } from "../src/index"
 
 describe("encode() — unified raw output", () => {
   // --- 1D barcode output ---
 
   it("returns { type: '1d', bars: [...] } for default code128", () => {
-    const result = encode("Hello");
-    expect(result.type).toBe("1d");
-    expect(result).toHaveProperty("bars");
+    const result = encode("Hello")
+    expect(result.type).toBe("1d")
+    expect(result).toHaveProperty("bars")
     if (result.type === "1d") {
-      expect(Array.isArray(result.bars)).toBe(true);
-      expect(result.bars.length).toBeGreaterThan(0);
+      expect(Array.isArray(result.bars)).toBe(true)
+      expect(result.bars.length).toBeGreaterThan(0)
       for (const bar of result.bars) {
-        expect(typeof bar).toBe("number");
-        expect(bar).toBeGreaterThanOrEqual(1);
+        expect(typeof bar).toBe("number")
+        expect(bar).toBeGreaterThanOrEqual(1)
       }
     }
-  });
+  })
 
   it("returns { type: '1d', bars: [...] } for explicit code128", () => {
-    const result = encode("Hello", { type: "code128" });
-    expect(result.type).toBe("1d");
+    const result = encode("Hello", { type: "code128" })
+    expect(result.type).toBe("1d")
     if (result.type === "1d") {
-      expect(result.bars.length).toBeGreaterThan(0);
+      expect(result.bars.length).toBeGreaterThan(0)
     }
-  });
+  })
 
   it("returns same bars as default when type is code128", () => {
-    const defaultResult = encode("Hello");
-    const explicitResult = encode("Hello", { type: "code128" });
-    expect(defaultResult).toEqual(explicitResult);
-  });
+    const defaultResult = encode("Hello")
+    const explicitResult = encode("Hello", { type: "code128" })
+    expect(defaultResult).toEqual(explicitResult)
+  })
 
   // --- 2D matrix output ---
 
   it("returns { type: '2d', matrix: [...] } for QR code", () => {
-    const result = encode("Hello", { type: "qr" });
-    expect(result.type).toBe("2d");
-    expect(result).toHaveProperty("matrix");
+    const result = encode("Hello", { type: "qr" })
+    expect(result.type).toBe("2d")
+    expect(result).toHaveProperty("matrix")
     if (result.type === "2d") {
-      expect(Array.isArray(result.matrix)).toBe(true);
-      expect(result.matrix.length).toBeGreaterThan(0);
+      expect(Array.isArray(result.matrix)).toBe(true)
+      expect(result.matrix.length).toBeGreaterThan(0)
       // Each row should be an array of booleans
       for (const row of result.matrix) {
-        expect(Array.isArray(row)).toBe(true);
+        expect(Array.isArray(row)).toBe(true)
         for (const cell of row) {
-          expect(typeof cell).toBe("boolean");
+          expect(typeof cell).toBe("boolean")
         }
       }
       // Matrix should be square for QR
-      expect(result.matrix.length).toBe(result.matrix[0]!.length);
+      expect(result.matrix.length).toBe(result.matrix[0]!.length)
     }
-  });
+  })
 
   it("returns { type: '2d', matrix: [...] } for Data Matrix", () => {
-    const result = encode("Hello", { type: "datamatrix" });
-    expect(result.type).toBe("2d");
+    const result = encode("Hello", { type: "datamatrix" })
+    expect(result.type).toBe("2d")
     if (result.type === "2d") {
-      expect(result.matrix.length).toBeGreaterThan(0);
+      expect(result.matrix.length).toBeGreaterThan(0)
     }
-  });
+  })
 
   it("returns { type: '2d', matrix: [...] } for PDF417", () => {
-    const result = encode("Hello", { type: "pdf417" });
-    expect(result.type).toBe("2d");
+    const result = encode("Hello", { type: "pdf417" })
+    expect(result.type).toBe("2d")
     if (result.type === "2d") {
-      expect(result.matrix.length).toBeGreaterThan(0);
+      expect(result.matrix.length).toBeGreaterThan(0)
     }
-  });
+  })
 
   it("returns { type: '2d', matrix: [...] } for Aztec", () => {
-    const result = encode("Hello", { type: "aztec" });
-    expect(result.type).toBe("2d");
+    const result = encode("Hello", { type: "aztec" })
+    expect(result.type).toBe("2d")
     if (result.type === "2d") {
-      expect(result.matrix.length).toBeGreaterThan(0);
+      expect(result.matrix.length).toBeGreaterThan(0)
     }
-  });
+  })
 
   // --- Various 1D barcode types ---
 
   it("returns 1d result for code39", () => {
-    const result = encode("HELLO", { type: "code39" });
-    expect(result.type).toBe("1d");
-  });
+    const result = encode("HELLO", { type: "code39" })
+    expect(result.type).toBe("1d")
+  })
 
   it("returns 1d result for code93", () => {
-    const result = encode("TEST", { type: "code93" });
-    expect(result.type).toBe("1d");
-  });
+    const result = encode("TEST", { type: "code93" })
+    expect(result.type).toBe("1d")
+  })
 
   it("returns 1d result for ean13", () => {
-    const result = encode("4006381333931", { type: "ean13" });
-    expect(result.type).toBe("1d");
-  });
+    const result = encode("4006381333931", { type: "ean13" })
+    expect(result.type).toBe("1d")
+  })
 
   it("returns 1d result for itf", () => {
-    const result = encode("1234567890", { type: "itf" });
-    expect(result.type).toBe("1d");
-  });
+    const result = encode("1234567890", { type: "itf" })
+    expect(result.type).toBe("1d")
+  })
 
   // --- Error handling ---
 
   it("throws for ean13 with wrong length", () => {
-    expect(() => encode("Hello", { type: "ean13" })).toThrow();
-  });
+    expect(() => encode("Hello", { type: "ean13" })).toThrow()
+  })
 
   it("throws for unsupported type", () => {
-    expect(() => encode("test", { type: "invalid" as any })).toThrow("Unsupported");
-  });
+    expect(() => encode("test", { type: "invalid" as any })).toThrow("Unsupported")
+  })
 
   // --- Different types produce different structures ---
 
   it("same text produces different structures for 1d vs 2d", () => {
-    const barcode = encode("12345678");
-    const qr = encode("12345678", { type: "qr" });
-    expect(barcode.type).toBe("1d");
-    expect(qr.type).toBe("2d");
-  });
+    const barcode = encode("12345678")
+    const qr = encode("12345678", { type: "qr" })
+    expect(barcode.type).toBe("1d")
+    expect(qr.type).toBe("2d")
+  })
 
   // --- Passthrough options work ---
 
   it("passes code128Charset option through", () => {
-    const auto = encode("123456", { type: "code128" });
-    const charsetC = encode("123456", { type: "code128", code128Charset: "C" });
+    const auto = encode("123456", { type: "code128" })
+    const charsetC = encode("123456", { type: "code128", code128Charset: "C" })
     // Both should succeed and produce 1d results
-    expect(auto.type).toBe("1d");
-    expect(charsetC.type).toBe("1d");
+    expect(auto.type).toBe("1d")
+    expect(charsetC.type).toBe("1d")
     // Charset C produces a more compact encoding for pure digits
     if (auto.type === "1d" && charsetC.type === "1d") {
-      expect(charsetC.bars.length).toBeLessThanOrEqual(auto.bars.length);
+      expect(charsetC.bars.length).toBeLessThanOrEqual(auto.bars.length)
     }
-  });
-});
+  })
+})

--- a/test/encoders-auspost-jppost.test.ts
+++ b/test/encoders-auspost-jppost.test.ts
@@ -1,99 +1,99 @@
-import { describe, expect, it } from "vitest";
-import { encodeAustraliaPost, encodeJapanPost } from "../src/encoders/fourstate";
+import { describe, expect, it } from "vitest"
+import { encodeAustraliaPost, encodeJapanPost } from "../src/encoders/fourstate"
 
 describe("Australia Post 4-State", () => {
   it("encodes FCC + DPID", () => {
-    const bars = encodeAustraliaPost("11", "12345678");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeAustraliaPost("11", "12345678")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("all values are valid states", () => {
-    const bars = encodeAustraliaPost("59", "98765432");
+    const bars = encodeAustraliaPost("59", "98765432")
     for (const b of bars) {
-      expect(["T", "A", "D", "F"]).toContain(b);
+      expect(["T", "A", "D", "F"]).toContain(b)
     }
-  });
+  })
 
   it("starts and ends with frame bars", () => {
-    const bars = encodeAustraliaPost("11", "12345678");
-    expect(bars[0]).toBe("F");
-    expect(bars[1]).toBe("A");
-  });
+    const bars = encodeAustraliaPost("11", "12345678")
+    expect(bars[0]).toBe("F")
+    expect(bars[1]).toBe("A")
+  })
 
   it("throws on invalid FCC", () => {
-    expect(() => encodeAustraliaPost("1", "12345678")).toThrow();
-  });
+    expect(() => encodeAustraliaPost("1", "12345678")).toThrow()
+  })
 
   it("throws on invalid DPID", () => {
-    expect(() => encodeAustraliaPost("11", "1234")).toThrow();
-  });
+    expect(() => encodeAustraliaPost("11", "1234")).toThrow()
+  })
 
   it("different data produces different output", () => {
-    const a = encodeAustraliaPost("11", "12345678");
-    const b = encodeAustraliaPost("11", "87654321");
-    expect(a).not.toEqual(b);
-  });
-});
+    const a = encodeAustraliaPost("11", "12345678")
+    const b = encodeAustraliaPost("11", "87654321")
+    expect(a).not.toEqual(b)
+  })
+})
 
 describe("Japan Post 4-State", () => {
   it("encodes 7-digit zipcode", () => {
-    const bars = encodeJapanPost("1000001");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeJapanPost("1000001")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("strips dashes from zipcode", () => {
-    const a = encodeJapanPost("100-0001");
-    const b = encodeJapanPost("1000001");
-    expect(a).toEqual(b);
-  });
+    const a = encodeJapanPost("100-0001")
+    const b = encodeJapanPost("1000001")
+    expect(a).toEqual(b)
+  })
 
   it("encodes zipcode with address", () => {
-    const bars = encodeJapanPost("1000001", "1-2-3");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeJapanPost("1000001", "1-2-3")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("all values are valid states", () => {
-    const bars = encodeJapanPost("1000001");
+    const bars = encodeJapanPost("1000001")
     for (const b of bars) {
-      expect(["T", "A", "D", "F"]).toContain(b);
+      expect(["T", "A", "D", "F"]).toContain(b)
     }
-  });
+  })
 
   it("throws on invalid zipcode", () => {
-    expect(() => encodeJapanPost("12345")).toThrow();
-  });
+    expect(() => encodeJapanPost("12345")).toThrow()
+  })
 
   it("throws on invalid address characters", () => {
-    expect(() => encodeJapanPost("1000001", "!@#")).toThrow();
-  });
+    expect(() => encodeJapanPost("1000001", "!@#")).toThrow()
+  })
 
   it("accepts alphabetic characters in address", () => {
-    const bars = encodeJapanPost("1000001", "A");
-    expect(bars.length).toBeGreaterThan(0);
+    const bars = encodeJapanPost("1000001", "A")
+    expect(bars.length).toBeGreaterThan(0)
     for (const b of bars) {
-      expect(["T", "A", "D", "F"]).toContain(b);
+      expect(["T", "A", "D", "F"]).toContain(b)
     }
-  });
+  })
 
   it("starts with F,D and ends with D,F", () => {
-    const bars = encodeJapanPost("1000001");
-    expect(bars[0]).toBe("F");
-    expect(bars[1]).toBe("D");
-    expect(bars[bars.length - 2]).toBe("D");
-    expect(bars[bars.length - 1]).toBe("F");
-  });
+    const bars = encodeJapanPost("1000001")
+    expect(bars[0]).toBe("F")
+    expect(bars[1]).toBe("D")
+    expect(bars[bars.length - 2]).toBe("D")
+    expect(bars[bars.length - 1]).toBe("F")
+  })
 
   it("produces correct barcode length (start + 21*3 bars + stop)", () => {
     // 2 start bars + 21 chars * 3 bars each + 2 stop bars = 67 bars
-    const bars = encodeJapanPost("1000001");
-    expect(bars.length).toBe(2 + 21 * 3 + 2);
-  });
+    const bars = encodeJapanPost("1000001")
+    expect(bars.length).toBe(2 + 21 * 3 + 2)
+  })
 
   it("uses mod 19 check digit", () => {
     // Two different inputs should produce different check digits
-    const a = encodeJapanPost("1000001");
-    const b = encodeJapanPost("1000002");
+    const a = encodeJapanPost("1000001")
+    const b = encodeJapanPost("1000002")
     // They should differ (different data → different check)
-    expect(a).not.toEqual(b);
-  });
-});
+    expect(a).not.toEqual(b)
+  })
+})

--- a/test/encoders-aztec-tables.test.ts
+++ b/test/encoders-aztec-tables.test.ts
@@ -6,7 +6,7 @@
  * directly.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   Mode,
   MODE_BITS,
@@ -20,19 +20,19 @@ import {
   GF_POLY,
   PUNCT_PAIRS,
   CHAR_TABLE,
-} from "../src/encoders/aztec/tables";
+} from "../src/encoders/aztec/tables"
 
-const ALL_MODES = [Mode.Upper, Mode.Lower, Mode.Mixed, Mode.Punct, Mode.Digit];
-const MODE_NAMES = ["Upper", "Lower", "Mixed", "Punct", "Digit"];
+const ALL_MODES = [Mode.Upper, Mode.Lower, Mode.Mixed, Mode.Punct, Mode.Digit]
+const MODE_NAMES = ["Upper", "Lower", "Mixed", "Punct", "Digit"]
 
 describe("Aztec mode bits", () => {
   it("uses 4 bits for Digit and 5 for every other mode", () => {
-    expect(MODE_BITS[Mode.Digit]).toBe(4);
+    expect(MODE_BITS[Mode.Digit]).toBe(4)
     for (const mode of [Mode.Upper, Mode.Lower, Mode.Mixed, Mode.Punct]) {
-      expect(MODE_BITS[mode], MODE_NAMES[mode]).toBe(5);
+      expect(MODE_BITS[mode], MODE_NAMES[mode]).toBe(5)
     }
-  });
-});
+  })
+})
 
 describe("getLatchSequence", () => {
   it("returns an empty sequence when the mode is unchanged", () => {
@@ -41,9 +41,9 @@ describe("getLatchSequence", () => {
         codes: [],
         modes: [],
         totalBits: 0,
-      });
+      })
     }
-  });
+  })
 
   const expected: Array<[Mode, Mode, number[], Mode[], number]> = [
     // From Upper
@@ -71,200 +71,198 @@ describe("getLatchSequence", () => {
     [Mode.Digit, Mode.Lower, [14, 28], [Mode.Digit, Mode.Upper], 9],
     [Mode.Digit, Mode.Mixed, [14, 29], [Mode.Digit, Mode.Upper], 9],
     [Mode.Digit, Mode.Punct, [14, 29, 30], [Mode.Digit, Mode.Upper, Mode.Mixed], 14],
-  ];
+  ]
 
   for (const [from, to, codes, modes, totalBits] of expected) {
     it(`${MODE_NAMES[from]} → ${MODE_NAMES[to]}`, () => {
-      expect(getLatchSequence(from, to)).toEqual({ codes, modes, totalBits });
-    });
+      expect(getLatchSequence(from, to)).toEqual({ codes, modes, totalBits })
+    })
   }
 
   it("covers every ordered pair of modes", () => {
-    expect(expected).toHaveLength(20); // 5 modes × 4 targets
-  });
+    expect(expected).toHaveLength(20) // 5 modes × 4 targets
+  })
 
   it("reports totalBits consistent with the modes each code is emitted in", () => {
     for (const [from, to] of expected) {
-      const seq = getLatchSequence(from, to);
-      const sum = seq.modes.reduce((acc, mode) => acc + MODE_BITS[mode], 0);
-      expect(seq.totalBits, `${MODE_NAMES[from]} → ${MODE_NAMES[to]}`).toBe(sum);
+      const seq = getLatchSequence(from, to)
+      const sum = seq.modes.reduce((acc, mode) => acc + MODE_BITS[mode], 0)
+      expect(seq.totalBits, `${MODE_NAMES[from]} → ${MODE_NAMES[to]}`).toBe(sum)
     }
-  });
+  })
 
   it("emits one mode entry per code", () => {
     for (const [from, to] of expected) {
-      const seq = getLatchSequence(from, to);
-      expect(seq.codes.length, `${MODE_NAMES[from]} → ${MODE_NAMES[to]}`).toBe(seq.modes.length);
+      const seq = getLatchSequence(from, to)
+      expect(seq.codes.length, `${MODE_NAMES[from]} → ${MODE_NAMES[to]}`).toBe(seq.modes.length)
     }
-  });
+  })
 
   it("starts every sequence in the source mode", () => {
     for (const [from, to] of expected) {
-      expect(getLatchSequence(from, to).modes[0], MODE_NAMES[from]).toBe(from);
+      expect(getLatchSequence(from, to).modes[0], MODE_NAMES[from]).toBe(from)
     }
-  });
+  })
 
   it("keeps every latch code within its mode's bit width", () => {
     for (const [from, to] of expected) {
-      const seq = getLatchSequence(from, to);
+      const seq = getLatchSequence(from, to)
       for (const [i, code] of seq.codes.entries()) {
-        const bits = MODE_BITS[seq.modes[i]!];
-        expect(code, `${MODE_NAMES[from]} → ${MODE_NAMES[to]} code ${code}`).toBeLessThan(
-          1 << bits,
-        );
+        const bits = MODE_BITS[seq.modes[i]!]
+        expect(code, `${MODE_NAMES[from]} → ${MODE_NAMES[to]} code ${code}`).toBeLessThan(1 << bits)
       }
     }
-  });
-});
+  })
+})
 
 describe("Aztec shift and binary-shift tables", () => {
   it("defines a shift-to-Punct code for the modes that have one", () => {
     for (const mode of [Mode.Upper, Mode.Lower, Mode.Mixed, Mode.Digit]) {
-      const code = SHIFT_TO_PUNCT[mode];
+      const code = SHIFT_TO_PUNCT[mode]
       if (code !== undefined) {
-        expect(code, MODE_NAMES[mode]).toBeLessThan(1 << MODE_BITS[mode]);
+        expect(code, MODE_NAMES[mode]).toBeLessThan(1 << MODE_BITS[mode])
       }
     }
-  });
+  })
 
   it("defines a binary shift code within each mode's bit width", () => {
     for (const mode of ALL_MODES) {
-      const bs = BINARY_SHIFT[mode];
+      const bs = BINARY_SHIFT[mode]
       if (bs) {
-        expect(bs.bits, MODE_NAMES[mode]).toBe(MODE_BITS[mode]);
-        expect(bs.code, MODE_NAMES[mode]).toBeLessThan(1 << bs.bits);
+        expect(bs.bits, MODE_NAMES[mode]).toBe(MODE_BITS[mode])
+        expect(bs.code, MODE_NAMES[mode]).toBeLessThan(1 << bs.bits)
       }
     }
-  });
-});
+  })
+})
 
 describe("Aztec character tables", () => {
   it("provides a table per mode", () => {
-    expect(CHAR_TABLE).toHaveLength(5);
-  });
+    expect(CHAR_TABLE).toHaveLength(5)
+  })
 
   it("keeps every character value inside its mode's bit width", () => {
     for (const [index, table] of CHAR_TABLE.entries()) {
-      const mode = ALL_MODES[index]!;
+      const mode = ALL_MODES[index]!
       for (const [ch, value] of Object.entries(table)) {
-        expect(value, `${MODE_NAMES[index]} "${ch}"`).toBeLessThan(1 << MODE_BITS[mode]);
-        expect(value, `${MODE_NAMES[index]} "${ch}"`).toBeGreaterThanOrEqual(0);
+        expect(value, `${MODE_NAMES[index]} "${ch}"`).toBeLessThan(1 << MODE_BITS[mode])
+        expect(value, `${MODE_NAMES[index]} "${ch}"`).toBeGreaterThanOrEqual(0)
       }
     }
-  });
+  })
 
   it("maps punctuation pairs to Punct-mode values", () => {
-    expect(PUNCT_PAIRS.size).toBeGreaterThan(0);
+    expect(PUNCT_PAIRS.size).toBeGreaterThan(0)
     for (const [pair, value] of PUNCT_PAIRS) {
-      expect(pair, `pair "${pair}"`).toHaveLength(2);
-      expect(value, `pair "${pair}"`).toBeLessThan(1 << MODE_BITS[Mode.Punct]);
+      expect(pair, `pair "${pair}"`).toHaveLength(2)
+      expect(value, `pair "${pair}"`).toBeLessThan(1 << MODE_BITS[Mode.Punct])
     }
-  });
+  })
 
   it("includes the common sentence-punctuation pairs", () => {
     for (const pair of [". ", ", "]) {
-      expect(PUNCT_PAIRS.has(pair), pair).toBe(true);
+      expect(PUNCT_PAIRS.has(pair), pair).toBe(true)
     }
-  });
-});
+  })
+})
 
 describe("Aztec symbol capacity tables", () => {
   it("returns the specified word size per layer count", () => {
-    expect(getWordSize(1)).toBe(6);
-    expect(getWordSize(2)).toBe(6);
-    expect(getWordSize(3)).toBe(8);
-    expect(getWordSize(8)).toBe(8);
-    expect(getWordSize(9)).toBe(10);
-    expect(getWordSize(22)).toBe(10);
-    expect(getWordSize(23)).toBe(12);
-    expect(getWordSize(32)).toBe(12);
-  });
+    expect(getWordSize(1)).toBe(6)
+    expect(getWordSize(2)).toBe(6)
+    expect(getWordSize(3)).toBe(8)
+    expect(getWordSize(8)).toBe(8)
+    expect(getWordSize(9)).toBe(10)
+    expect(getWordSize(22)).toBe(10)
+    expect(getWordSize(23)).toBe(12)
+    expect(getWordSize(32)).toBe(12)
+  })
 
   it("increases word size monotonically with layers", () => {
     for (let layers = 2; layers <= 32; layers++) {
       expect(getWordSize(layers), `layers ${layers}`).toBeGreaterThanOrEqual(
         getWordSize(layers - 1),
-      );
+      )
     }
-  });
+  })
 
   it("computes the base matrix size for compact and full symbols", () => {
-    expect(getBaseMatrixSize(1, true)).toBe(15);
-    expect(getBaseMatrixSize(4, true)).toBe(27);
-    expect(getBaseMatrixSize(1, false)).toBe(18);
-    expect(getBaseMatrixSize(32, false)).toBe(142);
-  });
+    expect(getBaseMatrixSize(1, true)).toBe(15)
+    expect(getBaseMatrixSize(4, true)).toBe(27)
+    expect(getBaseMatrixSize(1, false)).toBe(18)
+    expect(getBaseMatrixSize(32, false)).toBe(142)
+  })
 
   it("adds reference grid lines to full-range module counts", () => {
     // Compact symbols carry no reference grid
     for (const layers of [1, 2, 3, 4]) {
       expect(getModuleCount(layers, true), `compact ${layers}`).toBe(
         getBaseMatrixSize(layers, true),
-      );
+      )
     }
     // Full-range symbols are always larger than their base size
     for (const layers of [1, 8, 16, 32]) {
       expect(getModuleCount(layers, false), `full ${layers}`).toBeGreaterThan(
         getBaseMatrixSize(layers, false),
-      );
+      )
     }
-  });
+  })
 
   it("produces odd module counts (symbols are centred on a bullseye)", () => {
     for (const layers of [1, 2, 3, 4]) {
-      expect(getModuleCount(layers, true) % 2, `compact ${layers}`).toBe(1);
+      expect(getModuleCount(layers, true) % 2, `compact ${layers}`).toBe(1)
     }
     for (const layers of [1, 5, 10, 20, 32]) {
-      expect(getModuleCount(layers, false) % 2, `full ${layers}`).toBe(1);
+      expect(getModuleCount(layers, false) % 2, `full ${layers}`).toBe(1)
     }
-  });
+  })
 
   it("computes total bit capacity from the layer count", () => {
-    expect(getTotalBitCapacity(1, true)).toBe((88 + 16) * 1);
-    expect(getTotalBitCapacity(4, true)).toBe((88 + 64) * 4);
-    expect(getTotalBitCapacity(1, false)).toBe((112 + 16) * 1);
-    expect(getTotalBitCapacity(32, false)).toBe((112 + 512) * 32);
-  });
+    expect(getTotalBitCapacity(1, true)).toBe((88 + 16) * 1)
+    expect(getTotalBitCapacity(4, true)).toBe((88 + 64) * 4)
+    expect(getTotalBitCapacity(1, false)).toBe((112 + 16) * 1)
+    expect(getTotalBitCapacity(32, false)).toBe((112 + 512) * 32)
+  })
 
   it("grows capacity monotonically with layers", () => {
     for (const compact of [true, false]) {
-      const max = compact ? 4 : 32;
+      const max = compact ? 4 : 32
       for (let layers = 2; layers <= max; layers++) {
         expect(
           getTotalBitCapacity(layers, compact),
           `${compact ? "compact" : "full"} ${layers}`,
-        ).toBeGreaterThan(getTotalBitCapacity(layers - 1, compact));
+        ).toBeGreaterThan(getTotalBitCapacity(layers - 1, compact))
       }
     }
-  });
+  })
 
   it("gives full-range symbols more capacity than compact at equal layers", () => {
     for (const layers of [1, 2, 3, 4]) {
       expect(getTotalBitCapacity(layers, false), `layers ${layers}`).toBeGreaterThan(
         getTotalBitCapacity(layers, true),
-      );
+      )
     }
-  });
-});
+  })
+})
 
 describe("Aztec Galois field polynomials", () => {
   it("defines a primitive polynomial for every word size in use", () => {
     for (const wordSize of [4, 6, 8, 10, 12]) {
-      expect(GF_POLY[wordSize], `word size ${wordSize}`).toBeGreaterThan(0);
+      expect(GF_POLY[wordSize], `word size ${wordSize}`).toBeGreaterThan(0)
     }
-  });
+  })
 
   it("uses polynomials of the correct degree", () => {
     for (const wordSize of [4, 6, 8, 10, 12]) {
-      const poly = GF_POLY[wordSize]!;
+      const poly = GF_POLY[wordSize]!
       // A primitive polynomial for GF(2^n) has degree n → bit n is set
-      expect(poly >> wordSize, `word size ${wordSize}`).toBe(1);
+      expect(poly >> wordSize, `word size ${wordSize}`).toBe(1)
     }
-  });
+  })
 
   it("covers every word size the size table can produce", () => {
     for (let layers = 1; layers <= 32; layers++) {
-      expect(GF_POLY[getWordSize(layers)], `layers ${layers}`).toBeDefined();
+      expect(GF_POLY[getWordSize(layers)], `layers ${layers}`).toBeDefined()
     }
-  });
-});
+  })
+})

--- a/test/encoders-codabar.test.ts
+++ b/test/encoders-codabar.test.ts
@@ -1,124 +1,124 @@
-import { describe, expect, it } from "vitest";
-import { encodeCodabar } from "../src/encoders/codabar";
+import { describe, expect, it } from "vitest"
+import { encodeCodabar } from "../src/encoders/codabar"
 
 describe("encodeCodabar", () => {
   // --- Valid encoding ---
 
   it("encodes a simple numeric string", () => {
-    const bars = encodeCodabar("12345");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeCodabar("12345")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it("encodes a single digit", () => {
-    const bars = encodeCodabar("0");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCodabar("0")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes special data characters (-, $, :, /, ., +)", () => {
-    const bars = encodeCodabar("1-2$3:4/5.6+7");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCodabar("1-2$3:4/5.6+7")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("uses default start/stop A-A when no start/stop in text", () => {
-    const bars = encodeCodabar("123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCodabar("123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Start/stop characters in text ---
 
   it("recognizes start/stop characters in text", () => {
-    const bars = encodeCodabar("A123B");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCodabar("A123B")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("supports all start/stop pairs (A, B, C, D)", () => {
-    const barsA = encodeCodabar("A123A");
-    const barsB = encodeCodabar("B123B");
-    const barsC = encodeCodabar("C123C");
-    const barsD = encodeCodabar("D123D");
-    expect(barsA.length).toBeGreaterThan(0);
-    expect(barsB.length).toBeGreaterThan(0);
-    expect(barsC.length).toBeGreaterThan(0);
-    expect(barsD.length).toBeGreaterThan(0);
+    const barsA = encodeCodabar("A123A")
+    const barsB = encodeCodabar("B123B")
+    const barsC = encodeCodabar("C123C")
+    const barsD = encodeCodabar("D123D")
+    expect(barsA.length).toBeGreaterThan(0)
+    expect(barsB.length).toBeGreaterThan(0)
+    expect(barsC.length).toBeGreaterThan(0)
+    expect(barsD.length).toBeGreaterThan(0)
     // Different start/stop chars should produce different patterns
-    expect(barsA).not.toEqual(barsB);
-  });
+    expect(barsA).not.toEqual(barsB)
+  })
 
   it("handles lowercase start/stop characters (case-insensitive)", () => {
-    const barsUpper = encodeCodabar("A123B");
-    const barsLower = encodeCodabar("a123b");
-    expect(barsUpper).toEqual(barsLower);
-  });
+    const barsUpper = encodeCodabar("A123B")
+    const barsLower = encodeCodabar("a123b")
+    expect(barsUpper).toEqual(barsLower)
+  })
 
   // --- Custom start/stop via options ---
 
   it("uses custom start/stop from options", () => {
-    const bars = encodeCodabar("123", { start: "B", stop: "C" });
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCodabar("123", { start: "B", stop: "C" })
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("start/stop in text takes precedence over options", () => {
-    const barsText = encodeCodabar("A123D");
+    const barsText = encodeCodabar("A123D")
     // When text has start/stop, options are ignored
-    expect(barsText.length).toBeGreaterThan(0);
-  });
+    expect(barsText.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1 narrow, 3 wide)", () => {
-    const bars = encodeCodabar("12345");
+    const bars = encodeCodabar("12345")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(3);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(3)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("output length matches expected structure", () => {
     // For data of length N (without start/stop in text):
     // start(7) + gap(1) + N * (pattern(7) + gap(1)) + stop(7)
     // = 7 + 1 + N*8 + 7 = 15 + N*8
-    const bars = encodeCodabar("123");
-    expect(bars.length).toBe(15 + 3 * 8);
-  });
+    const bars = encodeCodabar("123")
+    expect(bars.length).toBe(15 + 3 * 8)
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeCodabar("123");
-    const bars2 = encodeCodabar("456");
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeCodabar("123")
+    const bars2 = encodeCodabar("456")
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same input produces same output", () => {
-    const bars1 = encodeCodabar("9876");
-    const bars2 = encodeCodabar("9876");
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeCodabar("9876")
+    const bars2 = encodeCodabar("9876")
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on empty input", () => {
-    expect(() => encodeCodabar("")).toThrow("must not be empty");
-  });
+    expect(() => encodeCodabar("")).toThrow("must not be empty")
+  })
 
   it("throws on invalid data characters", () => {
-    expect(() => encodeCodabar("A12@3A")).toThrow("Invalid Codabar character");
-  });
+    expect(() => encodeCodabar("A12@3A")).toThrow("Invalid Codabar character")
+  })
 
   it("throws on invalid start character in options", () => {
-    expect(() => encodeCodabar("123", { start: "X" })).toThrow("Invalid Codabar start character");
-  });
+    expect(() => encodeCodabar("123", { start: "X" })).toThrow("Invalid Codabar start character")
+  })
 
   it("throws on invalid stop character in options", () => {
-    expect(() => encodeCodabar("123", { stop: "Z" })).toThrow("Invalid Codabar stop character");
-  });
+    expect(() => encodeCodabar("123", { stop: "Z" })).toThrow("Invalid Codabar stop character")
+  })
 
   // --- Edge cases ---
 
   it("encodes data that contains only special characters", () => {
-    const bars = encodeCodabar("-.$+:/");
-    expect(bars.length).toBeGreaterThan(0);
-  });
-});
+    const bars = encodeCodabar("-.$+:/")
+    expect(bars.length).toBeGreaterThan(0)
+  })
+})

--- a/test/encoders-codablock-f.test.ts
+++ b/test/encoders-codablock-f.test.ts
@@ -1,53 +1,53 @@
-import { describe, expect, it } from "vitest";
-import { encodeCodablockF } from "../src/encoders/codablock-f";
+import { describe, expect, it } from "vitest"
+import { encodeCodablockF } from "../src/encoders/codablock-f"
 
 describe("Codablock F", () => {
   it("encodes short text", () => {
-    const result = encodeCodablockF("Hello");
-    expect(result.matrix.length).toBeGreaterThan(0);
-    expect(result.rows).toBeGreaterThan(0);
-    expect(result.cols).toBeGreaterThan(0);
-  });
+    const result = encodeCodablockF("Hello")
+    expect(result.matrix.length).toBeGreaterThan(0)
+    expect(result.rows).toBeGreaterThan(0)
+    expect(result.cols).toBeGreaterThan(0)
+  })
 
   it("produces boolean matrix", () => {
-    const result = encodeCodablockF("Test");
+    const result = encodeCodablockF("Test")
     for (const row of result.matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("all rows have same width", () => {
-    const result = encodeCodablockF("Hello World Test Data");
-    const widths = result.matrix.map((r) => r.length);
-    const unique = new Set(widths);
-    expect(unique.size).toBe(1);
-  });
+    const result = encodeCodablockF("Hello World Test Data")
+    const widths = result.matrix.map((r) => r.length)
+    const unique = new Set(widths)
+    expect(unique.size).toBe(1)
+  })
 
   it("more data produces more rows", () => {
-    const short = encodeCodablockF("Hi");
-    const long = encodeCodablockF("Hello World This Is A Longer Text");
-    expect(long.rows).toBeGreaterThan(short.rows);
-  });
+    const short = encodeCodablockF("Hi")
+    const long = encodeCodablockF("Hello World This Is A Longer Text")
+    expect(long.rows).toBeGreaterThan(short.rows)
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeCodablockF("")).toThrow();
-  });
+    expect(() => encodeCodablockF("")).toThrow()
+  })
 
   it("throws on non-encodable characters", () => {
-    expect(() => encodeCodablockF("\x80")).toThrow();
-  });
+    expect(() => encodeCodablockF("\x80")).toThrow()
+  })
 
   it("encodes control characters via Code A", () => {
-    const result = encodeCodablockF("\x01\x02\x03");
-    expect(result.matrix.length).toBeGreaterThan(0);
-    expect(result.rows).toBeGreaterThan(0);
-  });
+    const result = encodeCodablockF("\x01\x02\x03")
+    expect(result.matrix.length).toBeGreaterThan(0)
+    expect(result.rows).toBeGreaterThan(0)
+  })
 
   it("respects column count", () => {
-    const r1 = encodeCodablockF("Hello World", { columns: 4 });
-    const r2 = encodeCodablockF("Hello World", { columns: 8 });
-    expect(r1.rows).toBeGreaterThan(r2.rows);
-  });
-});
+    const r1 = encodeCodablockF("Hello World", { columns: 4 })
+    const r2 = encodeCodablockF("Hello World", { columns: 8 })
+    expect(r1.rows).toBeGreaterThan(r2.rows)
+  })
+})

--- a/test/encoders-code11.test.ts
+++ b/test/encoders-code11.test.ts
@@ -1,124 +1,124 @@
-import { describe, expect, it } from "vitest";
-import { encodeCode11 } from "../src/encoders/code11";
+import { describe, expect, it } from "vitest"
+import { encodeCode11 } from "../src/encoders/code11"
 
 describe("encodeCode11", () => {
   // --- Valid encoding ---
 
   it("encodes a simple numeric string", () => {
-    const bars = encodeCode11("12345");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeCode11("12345")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it("encodes a single digit", () => {
-    const bars = encodeCode11("0");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode11("0")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes the dash character", () => {
-    const bars = encodeCode11("123-456");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode11("123-456")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes all valid characters (0-9 and -)", () => {
-    const bars = encodeCode11("0123456789-");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode11("0123456789-")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1 narrow, 2 wide)", () => {
-    const bars = encodeCode11("12345");
+    const bars = encodeCode11("12345")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(2);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(2)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   // --- Check digit behavior ---
 
   it("includes one check digit (C) for data length <= 10", () => {
     // Data length 5, <= 10, so only C check digit
     // Structure: start(6) + (5 data + 1 check) * 6 + stop(5) = 6 + 36 + 5 = 47
-    const bars = encodeCode11("12345");
-    expect(bars.length).toBe(47);
-  });
+    const bars = encodeCode11("12345")
+    expect(bars.length).toBe(47)
+  })
 
   it("includes two check digits (C and K) for data length > 10", () => {
     // Data length 11, > 10, so C and K check digits
     // Structure: start(6) + (11 data + 2 checks) * 6 + stop(5) = 6 + 78 + 5 = 89
-    const bars = encodeCode11("12345678901");
-    expect(bars.length).toBe(89);
-  });
+    const bars = encodeCode11("12345678901")
+    expect(bars.length).toBe(89)
+  })
 
   it("data length exactly 10 gets only one check digit", () => {
     // Data length 10, <= 10, so only C
     // Structure: start(6) + (10 data + 1 check) * 6 + stop(5) = 6 + 66 + 5 = 77
-    const bars = encodeCode11("1234567890");
-    expect(bars.length).toBe(77);
-  });
+    const bars = encodeCode11("1234567890")
+    expect(bars.length).toBe(77)
+  })
 
   it("data length 11 gets two check digits", () => {
     // Structure: start(6) + (11 data + 2 checks) * 6 + stop(5) = 6 + 78 + 5 = 89
-    const bars = encodeCode11("12345678901");
-    expect(bars.length).toBe(89);
-  });
+    const bars = encodeCode11("12345678901")
+    expect(bars.length).toBe(89)
+  })
 
   it("output with more data is longer", () => {
-    const short = encodeCode11("1");
-    const long = encodeCode11("12345");
-    expect(long.length).toBeGreaterThan(short.length);
-  });
+    const short = encodeCode11("1")
+    const long = encodeCode11("12345")
+    expect(long.length).toBeGreaterThan(short.length)
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeCode11("123");
-    const bars2 = encodeCode11("456");
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeCode11("123")
+    const bars2 = encodeCode11("456")
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same input produces same output", () => {
-    const bars1 = encodeCode11("9876");
-    const bars2 = encodeCode11("9876");
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeCode11("9876")
+    const bars2 = encodeCode11("9876")
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on empty input", () => {
-    expect(() => encodeCode11("")).toThrow("must not be empty");
-  });
+    expect(() => encodeCode11("")).toThrow("must not be empty")
+  })
 
   it("throws on letters", () => {
-    expect(() => encodeCode11("ABC")).toThrow("Invalid Code 11 character");
-  });
+    expect(() => encodeCode11("ABC")).toThrow("Invalid Code 11 character")
+  })
 
   it("throws on invalid special characters", () => {
-    expect(() => encodeCode11("12.34")).toThrow("Invalid Code 11 character");
-    expect(() => encodeCode11("12+34")).toThrow("Invalid Code 11 character");
-    expect(() => encodeCode11("12$34")).toThrow("Invalid Code 11 character");
-  });
+    expect(() => encodeCode11("12.34")).toThrow("Invalid Code 11 character")
+    expect(() => encodeCode11("12+34")).toThrow("Invalid Code 11 character")
+    expect(() => encodeCode11("12$34")).toThrow("Invalid Code 11 character")
+  })
 
   it("throws on space character", () => {
-    expect(() => encodeCode11("12 34")).toThrow("Invalid Code 11 character");
-  });
+    expect(() => encodeCode11("12 34")).toThrow("Invalid Code 11 character")
+  })
 
   // --- Edge cases ---
 
   it("encodes a string of only dashes", () => {
-    const bars = encodeCode11("---");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode11("---")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes a string of all zeros", () => {
-    const bars = encodeCode11("0000000000");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode11("0000000000")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes a long string (triggers K check digit)", () => {
-    const bars = encodeCode11("1234567890123456789");
-    expect(bars.length).toBeGreaterThan(0);
-  });
-});
+    const bars = encodeCode11("1234567890123456789")
+    expect(bars.length).toBeGreaterThan(0)
+  })
+})

--- a/test/encoders-code128-charset.test.ts
+++ b/test/encoders-code128-charset.test.ts
@@ -1,115 +1,113 @@
-import { describe, expect, it } from "vitest";
-import { encodeCode128 } from "../src/encoders/code128";
+import { describe, expect, it } from "vitest"
+import { encodeCode128 } from "../src/encoders/code128"
 
 describe("encodeCode128 — forced charset selection", () => {
   // --- Charset A ---
 
   it("charset A encodes uppercase letters and digits", () => {
-    const bars = encodeCode128("HELLO123", { charset: "A" });
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeCode128("HELLO123", { charset: "A" })
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it("charset A encodes control characters", () => {
     // \x01 = SOH, \x02 = STX — both valid in Code 128A
-    const bars = encodeCode128("\x01\x02\x03", { charset: "A" });
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode128("\x01\x02\x03", { charset: "A" })
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("charset A throws on lowercase letters", () => {
-    expect(() => encodeCode128("hello", { charset: "A" })).toThrow("not encodable in Code 128A");
-  });
+    expect(() => encodeCode128("hello", { charset: "A" })).toThrow("not encodable in Code 128A")
+  })
 
   it("charset A throws on characters beyond ASCII 95", () => {
     // '`' is ASCII 96, not in charset A range
-    expect(() => encodeCode128("`", { charset: "A" })).toThrow("not encodable in Code 128A");
-  });
+    expect(() => encodeCode128("`", { charset: "A" })).toThrow("not encodable in Code 128A")
+  })
 
   // --- Charset B ---
 
   it("charset B encodes printable ASCII (lowercase and uppercase)", () => {
-    const bars = encodeCode128("Hello World!", { charset: "B" });
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode128("Hello World!", { charset: "B" })
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("charset B encodes all printable ASCII characters", () => {
-    const bars = encodeCode128("AaBb12!@#$%^&*()", { charset: "B" });
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode128("AaBb12!@#$%^&*()", { charset: "B" })
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("charset B throws on control characters", () => {
-    expect(() => encodeCode128("\x01Hello", { charset: "B" })).toThrow(
-      "not encodable in Code 128B",
-    );
-  });
+    expect(() => encodeCode128("\x01Hello", { charset: "B" })).toThrow("not encodable in Code 128B")
+  })
 
   // --- Charset C ---
 
   it("charset C encodes even-length digit strings", () => {
-    const bars = encodeCode128("123456", { charset: "C" });
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode128("123456", { charset: "C" })
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("charset C encodes digit pairs 00-99", () => {
-    const bars = encodeCode128("00990102", { charset: "C" });
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode128("00990102", { charset: "C" })
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("charset C throws on odd-length digit strings", () => {
-    expect(() => encodeCode128("12345", { charset: "C" })).toThrow("even number of digits");
-  });
+    expect(() => encodeCode128("12345", { charset: "C" })).toThrow("even number of digits")
+  })
 
   it("charset C throws on non-digit characters", () => {
-    expect(() => encodeCode128("12AB56", { charset: "C" })).toThrow("not encodable in Code 128C");
-  });
+    expect(() => encodeCode128("12AB56", { charset: "C" })).toThrow("not encodable in Code 128C")
+  })
 
   it("charset C throws on letters", () => {
-    expect(() => encodeCode128("Hello", { charset: "C" })).toThrow("not encodable in Code 128C");
-  });
+    expect(() => encodeCode128("Hello", { charset: "C" })).toThrow("not encodable in Code 128C")
+  })
 
   // --- Auto mode (default) ---
 
   it("auto mode still works as before (no options)", () => {
-    const bars = encodeCode128("Hello World");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode128("Hello World")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("auto mode still works as before (explicit auto)", () => {
-    const bars = encodeCode128("Hello World", { charset: "auto" });
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode128("Hello World", { charset: "auto" })
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("auto mode produces same result as no options", () => {
-    const noOpts = encodeCode128("Hello World");
-    const autoOpts = encodeCode128("Hello World", { charset: "auto" });
-    expect(noOpts).toEqual(autoOpts);
-  });
+    const noOpts = encodeCode128("Hello World")
+    const autoOpts = encodeCode128("Hello World", { charset: "auto" })
+    expect(noOpts).toEqual(autoOpts)
+  })
 
   // --- Different charsets produce different patterns ---
 
   it("different charsets produce different bar patterns for same input", () => {
     // "AB" is encodable in both A and B but with different start codes
-    const barsA = encodeCode128("AB", { charset: "A" });
-    const barsB = encodeCode128("AB", { charset: "B" });
+    const barsA = encodeCode128("AB", { charset: "A" })
+    const barsB = encodeCode128("AB", { charset: "B" })
     // They should differ because they use different start codes (START_A vs START_B),
     // which leads to different checksums
-    expect(barsA).not.toEqual(barsB);
-  });
+    expect(barsA).not.toEqual(barsB)
+  })
 
   it("charset C is more compact for pure digit strings", () => {
     // Code 128C encodes digit pairs, so it should produce fewer bars
-    const barsB = encodeCode128("12345678", { charset: "B" });
-    const barsC = encodeCode128("12345678", { charset: "C" });
-    expect(barsC.length).toBeLessThan(barsB.length);
-  });
+    const barsB = encodeCode128("12345678", { charset: "B" })
+    const barsC = encodeCode128("12345678", { charset: "C" })
+    expect(barsC.length).toBeLessThan(barsB.length)
+  })
 
   // --- Deterministic output ---
 
   it("same input and charset produce same output", () => {
-    const bars1 = encodeCode128("TEST", { charset: "A" });
-    const bars2 = encodeCode128("TEST", { charset: "A" });
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeCode128("TEST", { charset: "A" })
+    const bars2 = encodeCode128("TEST", { charset: "A" })
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Bar width validation ---
 
@@ -118,15 +116,15 @@ describe("encodeCode128 — forced charset selection", () => {
       { charset: "A" as const, text: "HELLO" },
       { charset: "B" as const, text: "Hello" },
       { charset: "C" as const, text: "123456" },
-    ];
+    ]
 
     for (const { charset, text } of charsets) {
-      const bars = encodeCode128(text, { charset });
+      const bars = encodeCode128(text, { charset })
       for (const w of bars) {
-        expect(w).toBeGreaterThanOrEqual(1);
-        expect(w).toBeLessThanOrEqual(4);
-        expect(Number.isInteger(w)).toBe(true);
+        expect(w).toBeGreaterThanOrEqual(1)
+        expect(w).toBeLessThanOrEqual(4)
+        expect(Number.isInteger(w)).toBe(true)
       }
     }
-  });
-});
+  })
+})

--- a/test/encoders-code16k.test.ts
+++ b/test/encoders-code16k.test.ts
@@ -1,43 +1,43 @@
-import { describe, expect, it } from "vitest";
-import { encodeCode16K } from "../src/encoders/code16k";
+import { describe, expect, it } from "vitest"
+import { encodeCode16K } from "../src/encoders/code16k"
 
 describe("Code 16K", () => {
   it("encodes short text", () => {
-    const result = encodeCode16K("Hello");
-    expect(result.matrix.length).toBeGreaterThanOrEqual(2);
-    expect(result.rows).toBeGreaterThanOrEqual(2);
-  });
+    const result = encodeCode16K("Hello")
+    expect(result.matrix.length).toBeGreaterThanOrEqual(2)
+    expect(result.rows).toBeGreaterThanOrEqual(2)
+  })
 
   it("produces boolean matrix", () => {
-    const result = encodeCode16K("Test");
+    const result = encodeCode16K("Test")
     for (const row of result.matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("minimum 2 rows", () => {
-    const result = encodeCode16K("Hi");
-    expect(result.rows).toBeGreaterThanOrEqual(2);
-  });
+    const result = encodeCode16K("Hi")
+    expect(result.rows).toBeGreaterThanOrEqual(2)
+  })
 
   it("maximum 16 rows", () => {
-    const result = encodeCode16K("A".repeat(70));
-    expect(result.rows).toBeLessThanOrEqual(16);
-  });
+    const result = encodeCode16K("A".repeat(70))
+    expect(result.rows).toBeLessThanOrEqual(16)
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeCode16K("")).toThrow();
-  });
+    expect(() => encodeCode16K("")).toThrow()
+  })
 
   it("throws on non-printable", () => {
-    expect(() => encodeCode16K("\x01")).toThrow();
-  });
+    expect(() => encodeCode16K("\x01")).toThrow()
+  })
 
   it("all rows same width", () => {
-    const result = encodeCode16K("Hello World");
-    const widths = new Set(result.matrix.map((r) => r.length));
-    expect(widths.size).toBe(1);
-  });
-});
+    const result = encodeCode16K("Hello World")
+    const widths = new Set(result.matrix.map((r) => r.length))
+    expect(widths.size).toBe(1)
+  })
+})

--- a/test/encoders-code39.test.ts
+++ b/test/encoders-code39.test.ts
@@ -1,166 +1,166 @@
-import { describe, expect, it } from "vitest";
-import { encodeCode39, encodeCode39Extended } from "../src/encoders/code39";
+import { describe, expect, it } from "vitest"
+import { encodeCode39, encodeCode39Extended } from "../src/encoders/code39"
 
 describe("encodeCode39", () => {
   // --- Valid encoding ---
 
   it("encodes a simple numeric string", () => {
-    const bars = encodeCode39("12345");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeCode39("12345")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it("encodes uppercase letters", () => {
-    const bars = encodeCode39("ABCXYZ");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode39("ABCXYZ")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes special characters (-, ., space, $, /, +, %)", () => {
-    const bars = encodeCode39("A-B.C $D/E+F%G");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode39("A-B.C $D/E+F%G")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes a single character", () => {
-    const bars = encodeCode39("A");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode39("A")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only positive integer widths (1 or 3 for bars/spaces, 1 for gaps)", () => {
-    const bars = encodeCode39("TEST");
+    const bars = encodeCode39("TEST")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(3);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(3)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("output length matches expected structure", () => {
     // For N data chars (no check digit):
     // start(9) + gap(1) + N*(pattern(9) + gap(1)) + stop(9) = 19 + N*10
-    const bars = encodeCode39("ABC");
+    const bars = encodeCode39("ABC")
     // 3 data chars: 19 + 3*10 = 49
-    expect(bars.length).toBe(49);
-  });
+    expect(bars.length).toBe(49)
+  })
 
   // --- Check digit calculation ---
 
   it("produces longer output with check digit enabled", () => {
-    const without = encodeCode39("CODE39");
-    const withCheck = encodeCode39("CODE39", { checkDigit: true });
+    const without = encodeCode39("CODE39")
+    const withCheck = encodeCode39("CODE39", { checkDigit: true })
     // With check digit: one extra character (9 pattern + 1 gap = 10 more elements)
-    expect(withCheck.length).toBe(without.length + 10);
-  });
+    expect(withCheck.length).toBe(without.length + 10)
+  })
 
   it("check digit does not change base encoding", () => {
-    const without = encodeCode39("1234");
-    const withCheck = encodeCode39("1234", { checkDigit: true });
+    const without = encodeCode39("1234")
+    const withCheck = encodeCode39("1234", { checkDigit: true })
     // The beginning of the encoding should be the same (start + first data chars)
     // start(9) + gap(1) = first 10 elements are identical
-    expect(withCheck.slice(0, 10)).toEqual(without.slice(0, 10));
-  });
+    expect(withCheck.slice(0, 10)).toEqual(without.slice(0, 10))
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeCode39("ABC");
-    const bars2 = encodeCode39("XYZ");
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeCode39("ABC")
+    const bars2 = encodeCode39("XYZ")
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same input produces same output", () => {
-    const bars1 = encodeCode39("HELLO");
-    const bars2 = encodeCode39("HELLO");
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeCode39("HELLO")
+    const bars2 = encodeCode39("HELLO")
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on empty input", () => {
-    expect(() => encodeCode39("")).toThrow("must not be empty");
-  });
+    expect(() => encodeCode39("")).toThrow("must not be empty")
+  })
 
   it("throws on lowercase letters (not in Code 39 charset)", () => {
-    expect(() => encodeCode39("abc")).toThrow("Invalid Code 39 character");
-  });
+    expect(() => encodeCode39("abc")).toThrow("Invalid Code 39 character")
+  })
 
   it("throws on star character (reserved for start/stop)", () => {
-    expect(() => encodeCode39("A*B")).toThrow("start/stop character");
-  });
+    expect(() => encodeCode39("A*B")).toThrow("start/stop character")
+  })
 
   it("throws on invalid characters", () => {
-    expect(() => encodeCode39("A@B")).toThrow("Invalid Code 39 character");
-    expect(() => encodeCode39("A#B")).toThrow("Invalid Code 39 character");
-  });
-});
+    expect(() => encodeCode39("A@B")).toThrow("Invalid Code 39 character")
+    expect(() => encodeCode39("A#B")).toThrow("Invalid Code 39 character")
+  })
+})
 
 describe("encodeCode39Extended", () => {
   // --- Valid encoding ---
 
   it("encodes lowercase letters via extended mapping", () => {
-    const bars = encodeCode39Extended("abc");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode39Extended("abc")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes mixed case text", () => {
-    const bars = encodeCode39Extended("Hello");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode39Extended("Hello")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes punctuation and special ASCII characters", () => {
-    const bars = encodeCode39Extended("test@123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode39Extended("test@123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes native Code 39 characters directly", () => {
     // Native chars like digits and uppercase should still work
-    const bars = encodeCode39Extended("ABC123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode39Extended("ABC123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1 or 3)", () => {
-    const bars = encodeCode39Extended("test");
+    const bars = encodeCode39Extended("test")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(3);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(3)
     }
-  });
+  })
 
   // --- Extended produces longer output due to character pairs ---
 
   it("lowercase input is longer than uppercase (2 Code 39 chars per lowercase)", () => {
-    const upper = encodeCode39Extended("A");
-    const lower = encodeCode39Extended("a");
+    const upper = encodeCode39Extended("A")
+    const lower = encodeCode39Extended("a")
     // 'a' maps to '+A' (2 code 39 chars), 'A' maps to 'A' (1 code 39 char)
-    expect(lower.length).toBeGreaterThan(upper.length);
-  });
+    expect(lower.length).toBeGreaterThan(upper.length)
+  })
 
   // --- Check digit works with extended ---
 
   it("supports check digit option", () => {
-    const without = encodeCode39Extended("abc");
-    const withCheck = encodeCode39Extended("abc", { checkDigit: true });
-    expect(withCheck.length).toBeGreaterThan(without.length);
-  });
+    const without = encodeCode39Extended("abc")
+    const withCheck = encodeCode39Extended("abc", { checkDigit: true })
+    expect(withCheck.length).toBeGreaterThan(without.length)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on empty input", () => {
-    expect(() => encodeCode39Extended("")).toThrow("must not be empty");
-  });
+    expect(() => encodeCode39Extended("")).toThrow("must not be empty")
+  })
 
   it("throws on non-ASCII characters (code > 127)", () => {
-    expect(() => encodeCode39Extended("\u00C9")).toThrow("only ASCII 0-127");
-  });
+    expect(() => encodeCode39Extended("\u00C9")).toThrow("only ASCII 0-127")
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeCode39Extended("hello");
-    const bars2 = encodeCode39Extended("world");
-    expect(bars1).not.toEqual(bars2);
-  });
-});
+    const bars1 = encodeCode39Extended("hello")
+    const bars2 = encodeCode39Extended("world")
+    expect(bars1).not.toEqual(bars2)
+  })
+})

--- a/test/encoders-code93.test.ts
+++ b/test/encoders-code93.test.ts
@@ -1,154 +1,154 @@
-import { describe, expect, it } from "vitest";
-import { encodeCode93, encodeCode93Extended } from "../src/encoders/code93";
+import { describe, expect, it } from "vitest"
+import { encodeCode93, encodeCode93Extended } from "../src/encoders/code93"
 
 describe("encodeCode93", () => {
   // --- Valid encoding ---
 
   it("encodes a simple numeric string", () => {
-    const bars = encodeCode93("12345");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeCode93("12345")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it("encodes uppercase letters", () => {
-    const bars = encodeCode93("ABCXYZ");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode93("ABCXYZ")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes special characters (-, ., space, $, /, +, %)", () => {
-    const bars = encodeCode93("A-B.C $D/E+F%G");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode93("A-B.C $D/E+F%G")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes a single character", () => {
-    const bars = encodeCode93("A");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode93("A")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only positive integer widths", () => {
-    const bars = encodeCode93("TEST93");
+    const bars = encodeCode93("TEST93")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(4);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(4)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("ends with a termination bar of width 1", () => {
-    const bars = encodeCode93("ABC");
-    expect(bars[bars.length - 1]).toBe(1);
-  });
+    const bars = encodeCode93("ABC")
+    expect(bars[bars.length - 1]).toBe(1)
+  })
 
   // --- Check digits are always included (C and K) ---
 
   it("longer input produces longer output", () => {
-    const short = encodeCode93("A");
-    const long = encodeCode93("ABCDE");
-    expect(long.length).toBeGreaterThan(short.length);
-  });
+    const short = encodeCode93("A")
+    const long = encodeCode93("ABCDE")
+    expect(long.length).toBeGreaterThan(short.length)
+  })
 
   it("output includes start/stop + data + 2 check digits + terminator", () => {
     // Each char in Code 93 has a 9-module binary pattern that becomes a variable-width run.
     // Just check it is non-empty and reasonable
-    const bars = encodeCode93("TEST");
+    const bars = encodeCode93("TEST")
     // Start(varies) + 4 data + 2 check digits + stop(varies) + termination(1)
-    expect(bars.length).toBeGreaterThan(10);
-  });
+    expect(bars.length).toBeGreaterThan(10)
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeCode93("ABC");
-    const bars2 = encodeCode93("XYZ");
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeCode93("ABC")
+    const bars2 = encodeCode93("XYZ")
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same input produces same output (deterministic)", () => {
-    const bars1 = encodeCode93("CODE93");
-    const bars2 = encodeCode93("CODE93");
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeCode93("CODE93")
+    const bars2 = encodeCode93("CODE93")
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on empty input", () => {
-    expect(() => encodeCode93("")).toThrow("must not be empty");
-  });
+    expect(() => encodeCode93("")).toThrow("must not be empty")
+  })
 
   it("throws on lowercase letters (not in native Code 93 charset)", () => {
-    expect(() => encodeCode93("abc")).toThrow("Invalid Code 93 character");
-  });
+    expect(() => encodeCode93("abc")).toThrow("Invalid Code 93 character")
+  })
 
   it("throws on characters outside the charset", () => {
-    expect(() => encodeCode93("A@B")).toThrow("Invalid Code 93 character");
-    expect(() => encodeCode93("A#B")).toThrow("Invalid Code 93 character");
-  });
-});
+    expect(() => encodeCode93("A@B")).toThrow("Invalid Code 93 character")
+    expect(() => encodeCode93("A#B")).toThrow("Invalid Code 93 character")
+  })
+})
 
 describe("encodeCode93Extended", () => {
   // --- Valid encoding ---
 
   it("encodes lowercase letters", () => {
-    const bars = encodeCode93Extended("abc");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode93Extended("abc")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes mixed case text", () => {
-    const bars = encodeCode93Extended("Hello World");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode93Extended("Hello World")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes punctuation and special ASCII characters", () => {
-    const bars = encodeCode93Extended("test@123!");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode93Extended("test@123!")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes native Code 93 characters directly", () => {
-    const bars = encodeCode93Extended("ABC123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode93Extended("ABC123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths", () => {
-    const bars = encodeCode93Extended("hello");
+    const bars = encodeCode93Extended("hello")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(4);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(4)
     }
-  });
+  })
 
   it("ends with a termination bar of width 1", () => {
-    const bars = encodeCode93Extended("test");
-    expect(bars[bars.length - 1]).toBe(1);
-  });
+    const bars = encodeCode93Extended("test")
+    expect(bars[bars.length - 1]).toBe(1)
+  })
 
   // --- Extended produces longer output for non-native chars ---
 
   it("lowercase input is longer than equivalent uppercase (shift pairs)", () => {
-    const upper = encodeCode93Extended("A");
-    const lower = encodeCode93Extended("a");
+    const upper = encodeCode93Extended("A")
+    const lower = encodeCode93Extended("a")
     // 'a' maps to (+A) = 2 code 93 values, 'A' maps to 1 value
-    expect(lower.length).toBeGreaterThan(upper.length);
-  });
+    expect(lower.length).toBeGreaterThan(upper.length)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on empty input", () => {
-    expect(() => encodeCode93Extended("")).toThrow("must not be empty");
-  });
+    expect(() => encodeCode93Extended("")).toThrow("must not be empty")
+  })
 
   it("throws on non-ASCII characters (code > 127)", () => {
-    expect(() => encodeCode93Extended("\u00E9")).toThrow("ASCII");
-  });
+    expect(() => encodeCode93Extended("\u00E9")).toThrow("ASCII")
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeCode93Extended("hello");
-    const bars2 = encodeCode93Extended("world");
-    expect(bars1).not.toEqual(bars2);
-  });
-});
+    const bars1 = encodeCode93Extended("hello")
+    const bars2 = encodeCode93Extended("world")
+    expect(bars1).not.toEqual(bars2)
+  })
+})

--- a/test/encoders-datamatrix-modes.test.ts
+++ b/test/encoders-datamatrix-modes.test.ts
@@ -1,70 +1,70 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   encodeASCII,
   encodeC40,
   encodeTextMode,
   encodeAuto,
-} from "../src/encoders/datamatrix/encoder";
+} from "../src/encoders/datamatrix/encoder"
 
 describe("Data Matrix C40 encoding", () => {
   it("encodes uppercase text", () => {
-    const cw = encodeC40("HELLO WORLD");
-    expect(cw[0]).toBe(230); // C40 latch
-    expect(cw.length).toBeLessThan(encodeASCII("HELLO WORLD").length + 1);
-  });
+    const cw = encodeC40("HELLO WORLD")
+    expect(cw[0]).toBe(230) // C40 latch
+    expect(cw.length).toBeLessThan(encodeASCII("HELLO WORLD").length + 1)
+  })
 
   it("encodes digits efficiently", () => {
-    const cw = encodeC40("ABC 123");
-    expect(cw[0]).toBe(230);
-    expect(cw.length).toBeGreaterThan(1);
-  });
+    const cw = encodeC40("ABC 123")
+    expect(cw[0]).toBe(230)
+    expect(cw.length).toBeGreaterThan(1)
+  })
 
   it("falls back for non-C40 characters", () => {
-    const cw = encodeC40("hello"); // lowercase not in C40 basic set
+    const cw = encodeC40("hello") // lowercase not in C40 basic set
     // Should include unlatch (254) and encode rest in ASCII
-    expect(cw).toContain(254);
-  });
-});
+    expect(cw).toContain(254)
+  })
+})
 
 describe("Data Matrix Text encoding", () => {
   it("encodes lowercase text", () => {
-    const cw = encodeTextMode("hello world");
-    expect(cw[0]).toBe(239); // Text latch
-    expect(cw.length).toBeLessThan(encodeASCII("hello world").length + 1);
-  });
+    const cw = encodeTextMode("hello world")
+    expect(cw[0]).toBe(239) // Text latch
+    expect(cw.length).toBeLessThan(encodeASCII("hello world").length + 1)
+  })
 
   it("handles uppercase via shift", () => {
-    const cw = encodeTextMode("Hello");
-    expect(cw[0]).toBe(239);
-    expect(cw.length).toBeGreaterThan(1);
-  });
-});
+    const cw = encodeTextMode("Hello")
+    expect(cw[0]).toBe(239)
+    expect(cw.length).toBeGreaterThan(1)
+  })
+})
 
 describe("Data Matrix auto encoding", () => {
   it("uses ASCII for mixed content", () => {
-    const cw = encodeAuto("Hi 123");
+    const cw = encodeAuto("Hi 123")
     // Short mixed text — ASCII should win or be similar
-    expect(cw.length).toBeGreaterThan(0);
-  });
+    expect(cw.length).toBeGreaterThan(0)
+  })
 
   it("uses C40 for uppercase-heavy text", () => {
-    const auto = encodeAuto("HELLO WORLD ABC DEF");
-    const ascii = encodeASCII("HELLO WORLD ABC DEF");
+    const auto = encodeAuto("HELLO WORLD ABC DEF")
+    const ascii = encodeASCII("HELLO WORLD ABC DEF")
     // C40 should be more efficient
-    expect(auto.length).toBeLessThanOrEqual(ascii.length);
-  });
+    expect(auto.length).toBeLessThanOrEqual(ascii.length)
+  })
 
   it("uses Text mode for lowercase-heavy text", () => {
-    const auto = encodeAuto("hello world abc def");
-    const ascii = encodeASCII("hello world abc def");
-    expect(auto.length).toBeLessThanOrEqual(ascii.length);
-  });
+    const auto = encodeAuto("hello world abc def")
+    const ascii = encodeASCII("hello world abc def")
+    expect(auto.length).toBeLessThanOrEqual(ascii.length)
+  })
 
   it("produces valid codewords", () => {
-    const cw = encodeAuto("Test Data 123");
+    const cw = encodeAuto("Test Data 123")
     for (const c of cw) {
-      expect(c).toBeGreaterThanOrEqual(0);
-      expect(c).toBeLessThanOrEqual(255);
+      expect(c).toBeGreaterThanOrEqual(0)
+      expect(c).toBeLessThanOrEqual(255)
     }
-  });
-});
+  })
+})

--- a/test/encoders-deutsche-post.test.ts
+++ b/test/encoders-deutsche-post.test.ts
@@ -1,61 +1,61 @@
-import { describe, expect, it } from "vitest";
-import { encodeIdentcode, encodeLeitcode } from "../src/encoders/deutsche-post";
-import { barcode } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { encodeIdentcode, encodeLeitcode } from "../src/encoders/deutsche-post"
+import { barcode } from "../src/index"
 
 describe("Identcode", () => {
   it("encodes 11 digits (auto check digit)", () => {
-    const bars = encodeIdentcode("56300001014");
-    expect(bars.length).toBeGreaterThan(0);
-    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1);
-  });
+    const bars = encodeIdentcode("56300001014")
+    expect(bars.length).toBeGreaterThan(0)
+    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1)
+  })
 
   it("encodes 12 digits (with check)", () => {
-    const bars = encodeIdentcode("563000010140");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeIdentcode("563000010140")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("throws on non-digits", () => {
-    expect(() => encodeIdentcode("5630000ABC")).toThrow();
-  });
+    expect(() => encodeIdentcode("5630000ABC")).toThrow()
+  })
 
   it("throws on wrong length", () => {
-    expect(() => encodeIdentcode("123")).toThrow();
-  });
+    expect(() => encodeIdentcode("123")).toThrow()
+  })
 
   it("works via barcode() function", () => {
-    const svg = barcode("56300001014", { type: "identcode" });
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = barcode("56300001014", { type: "identcode" })
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("Leitcode", () => {
   it("encodes 13 digits (auto check digit)", () => {
-    const bars = encodeLeitcode("2130000000014");
-    expect(bars.length).toBeGreaterThan(0);
-    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1);
-  });
+    const bars = encodeLeitcode("2130000000014")
+    expect(bars.length).toBeGreaterThan(0)
+    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1)
+  })
 
   it("encodes 14 digits (with check)", () => {
-    const bars = encodeLeitcode("21300000000146");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeLeitcode("21300000000146")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("throws on non-digits", () => {
-    expect(() => encodeLeitcode("ABC")).toThrow();
-  });
+    expect(() => encodeLeitcode("ABC")).toThrow()
+  })
 
   it("throws on wrong length", () => {
-    expect(() => encodeLeitcode("12345")).toThrow();
-  });
+    expect(() => encodeLeitcode("12345")).toThrow()
+  })
 
   it("works via barcode() function", () => {
-    const svg = barcode("2130000000014", { type: "leitcode" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("2130000000014", { type: "leitcode" })
+    expect(svg).toContain("<svg")
+  })
 
   it("different data produces different output", () => {
-    const a = encodeLeitcode("2130000000014");
-    const b = encodeLeitcode("2130000000024");
-    expect(a).not.toEqual(b);
-  });
-});
+    const a = encodeLeitcode("2130000000014")
+    const b = encodeLeitcode("2130000000024")
+    expect(a).not.toEqual(b)
+  })
+})

--- a/test/encoders-dotcode.test.ts
+++ b/test/encoders-dotcode.test.ts
@@ -1,56 +1,56 @@
-import { describe, expect, it } from "vitest";
-import { encodeDotCode } from "../src/encoders/dotcode";
+import { describe, expect, it } from "vitest"
+import { encodeDotCode } from "../src/encoders/dotcode"
 
 describe("DotCode", () => {
   it("encodes short text", () => {
-    const matrix = encodeDotCode("Hello");
-    expect(matrix.length).toBeGreaterThan(0);
-    expect(matrix[0]!.length).toBeGreaterThan(0);
-  });
+    const matrix = encodeDotCode("Hello")
+    expect(matrix.length).toBeGreaterThan(0)
+    expect(matrix[0]!.length).toBeGreaterThan(0)
+  })
 
   it("height + width is odd (DotCode spec requirement)", () => {
-    const matrix = encodeDotCode("Test");
-    expect((matrix.length + matrix[0]!.length) % 2).toBe(1);
-  });
+    const matrix = encodeDotCode("Test")
+    expect((matrix.length + matrix[0]!.length) % 2).toBe(1)
+  })
 
   it("checkerboard pattern — no adjacent dots", () => {
-    const matrix = encodeDotCode("Test data");
+    const matrix = encodeDotCode("Test data")
     for (let r = 0; r < matrix.length; r++) {
       for (let c = 0; c < matrix[r]!.length; c++) {
         if (matrix[r]![c] && (r + c) % 2 !== 0) {
           // Dots should only appear at even (r+c) positions
-          expect(true).toBe(false); // fail
+          expect(true).toBe(false) // fail
         }
       }
     }
-  });
+  })
 
   it("produces boolean matrix", () => {
-    const matrix = encodeDotCode("Data");
+    const matrix = encodeDotCode("Data")
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeDotCode("")).toThrow();
-  });
+    expect(() => encodeDotCode("")).toThrow()
+  })
 
   it("larger data produces larger matrix", () => {
-    const small = encodeDotCode("Hi");
-    const large = encodeDotCode("This is a longer DotCode message for testing purposes");
-    const smallArea = small.length * small[0]!.length;
-    const largeArea = large.length * large[0]!.length;
-    expect(largeArea).toBeGreaterThan(smallArea);
-  });
+    const small = encodeDotCode("Hi")
+    const large = encodeDotCode("This is a longer DotCode message for testing purposes")
+    const smallArea = small.length * small[0]!.length
+    const largeArea = large.length * large[0]!.length
+    expect(largeArea).toBeGreaterThan(smallArea)
+  })
 
   it("different data produces different output", () => {
-    const a = encodeDotCode("Hello");
-    const b = encodeDotCode("World");
-    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
-});
+    const a = encodeDotCode("Hello")
+    const b = encodeDotCode("World")
+    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
+})

--- a/test/encoders-ean-addon.test.ts
+++ b/test/encoders-ean-addon.test.ts
@@ -1,168 +1,168 @@
-import { describe, expect, it } from "vitest";
-import { encodeEAN2, encodeEAN5 } from "../src/encoders/ean-addon";
+import { describe, expect, it } from "vitest"
+import { encodeEAN2, encodeEAN5 } from "../src/encoders/ean-addon"
 
 describe("encodeEAN2", () => {
   // --- Valid encoding ---
 
   it("encodes a 2-digit string", () => {
-    const bars = encodeEAN2("12");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeEAN2("12")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it('encodes "00" (minimum value)', () => {
-    const bars = encodeEAN2("00");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeEAN2("00")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it('encodes "99" (maximum value)', () => {
-    const bars = encodeEAN2("99");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeEAN2("99")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1-4)", () => {
-    const bars = encodeEAN2("42");
+    const bars = encodeEAN2("42")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(4);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(4)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("output length is fixed", () => {
     // EAN-2: start(3) + digit(4) + delineator(2) + digit(4) = 13
-    const bars = encodeEAN2("12");
-    expect(bars.length).toBe(13);
-  });
+    const bars = encodeEAN2("12")
+    expect(bars.length).toBe(13)
+  })
 
   // --- Parity changes based on value mod 4 ---
 
   it("all four parity patterns produce different results", () => {
-    const p0 = encodeEAN2("00"); // 0 mod 4 = 0 -> LL
-    const p1 = encodeEAN2("01"); // 1 mod 4 = 1 -> LG
-    const p2 = encodeEAN2("02"); // 2 mod 4 = 2 -> GL
-    const p3 = encodeEAN2("03"); // 3 mod 4 = 3 -> GG
+    const p0 = encodeEAN2("00") // 0 mod 4 = 0 -> LL
+    const p1 = encodeEAN2("01") // 1 mod 4 = 1 -> LG
+    const p2 = encodeEAN2("02") // 2 mod 4 = 2 -> GL
+    const p3 = encodeEAN2("03") // 3 mod 4 = 3 -> GG
     // All should differ (different parity patterns)
-    const results = [p0, p1, p2, p3];
+    const results = [p0, p1, p2, p3]
     for (let i = 0; i < results.length; i++) {
       for (let j = i + 1; j < results.length; j++) {
-        expect(results[i]).not.toEqual(results[j]);
+        expect(results[i]).not.toEqual(results[j])
       }
     }
-  });
+  })
 
   it("values with same mod-4 residue share parity pattern", () => {
     // 00 mod 4 = 0, 04 mod 4 = 0 — same parity, but different digit patterns
-    const bars1 = encodeEAN2("00");
-    const bars2 = encodeEAN2("04");
+    const bars1 = encodeEAN2("00")
+    const bars2 = encodeEAN2("04")
     // They should have same length but different content (different digits encoded)
-    expect(bars1.length).toBe(bars2.length);
-    expect(bars1).not.toEqual(bars2);
-  });
+    expect(bars1.length).toBe(bars2.length)
+    expect(bars1).not.toEqual(bars2)
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeEAN2("12");
-    const bars2 = encodeEAN2("34");
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeEAN2("12")
+    const bars2 = encodeEAN2("34")
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same input produces same output", () => {
-    const bars1 = encodeEAN2("57");
-    const bars2 = encodeEAN2("57");
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeEAN2("57")
+    const bars2 = encodeEAN2("57")
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on non-digits", () => {
-    expect(() => encodeEAN2("AB")).toThrow("digits only");
-  });
+    expect(() => encodeEAN2("AB")).toThrow("digits only")
+  })
 
   it("throws on wrong length", () => {
-    expect(() => encodeEAN2("1")).toThrow("exactly 2 digits");
-    expect(() => encodeEAN2("123")).toThrow("exactly 2 digits");
-  });
+    expect(() => encodeEAN2("1")).toThrow("exactly 2 digits")
+    expect(() => encodeEAN2("123")).toThrow("exactly 2 digits")
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeEAN2("")).toThrow();
-  });
-});
+    expect(() => encodeEAN2("")).toThrow()
+  })
+})
 
 describe("encodeEAN5", () => {
   // --- Valid encoding ---
 
   it("encodes a 5-digit string", () => {
-    const bars = encodeEAN5("52495");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeEAN5("52495")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it('encodes "00000" (minimum value)', () => {
-    const bars = encodeEAN5("00000");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeEAN5("00000")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it('encodes "99999" (maximum value)', () => {
-    const bars = encodeEAN5("99999");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeEAN5("99999")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1-4)", () => {
-    const bars = encodeEAN5("52495");
+    const bars = encodeEAN5("52495")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(4);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(4)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("output length is fixed", () => {
     // EAN-5: start(3) + digit(4) + 4 * (delineator(2) + digit(4)) = 3 + 4 + 4*6 = 31
-    const bars = encodeEAN5("12345");
-    expect(bars.length).toBe(31);
-  });
+    const bars = encodeEAN5("12345")
+    expect(bars.length).toBe(31)
+  })
 
   // --- Checksum-based parity ---
 
   it("different checksum values produce different parity encodings", () => {
     // Use inputs designed to produce different checksum values
-    const bars1 = encodeEAN5("00000"); // checksum = 0
-    const bars2 = encodeEAN5("10000"); // checksum = 3
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeEAN5("00000") // checksum = 0
+    const bars2 = encodeEAN5("10000") // checksum = 3
+    expect(bars1).not.toEqual(bars2)
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeEAN5("12345");
-    const bars2 = encodeEAN5("54321");
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeEAN5("12345")
+    const bars2 = encodeEAN5("54321")
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same input produces same output", () => {
-    const bars1 = encodeEAN5("52495");
-    const bars2 = encodeEAN5("52495");
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeEAN5("52495")
+    const bars2 = encodeEAN5("52495")
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on non-digits", () => {
-    expect(() => encodeEAN5("ABCDE")).toThrow("digits only");
-  });
+    expect(() => encodeEAN5("ABCDE")).toThrow("digits only")
+  })
 
   it("throws on wrong length", () => {
-    expect(() => encodeEAN5("1234")).toThrow("exactly 5 digits");
-    expect(() => encodeEAN5("123456")).toThrow("exactly 5 digits");
-  });
+    expect(() => encodeEAN5("1234")).toThrow("exactly 5 digits")
+    expect(() => encodeEAN5("123456")).toThrow("exactly 5 digits")
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeEAN5("")).toThrow();
-  });
-});
+    expect(() => encodeEAN5("")).toThrow()
+  })
+})

--- a/test/encoders-edge-paths.test.ts
+++ b/test/encoders-edge-paths.test.ts
@@ -4,315 +4,315 @@
  * encoding modes, Codablock-F charset transitions, and gradient corner styling.
  */
 
-import { describe, expect, it } from "vitest";
-import { encodeCode128 } from "../src/encoders/code128";
-import { encodeUPCA, encodeUPCE } from "../src/encoders/upc";
-import { encodeHanXin } from "../src/encoders/hanxin";
-import { encodeCodablockF } from "../src/encoders/codablock-f";
-import { encodeGS1DataBarExpanded } from "../src/encoders/gs1-databar";
-import { renderQRCodeSVG } from "../src/renderers/svg/qr";
-import { encodeQR } from "../src/encoders/qr/index";
+import { describe, expect, it } from "vitest"
+import { encodeCode128 } from "../src/encoders/code128"
+import { encodeUPCA, encodeUPCE } from "../src/encoders/upc"
+import { encodeHanXin } from "../src/encoders/hanxin"
+import { encodeCodablockF } from "../src/encoders/codablock-f"
+import { encodeGS1DataBarExpanded } from "../src/encoders/gs1-databar"
+import { renderQRCodeSVG } from "../src/renderers/svg/qr"
+import { encodeQR } from "../src/encoders/qr/index"
 
 describe("Code 128 charset switching", () => {
   it("uses Code C for long digit runs", () => {
     // Pure digits pack two per codeword, so bars stay short
-    const digits = encodeCode128("1234567890");
-    const letters = encodeCode128("ABCDEFGHIJ");
-    expect(digits.length).toBeLessThan(letters.length);
-  });
+    const digits = encodeCode128("1234567890")
+    const letters = encodeCode128("ABCDEFGHIJ")
+    expect(digits.length).toBeLessThan(letters.length)
+  })
 
   it("encodes printable ASCII", () => {
-    expect(() => encodeCode128("Hello, World! 123")).not.toThrow();
-  });
+    expect(() => encodeCode128("Hello, World! 123")).not.toThrow()
+  })
 
   it("shifts to Code A for a single control character between printables", () => {
-    const withControl = encodeCode128("AB\tCD");
-    const without = encodeCode128("ABCD");
-    expect(withControl.length).toBeGreaterThan(without.length);
-  });
+    const withControl = encodeCode128("AB\tCD")
+    const without = encodeCode128("ABCD")
+    expect(withControl.length).toBeGreaterThan(without.length)
+  })
 
   it("latches to Code A for consecutive control characters", () => {
-    expect(() => encodeCode128("AB\t\n\rCD")).not.toThrow();
-    expect(encodeCode128("AB\t\nCD")).not.toEqual(encodeCode128("AB\t\rCD"));
-  });
+    expect(() => encodeCode128("AB\t\n\rCD")).not.toThrow()
+    expect(encodeCode128("AB\t\nCD")).not.toEqual(encodeCode128("AB\t\rCD"))
+  })
 
   it("handles a control character at the end of the string", () => {
-    expect(() => encodeCode128("ABC\n")).not.toThrow();
-  });
+    expect(() => encodeCode128("ABC\n")).not.toThrow()
+  })
 
   it("handles a leading control character", () => {
-    expect(() => encodeCode128("\tABC")).not.toThrow();
-  });
+    expect(() => encodeCode128("\tABC")).not.toThrow()
+  })
 
   it("switches between digits and letters", () => {
-    expect(() => encodeCode128("ABC123456789DEF")).not.toThrow();
-    expect(() => encodeCode128("123456ABC789012")).not.toThrow();
-  });
+    expect(() => encodeCode128("ABC123456789DEF")).not.toThrow()
+    expect(() => encodeCode128("123456ABC789012")).not.toThrow()
+  })
 
   it("honours a forced charset", () => {
     expect(encodeCode128("123456", { charset: "C" })).not.toEqual(
       encodeCode128("123456", { charset: "B" }),
-    );
-    expect(() => encodeCode128("ABC", { charset: "A" })).not.toThrow();
-  });
+    )
+    expect(() => encodeCode128("ABC", { charset: "A" })).not.toThrow()
+  })
 
   it("rejects an odd digit count in forced Code C", () => {
-    expect(() => encodeCode128("12345", { charset: "C" })).toThrow();
-  });
+    expect(() => encodeCode128("12345", { charset: "C" })).toThrow()
+  })
 
   it("rejects characters outside the selected charset", () => {
-    expect(() => encodeCode128("abc", { charset: "A" })).toThrow();
-  });
-});
+    expect(() => encodeCode128("abc", { charset: "A" })).toThrow()
+  })
+})
 
 describe("UPC-E expansion rules", () => {
   // The final digit selects how the 6-digit payload expands to UPC-A
-  const payloads = ["12300", "12310", "12320", "12330", "12340", "12350"];
+  const payloads = ["12300", "12310", "12320", "12330", "12340", "12350"]
 
   it("expands every last-digit rule (0-9)", () => {
     for (let lastDigit = 0; lastDigit <= 9; lastDigit++) {
-      const code = `${payloads[Math.min(lastDigit, 5)]!.slice(0, 5)}${lastDigit}`;
-      expect(() => encodeUPCE(code), `last digit ${lastDigit}`).not.toThrow();
+      const code = `${payloads[Math.min(lastDigit, 5)]!.slice(0, 5)}${lastDigit}`
+      expect(() => encodeUPCE(code), `last digit ${lastDigit}`).not.toThrow()
     }
-  });
+  })
 
   it("produces distinct symbols per expansion rule", () => {
-    const seen = new Set<string>();
+    const seen = new Set<string>()
     for (let lastDigit = 0; lastDigit <= 9; lastDigit++) {
-      const bars = encodeUPCE(`12345${lastDigit}`).bars.join(",");
-      seen.add(bars);
+      const bars = encodeUPCE(`12345${lastDigit}`).bars.join(",")
+      seen.add(bars)
     }
-    expect(seen.size).toBe(10);
-  });
+    expect(seen.size).toBe(10)
+  })
 
   it("accepts a 7-digit form with a number system prefix", () => {
-    expect(() => encodeUPCE("0123456")).not.toThrow();
-    expect(() => encodeUPCE("1123456")).not.toThrow();
-  });
+    expect(() => encodeUPCE("0123456")).not.toThrow()
+    expect(() => encodeUPCE("1123456")).not.toThrow()
+  })
 
   it("accepts an 8-digit form and validates the check digit", () => {
-    const seven = encodeUPCE("0123456");
-    expect(seven.bars.length).toBeGreaterThan(0);
-    expect(seven.guards.length).toBeGreaterThan(0);
-  });
+    const seven = encodeUPCE("0123456")
+    expect(seven.bars.length).toBeGreaterThan(0)
+    expect(seven.guards.length).toBeGreaterThan(0)
+  })
 
   it("rejects a mismatched check digit in the 8-digit form", () => {
     // Find a valid 8-digit code, then corrupt its check digit
-    const valid = encodeUPCE("01234565");
-    expect(valid).toBeDefined();
-    expect(() => encodeUPCE("01234560")).toThrow(/check digit/i);
-  });
+    const valid = encodeUPCE("01234565")
+    expect(valid).toBeDefined()
+    expect(() => encodeUPCE("01234560")).toThrow(/check digit/i)
+  })
 
   it("rejects a non-numeric payload", () => {
-    expect(() => encodeUPCE("12A456")).toThrow();
-  });
+    expect(() => encodeUPCE("12A456")).toThrow()
+  })
 
   it("UPC-A round-trips its check digit", () => {
-    const withCheck = encodeUPCA("036000291452");
-    const without = encodeUPCA("03600029145");
-    expect(withCheck.bars).toEqual(without.bars);
-  });
+    const withCheck = encodeUPCA("036000291452")
+    const without = encodeUPCA("03600029145")
+    expect(withCheck.bars).toEqual(without.bars)
+  })
 
   it("UPC-A rejects a bad check digit", () => {
-    expect(() => encodeUPCA("036000291450")).toThrow();
-  });
-});
+    expect(() => encodeUPCA("036000291450")).toThrow()
+  })
+})
 
 describe("Han Xin encoding modes", () => {
   it("uses numeric mode for digits", () => {
-    const numeric = encodeHanXin("1234567890123456");
-    const text = encodeHanXin("ABCDEFGHIJKLMNOP");
+    const numeric = encodeHanXin("1234567890123456")
+    const text = encodeHanXin("ABCDEFGHIJKLMNOP")
     // Numeric packs 3 digits per 10 bits, so it needs no more space than text
-    expect(numeric.length).toBeLessThanOrEqual(text.length);
-  });
+    expect(numeric.length).toBeLessThanOrEqual(text.length)
+  })
 
   it("encodes digit groups of 1, 2 and 3", () => {
     for (const digits of ["1", "12", "123", "1234", "12345", "123456"]) {
-      expect(() => encodeHanXin(digits), digits).not.toThrow();
+      expect(() => encodeHanXin(digits), digits).not.toThrow()
     }
-  });
+  })
 
   it("uses text mode for printable ASCII", () => {
-    expect(() => encodeHanXin("Hello, World!")).not.toThrow();
-  });
+    expect(() => encodeHanXin("Hello, World!")).not.toThrow()
+  })
 
   it("falls back to binary mode for non-ASCII", () => {
-    const ascii = encodeHanXin("HELLO");
-    const unicode = encodeHanXin("中文字符");
-    expect(unicode.length).toBeGreaterThan(0);
-    expect(unicode).not.toEqual(ascii);
-  });
+    const ascii = encodeHanXin("HELLO")
+    const unicode = encodeHanXin("中文字符")
+    expect(unicode.length).toBeGreaterThan(0)
+    expect(unicode).not.toEqual(ascii)
+  })
 
   it("produces a square symbol sized by version", () => {
     for (const version of [1, 5, 10, 20]) {
-      const m = encodeHanXin("HELLO", { version });
-      expect(m.length, `v${version}`).toBe(version * 2 + 21);
-      expect(m[0]!.length, `v${version}`).toBe(version * 2 + 21);
+      const m = encodeHanXin("HELLO", { version })
+      expect(m.length, `v${version}`).toBe(version * 2 + 21)
+      expect(m[0]!.length, `v${version}`).toBe(version * 2 + 21)
     }
-  });
+  })
 
   it("grows the symbol as the EC level rises", () => {
-    const payload = "HAN XIN CODE CAPACITY TEST ".repeat(6);
+    const payload = "HAN XIN CODE CAPACITY TEST ".repeat(6)
     expect(encodeHanXin(payload, { ecLevel: 4 }).length).toBeGreaterThanOrEqual(
       encodeHanXin(payload, { ecLevel: 1 }).length,
-    );
-  });
+    )
+  })
 
   it("rejects empty input", () => {
-    expect(() => encodeHanXin("")).toThrow(/must not be empty/);
-  });
+    expect(() => encodeHanXin("")).toThrow(/must not be empty/)
+  })
 
   it("rejects data too long for any version", () => {
-    expect(() => encodeHanXin("A".repeat(100000))).toThrow(/too long/i);
-  });
+    expect(() => encodeHanXin("A".repeat(100000))).toThrow(/too long/i)
+  })
 
   it("encodes a payload that needs a large version", () => {
-    const m = encodeHanXin("X".repeat(500));
-    expect(m.length).toBeGreaterThan(21);
-  });
-});
+    const m = encodeHanXin("X".repeat(500))
+    expect(m.length).toBeGreaterThan(21)
+  })
+})
 
 describe("Codablock-F charset transitions", () => {
   it("starts in Code C for a leading digit run", () => {
-    expect(() => encodeCodablockF("1234567890")).not.toThrow();
-  });
+    expect(() => encodeCodablockF("1234567890")).not.toThrow()
+  })
 
   it("starts in Code A for a leading control character", () => {
-    expect(() => encodeCodablockF("\tABC")).not.toThrow();
-  });
+    expect(() => encodeCodablockF("\tABC")).not.toThrow()
+  })
 
   it("starts in Code B for leading printable text", () => {
-    expect(() => encodeCodablockF("ABCdef")).not.toThrow();
-  });
+    expect(() => encodeCodablockF("ABCdef")).not.toThrow()
+  })
 
   it("switches from Code C to Code B", () => {
-    expect(() => encodeCodablockF("123456ABCdef")).not.toThrow();
-  });
+    expect(() => encodeCodablockF("123456ABCdef")).not.toThrow()
+  })
 
   it("switches from Code C to Code A", () => {
-    expect(() => encodeCodablockF("123456\t\nABC")).not.toThrow();
-  });
+    expect(() => encodeCodablockF("123456\t\nABC")).not.toThrow()
+  })
 
   it("switches into Code C mid-string for a long digit run", () => {
-    expect(() => encodeCodablockF("ABC12345678901234")).not.toThrow();
-  });
+    expect(() => encodeCodablockF("ABC12345678901234")).not.toThrow()
+  })
 
   it("switches between Code A and Code B", () => {
-    expect(() => encodeCodablockF("ABC\tdef\tGHI")).not.toThrow();
-  });
+    expect(() => encodeCodablockF("ABC\tdef\tGHI")).not.toThrow()
+  })
 
   it("encodes control characters in Code A", () => {
-    expect(() => encodeCodablockF("")).not.toThrow();
-  });
+    expect(() => encodeCodablockF("")).not.toThrow()
+  })
 
   it("rejects unsupported characters", () => {
-    expect(() => encodeCodablockF("café")).toThrow(/unsupported character/i);
-  });
+    expect(() => encodeCodablockF("café")).toThrow(/unsupported character/i)
+  })
 
   it("rejects empty input", () => {
-    expect(() => encodeCodablockF("")).toThrow();
-  });
+    expect(() => encodeCodablockF("")).toThrow()
+  })
 
   it("honours the columns option", () => {
-    const narrow = encodeCodablockF("CODABLOCK F TEST DATA", { columns: 8 });
-    const wide = encodeCodablockF("CODABLOCK F TEST DATA", { columns: 16 });
-    expect(narrow.cols).toBeLessThan(wide.cols);
-    expect(narrow.rows).toBeGreaterThanOrEqual(wide.rows);
-  });
+    const narrow = encodeCodablockF("CODABLOCK F TEST DATA", { columns: 8 })
+    const wide = encodeCodablockF("CODABLOCK F TEST DATA", { columns: 16 })
+    expect(narrow.cols).toBeLessThan(wide.cols)
+    expect(narrow.rows).toBeGreaterThanOrEqual(wide.rows)
+  })
 
   it("adds rows as the payload grows", () => {
-    const short = encodeCodablockF("SHORT");
-    const long = encodeCodablockF("A MUCH LONGER PAYLOAD THAT NEEDS SEVERAL ROWS TO ENCODE");
-    expect(long.rows).toBeGreaterThan(short.rows);
-  });
+    const short = encodeCodablockF("SHORT")
+    const long = encodeCodablockF("A MUCH LONGER PAYLOAD THAT NEEDS SEVERAL ROWS TO ENCODE")
+    expect(long.rows).toBeGreaterThan(short.rows)
+  })
 
   it("reports matrix dimensions consistent with the matrix", () => {
-    const result = encodeCodablockF("CODABLOCK");
-    expect(result.matrix).toHaveLength(result.rows);
-    expect(result.matrix[0]).toHaveLength(result.cols);
-  });
-});
+    const result = encodeCodablockF("CODABLOCK")
+    expect(result.matrix).toHaveLength(result.rows)
+    expect(result.matrix[0]).toHaveLength(result.cols)
+  })
+})
 
 describe("GS1 DataBar Expanded", () => {
   it("encodes AI element strings", () => {
-    expect(() => encodeGS1DataBarExpanded("(01)90012345678908")).not.toThrow();
-  });
+    expect(() => encodeGS1DataBarExpanded("(01)90012345678908")).not.toThrow()
+  })
 
   it("encodes multiple AIs", () => {
-    expect(() => encodeGS1DataBarExpanded("(01)90012345678908(10)ABC123")).not.toThrow();
-  });
+    expect(() => encodeGS1DataBarExpanded("(01)90012345678908(10)ABC123")).not.toThrow()
+  })
 
   it("encodes alphanumeric and numeric AI values", () => {
-    const numeric = encodeGS1DataBarExpanded("(01)90012345678908(3103)000189");
-    const alpha = encodeGS1DataBarExpanded("(01)90012345678908(10)ABC");
-    expect(numeric).not.toEqual(alpha);
-  });
+    const numeric = encodeGS1DataBarExpanded("(01)90012345678908(3103)000189")
+    const alpha = encodeGS1DataBarExpanded("(01)90012345678908(10)ABC")
+    expect(numeric).not.toEqual(alpha)
+  })
 
   it("grows with payload length", () => {
-    const short = encodeGS1DataBarExpanded("(01)90012345678908");
-    const long = encodeGS1DataBarExpanded("(01)90012345678908(10)LOT12345678(21)SERIAL9876");
-    expect(long.length).toBeGreaterThan(short.length);
-  });
+    const short = encodeGS1DataBarExpanded("(01)90012345678908")
+    const long = encodeGS1DataBarExpanded("(01)90012345678908(10)LOT12345678(21)SERIAL9876")
+    expect(long.length).toBeGreaterThan(short.length)
+  })
 
   // The general field switches between numeric, alphanumeric and ISO 646
   // submodes depending on the characters encountered.
   it("encodes uppercase letters in alphanumeric mode", () => {
-    expect(encodeGS1DataBarExpanded("(10)ABC").length).toBeGreaterThan(0);
-  });
+    expect(encodeGS1DataBarExpanded("(10)ABC").length).toBeGreaterThan(0)
+  })
 
   it("encodes alphanumeric punctuation", () => {
     // * , - . / each have a dedicated alphanumeric value
     for (const value of ["A*B", "A,B", "A-B", "A.B", "A/B"]) {
-      expect(encodeGS1DataBarExpanded(`(10)${value}`).length, value).toBeGreaterThan(0);
+      expect(encodeGS1DataBarExpanded(`(10)${value}`).length, value).toBeGreaterThan(0)
     }
-  });
+  })
 
   it("latches to ISO 646 for lowercase letters", () => {
-    const upper = encodeGS1DataBarExpanded("(10)ABC");
-    const lower = encodeGS1DataBarExpanded("(10)abc");
-    expect(lower).not.toEqual(upper);
-    expect(lower.length).toBeGreaterThan(0);
-  });
+    const upper = encodeGS1DataBarExpanded("(10)ABC")
+    const lower = encodeGS1DataBarExpanded("(10)abc")
+    expect(lower).not.toEqual(upper)
+    expect(lower.length).toBeGreaterThan(0)
+  })
 
   it("encodes other characters as 8-bit ISO 646 values", () => {
-    expect(encodeGS1DataBarExpanded("(10)A#B%C").length).toBeGreaterThan(0);
-  });
+    expect(encodeGS1DataBarExpanded("(10)A#B%C").length).toBeGreaterThan(0)
+  })
 
   it("latches back to numeric for digit pairs after letters", () => {
-    expect(encodeGS1DataBarExpanded("(10)ABC12DEF").length).toBeGreaterThan(0);
-  });
+    expect(encodeGS1DataBarExpanded("(10)ABC12DEF").length).toBeGreaterThan(0)
+  })
 
   it("handles a single trailing digit", () => {
-    expect(encodeGS1DataBarExpanded("(10)A1").length).toBeGreaterThan(0);
-  });
+    expect(encodeGS1DataBarExpanded("(10)A1").length).toBeGreaterThan(0)
+  })
 
   it("handles an all-numeric general field", () => {
-    expect(encodeGS1DataBarExpanded("(10)12345").length).toBeGreaterThan(0);
-  });
+    expect(encodeGS1DataBarExpanded("(10)12345").length).toBeGreaterThan(0)
+  })
 
   it("inserts FNC1 separators between variable-length AIs", () => {
-    const single = encodeGS1DataBarExpanded("(10)ABC");
-    const double = encodeGS1DataBarExpanded("(10)ABC(21)XYZ");
-    expect(double.length).toBeGreaterThan(single.length);
-  });
+    const single = encodeGS1DataBarExpanded("(10)ABC")
+    const double = encodeGS1DataBarExpanded("(10)ABC(21)XYZ")
+    expect(double.length).toBeGreaterThan(single.length)
+  })
 
   it("rejects empty input", () => {
-    expect(() => encodeGS1DataBarExpanded("")).toThrow(/must not be empty/);
-  });
+    expect(() => encodeGS1DataBarExpanded("")).toThrow(/must not be empty/)
+  })
 
   it("produces an even-length alternating bar/space pattern", () => {
     for (const data of ["(10)ABC", "(10)abc", "(01)90012345678908"]) {
-      const bars = encodeGS1DataBarExpanded(data);
+      const bars = encodeGS1DataBarExpanded(data)
       expect(
         bars.every((w) => w > 0),
         data,
-      ).toBe(true);
+      ).toBe(true)
     }
-  });
-});
+  })
+})
 
 describe("QR renderer — gradients and corner styling", () => {
-  const matrix = encodeQR("HELLO");
+  const matrix = encodeQR("HELLO")
   const gradient = {
     type: "linear" as const,
     rotation: 45,
@@ -320,57 +320,57 @@ describe("QR renderer — gradients and corner styling", () => {
       { offset: 0, color: "#ff0000" },
       { offset: 1, color: "#0000ff" },
     ],
-  };
+  }
   const radial = {
     type: "radial" as const,
     stops: [
       { offset: 0, color: "#00ff00" },
       { offset: 1, color: "#000000" },
     ],
-  };
+  }
 
   it("applies a gradient background", () => {
-    const svg = renderQRCodeSVG(matrix, { background: gradient });
-    expect(svg).toContain("<linearGradient");
-    expect(svg).toContain('<rect width="100%" height="100%" fill="url(#');
-  });
+    const svg = renderQRCodeSVG(matrix, { background: gradient })
+    expect(svg).toContain("<linearGradient")
+    expect(svg).toContain('<rect width="100%" height="100%" fill="url(#')
+  })
 
   it("applies a radial gradient background", () => {
-    expect(renderQRCodeSVG(matrix, { background: radial })).toContain("<radialGradient");
-  });
+    expect(renderQRCodeSVG(matrix, { background: radial })).toContain("<radialGradient")
+  })
 
   it("applies a gradient to the modules", () => {
-    const svg = renderQRCodeSVG(matrix, { color: gradient });
-    expect(svg).toContain("<linearGradient");
-  });
+    const svg = renderQRCodeSVG(matrix, { color: gradient })
+    expect(svg).toContain("<linearGradient")
+  })
 
   it("styles corner outer rings with a solid color", () => {
     const svg = renderQRCodeSVG(matrix, {
       corners: { topLeft: { outerColor: "#ff0000", outerShape: "rounded" } },
-    });
-    expect(svg).toContain('fill="#ff0000"');
-  });
+    })
+    expect(svg).toContain('fill="#ff0000"')
+  })
 
   it("styles corner outer rings with a gradient", () => {
     const svg = renderQRCodeSVG(matrix, {
       corners: { topLeft: { outerColor: gradient } },
-    });
-    expect(svg).toContain("<linearGradient");
-  });
+    })
+    expect(svg).toContain("<linearGradient")
+  })
 
   it("styles corner inner squares with a solid color", () => {
     const svg = renderQRCodeSVG(matrix, {
       corners: { topRight: { innerColor: "#00ff00", innerShape: "dots" } },
-    });
-    expect(svg).toContain('fill="#00ff00"');
-  });
+    })
+    expect(svg).toContain('fill="#00ff00"')
+  })
 
   it("styles corner inner squares with a gradient", () => {
     const svg = renderQRCodeSVG(matrix, {
       corners: { bottomLeft: { innerColor: radial } },
-    });
-    expect(svg).toContain("<radialGradient");
-  });
+    })
+    expect(svg).toContain("<radialGradient")
+  })
 
   it("styles all three corners independently", () => {
     const svg = renderQRCodeSVG(matrix, {
@@ -379,23 +379,23 @@ describe("QR renderer — gradients and corner styling", () => {
         topRight: { outerColor: "#222222" },
         bottomLeft: { outerColor: "#333333" },
       },
-    });
-    expect(svg).toContain('fill="#111111"');
-    expect(svg).toContain('fill="#222222"');
-    expect(svg).toContain('fill="#333333"');
-  });
+    })
+    expect(svg).toContain('fill="#111111"')
+    expect(svg).toContain('fill="#222222"')
+    expect(svg).toContain('fill="#333333"')
+  })
 
   it("supports every corner outer shape", () => {
     for (const outerShape of ["square", "rounded", "dots", "extra-rounded", "classy"] as const) {
-      const svg = renderQRCodeSVG(matrix, { corners: { topLeft: { outerShape } } });
-      expect(svg, outerShape).toContain("<path");
+      const svg = renderQRCodeSVG(matrix, { corners: { topLeft: { outerShape } } })
+      expect(svg, outerShape).toContain("<path")
     }
-  });
+  })
 
   it("supports every corner inner shape", () => {
     for (const innerShape of ["square", "dots", "rounded"] as const) {
-      const svg = renderQRCodeSVG(matrix, { corners: { topLeft: { innerShape } } });
-      expect(svg, innerShape).toContain("<path");
+      const svg = renderQRCodeSVG(matrix, { corners: { topLeft: { innerShape } } })
+      expect(svg, innerShape).toContain("<path")
     }
-  });
-});
+  })
+})

--- a/test/encoders-fourstate.test.ts
+++ b/test/encoders-fourstate.test.ts
@@ -1,70 +1,70 @@
-import { describe, expect, it } from "vitest";
-import { encodeRM4SCC, encodeKIX } from "../src/encoders/fourstate";
+import { describe, expect, it } from "vitest"
+import { encodeRM4SCC, encodeKIX } from "../src/encoders/fourstate"
 
 describe("RM4SCC (Royal Mail)", () => {
   it("encodes postcode", () => {
-    const bars = encodeRM4SCC("EC1A1BB");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(bars[0]).toBe("A"); // start bar
-    expect(bars[bars.length - 1]).toBe("F"); // stop bar
-  });
+    const bars = encodeRM4SCC("EC1A1BB")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(bars[0]).toBe("A") // start bar
+    expect(bars[bars.length - 1]).toBe("F") // stop bar
+  })
 
   it("all values are valid states", () => {
-    const bars = encodeRM4SCC("SW1A2AA");
+    const bars = encodeRM4SCC("SW1A2AA")
     for (const b of bars) {
-      expect(["T", "A", "D", "F"]).toContain(b);
+      expect(["T", "A", "D", "F"]).toContain(b)
     }
-  });
+  })
 
   it("includes check digit (longer than raw data)", () => {
-    const bars = encodeRM4SCC("AB");
+    const bars = encodeRM4SCC("AB")
     // 2 data chars + 1 check = 3 chars × 4 bars + start + stop = 14
-    expect(bars.length).toBe(14);
-  });
+    expect(bars.length).toBe(14)
+  })
 
   it("strips spaces", () => {
-    const a = encodeRM4SCC("EC1A 1BB");
-    const b = encodeRM4SCC("EC1A1BB");
-    expect(a).toEqual(b);
-  });
+    const a = encodeRM4SCC("EC1A 1BB")
+    const b = encodeRM4SCC("EC1A1BB")
+    expect(a).toEqual(b)
+  })
 
   it("case insensitive", () => {
-    const a = encodeRM4SCC("ec1a1bb");
-    const b = encodeRM4SCC("EC1A1BB");
-    expect(a).toEqual(b);
-  });
+    const a = encodeRM4SCC("ec1a1bb")
+    const b = encodeRM4SCC("EC1A1BB")
+    expect(a).toEqual(b)
+  })
 
   it("throws on invalid characters", () => {
-    expect(() => encodeRM4SCC("EC1A-1BB")).toThrow();
-  });
+    expect(() => encodeRM4SCC("EC1A-1BB")).toThrow()
+  })
 
   it("different postcodes produce different output", () => {
-    const a = encodeRM4SCC("EC1A1BB");
-    const b = encodeRM4SCC("SW1A2AA");
-    expect(a).not.toEqual(b);
-  });
-});
+    const a = encodeRM4SCC("EC1A1BB")
+    const b = encodeRM4SCC("SW1A2AA")
+    expect(a).not.toEqual(b)
+  })
+})
 
 describe("KIX (Dutch PostNL)", () => {
   it("encodes postcode", () => {
-    const bars = encodeKIX("1234AB");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeKIX("1234AB")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("has no start/stop bars", () => {
-    const bars = encodeKIX("1234AB");
+    const bars = encodeKIX("1234AB")
     // 6 chars × 4 bars = 24 (no start/stop, no check digit)
-    expect(bars.length).toBe(24);
-  });
+    expect(bars.length).toBe(24)
+  })
 
   it("all values are valid states", () => {
-    const bars = encodeKIX("9999ZZ");
+    const bars = encodeKIX("9999ZZ")
     for (const b of bars) {
-      expect(["T", "A", "D", "F"]).toContain(b);
+      expect(["T", "A", "D", "F"]).toContain(b)
     }
-  });
+  })
 
   it("throws on invalid characters", () => {
-    expect(() => encodeKIX("1234-AB")).toThrow();
-  });
-});
+    expect(() => encodeKIX("1234-AB")).toThrow()
+  })
+})

--- a/test/encoders-gs1-128-extended.test.ts
+++ b/test/encoders-gs1-128-extended.test.ts
@@ -1,76 +1,76 @@
-import { describe, expect, it } from "vitest";
-import { encodeGS1128 } from "../src/encoders/gs1-128";
+import { describe, expect, it } from "vitest"
+import { encodeGS1128 } from "../src/encoders/gs1-128"
 
 describe("GS1-128 extended AIs", () => {
   it("encodes SSCC-18 with AI 00", () => {
-    const bars = encodeGS1128("(00)123456789012345678");
-    expect(bars.length).toBeGreaterThan(0);
-    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1);
-  });
+    const bars = encodeGS1128("(00)123456789012345678")
+    expect(bars.length).toBeGreaterThan(0)
+    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1)
+  })
 
   it("encodes AI 310x weight", () => {
-    const bars = encodeGS1128("(3102)123456");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(3102)123456")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes AI 402 shipment ID (17 digits)", () => {
-    const bars = encodeGS1128("(402)12345678901234567");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(402)12345678901234567")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes AI 240 additional item ID", () => {
-    const bars = encodeGS1128("(240)PARTNUM123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(240)PARTNUM123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes AI 710 NHRN", () => {
-    const bars = encodeGS1128("(710)ABC123DEF");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(710)ABC123DEF")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes AI 12 due date", () => {
-    const bars = encodeGS1128("(12)260401");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(12)260401")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes AI 420 domestic postal code", () => {
-    const bars = encodeGS1128("(420)12345");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(420)12345")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes AI 8007 IBAN", () => {
-    const bars = encodeGS1128("(8007)DE89370400440532013000");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(8007)DE89370400440532013000")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes multiple mixed AIs", () => {
-    const bars = encodeGS1128("(01)12345678901234(10)BATCH01(17)260101(21)SERIAL01");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(01)12345678901234(10)BATCH01(17)260101(21)SERIAL01")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("handles unknown AI as variable-length without error", () => {
-    const bars = encodeGS1128("(99)UNKNOWNDATA");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(99)UNKNOWNDATA")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes SSCC + GTIN together", () => {
-    const bars = encodeGS1128("(00)123456789012345678(01)12345678901234");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(00)123456789012345678(01)12345678901234")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes trade measure 350x area", () => {
-    const bars = encodeGS1128("(3500)654321");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(3500)654321")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes amount payable 390x", () => {
-    const bars = encodeGS1128("(3900)12345");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(3900)12345")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("different AIs produce different outputs", () => {
-    const a = encodeGS1128("(01)12345678901234");
-    const b = encodeGS1128("(02)12345678901234");
-    expect(a).not.toEqual(b);
-  });
-});
+    const a = encodeGS1128("(01)12345678901234")
+    const b = encodeGS1128("(02)12345678901234")
+    expect(a).not.toEqual(b)
+  })
+})

--- a/test/encoders-gs1-128.test.ts
+++ b/test/encoders-gs1-128.test.ts
@@ -1,176 +1,176 @@
-import { describe, expect, it } from "vitest";
-import { encodeGS1128 } from "../src/encoders/gs1-128";
+import { describe, expect, it } from "vitest"
+import { encodeGS1128 } from "../src/encoders/gs1-128"
 
 describe("encodeGS1128", () => {
   // --- Valid encoding (parenthesized AI format) ---
 
   it("encodes a single fixed-length AI field", () => {
-    const bars = encodeGS1128("(01)12345678901234");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeGS1128("(01)12345678901234")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it("encodes multiple AI fields", () => {
-    const bars = encodeGS1128("(01)12345678901234(17)260101");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(01)12345678901234(17)260101")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes with variable-length AI field", () => {
-    const bars = encodeGS1128("(10)ABC123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(10)ABC123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes mixed fixed and variable-length AI fields", () => {
-    const bars = encodeGS1128("(01)12345678901234(10)ABC123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(01)12345678901234(10)ABC123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes AI 21 (serial number)", () => {
-    const bars = encodeGS1128("(21)SERIAL123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(21)SERIAL123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes date AI fields (11, 13, 15, 17)", () => {
-    const bars11 = encodeGS1128("(11)260101");
-    const bars13 = encodeGS1128("(13)260101");
-    const bars15 = encodeGS1128("(15)260101");
-    const bars17 = encodeGS1128("(17)260101");
-    expect(bars11.length).toBeGreaterThan(0);
-    expect(bars13.length).toBeGreaterThan(0);
-    expect(bars15.length).toBeGreaterThan(0);
-    expect(bars17.length).toBeGreaterThan(0);
-  });
+    const bars11 = encodeGS1128("(11)260101")
+    const bars13 = encodeGS1128("(13)260101")
+    const bars15 = encodeGS1128("(15)260101")
+    const bars17 = encodeGS1128("(17)260101")
+    expect(bars11.length).toBeGreaterThan(0)
+    expect(bars13.length).toBeGreaterThan(0)
+    expect(bars15.length).toBeGreaterThan(0)
+    expect(bars17.length).toBeGreaterThan(0)
+  })
 
   it("encodes AI 20 (product variant)", () => {
-    const bars = encodeGS1128("(20)05");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(20)05")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Valid encoding (plain string format) ---
 
   it("encodes a plain numeric string", () => {
-    const bars = encodeGS1128("1234567890");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("1234567890")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes a plain alphanumeric string", () => {
-    const bars = encodeGS1128("ABC123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("ABC123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1-4)", () => {
-    const bars = encodeGS1128("(01)12345678901234");
+    const bars = encodeGS1128("(01)12345678901234")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(4);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(4)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("ends with the stop pattern", () => {
-    const bars = encodeGS1128("(01)12345678901234");
+    const bars = encodeGS1128("(01)12345678901234")
     // Stop pattern is [2, 3, 3, 1, 1, 1, 2] (7 elements)
-    const lastSeven = bars.slice(-7);
-    expect(lastSeven).toEqual([2, 3, 3, 1, 1, 1, 2]);
-  });
+    const lastSeven = bars.slice(-7)
+    expect(lastSeven).toEqual([2, 3, 3, 1, 1, 1, 2])
+  })
 
   // --- FNC1 separator handling ---
 
   it("variable-length field followed by another field inserts FNC1 separator", () => {
     // AI 10 is variable-length, AI 01 is fixed
-    const barsWithSep = encodeGS1128("(10)ABC(01)12345678901234");
-    expect(barsWithSep.length).toBeGreaterThan(0);
-  });
+    const barsWithSep = encodeGS1128("(10)ABC(01)12345678901234")
+    expect(barsWithSep.length).toBeGreaterThan(0)
+  })
 
   it("fixed-length field does not need FNC1 separator before next field", () => {
     // AI 01 is fixed (14 digits), so no FNC1 between 01 and 17
-    const bars = encodeGS1128("(01)12345678901234(17)260101");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(01)12345678901234(17)260101")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeGS1128("(01)12345678901234");
-    const bars2 = encodeGS1128("(01)98765432109876");
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeGS1128("(01)12345678901234")
+    const bars2 = encodeGS1128("(01)98765432109876")
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same input produces same output", () => {
-    const bars1 = encodeGS1128("(01)12345678901234");
-    const bars2 = encodeGS1128("(01)12345678901234");
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeGS1128("(01)12345678901234")
+    const bars2 = encodeGS1128("(01)12345678901234")
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on empty input", () => {
-    expect(() => encodeGS1128("")).toThrow("must not be empty");
-  });
+    expect(() => encodeGS1128("")).toThrow("must not be empty")
+  })
 
   it("throws on missing closing parenthesis in AI", () => {
-    expect(() => encodeGS1128("(01 12345678901234")).toThrow("Missing closing ')'");
-  });
+    expect(() => encodeGS1128("(01 12345678901234")).toThrow("Missing closing ')'")
+  })
 
   it("throws on invalid AI (non-numeric)", () => {
-    expect(() => encodeGS1128("(AB)12345")).toThrow("must contain only digits");
-  });
+    expect(() => encodeGS1128("(AB)12345")).toThrow("must contain only digits")
+  })
 
   it("throws on empty data for an AI field", () => {
-    expect(() => encodeGS1128("(01)")).toThrow("Empty data");
-  });
+    expect(() => encodeGS1128("(01)")).toThrow("Empty data")
+  })
 
   it("throws on AI with wrong fixed-length data", () => {
     // AI 01 requires exactly 14 digits
-    expect(() => encodeGS1128("(01)123")).toThrow("requires exactly");
-  });
+    expect(() => encodeGS1128("(01)123")).toThrow("requires exactly")
+  })
 
   it("throws on AI with data that does not match expected format", () => {
     // AI 01 requires 14 digits, letters are not valid
-    expect(() => encodeGS1128("(01)ABCDEFGHIJKLMN")).toThrow("does not match expected format");
-  });
+    expect(() => encodeGS1128("(01)ABCDEFGHIJKLMN")).toThrow("does not match expected format")
+  })
 
   it("throws when AI string has no opening parenthesis", () => {
     // This would be treated as plain string (no parenthesized format)
     // But if it starts with '(' and is malformed, it should throw
-    expect(() => encodeGS1128("()")).toThrow();
-  });
+    expect(() => encodeGS1128("()")).toThrow()
+  })
 
   // --- Edge cases ---
 
   it("encodes a single AI with maximum-length variable data", () => {
     // AI 10 has maxLength 20
-    const bars = encodeGS1128("(10)ABCDEFGHIJKLMNOPQRST");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(10)ABCDEFGHIJKLMNOPQRST")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("handles three-digit AI codes", () => {
     // AI 400 is a valid 3-digit AI
-    const bars = encodeGS1128("(400)ORDERREF123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(400)ORDERREF123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("handles four-digit AI codes", () => {
     // AI 3100 is a valid 4-digit AI (net weight in kg, 0 decimals)
-    const bars = encodeGS1128("(3100)001234");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(3100)001234")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes multiple variable-length fields", () => {
-    const bars = encodeGS1128("(10)BATCH1(21)SERIAL1");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1128("(10)BATCH1(21)SERIAL1")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("Code C optimization for long numeric runs", () => {
     // A long numeric AI value should encode more compactly
-    const bars = encodeGS1128("(01)12345678901234");
+    const bars = encodeGS1128("(01)12345678901234")
     // Just verify it produces valid output
-    expect(bars.length).toBeGreaterThan(0);
+    expect(bars.length).toBeGreaterThan(0)
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(4);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(4)
     }
-  });
-});
+  })
+})

--- a/test/encoders-gs1-composite.test.ts
+++ b/test/encoders-gs1-composite.test.ts
@@ -1,49 +1,49 @@
-import { describe, expect, it } from "vitest";
-import { encodeGS1Composite } from "../src/encoders/gs1-composite";
+import { describe, expect, it } from "vitest"
+import { encodeGS1Composite } from "../src/encoders/gs1-composite"
 
 describe("GS1 Composite", () => {
   it("encodes CC-A (MicroPDF417, 2 columns)", () => {
-    const result = encodeGS1Composite("(17)260101(10)BATCH01", "CC-A");
-    expect(result.type).toBe("CC-A");
-    expect(result.rows).toBeGreaterThan(0);
-    expect(result.composite.length).toBe(result.rows);
-  });
+    const result = encodeGS1Composite("(17)260101(10)BATCH01", "CC-A")
+    expect(result.type).toBe("CC-A")
+    expect(result.rows).toBeGreaterThan(0)
+    expect(result.composite.length).toBe(result.rows)
+  })
 
   it("encodes CC-B (MicroPDF417, 3 columns)", () => {
-    const result = encodeGS1Composite("(17)260101(10)BATCH01", "CC-B");
-    expect(result.type).toBe("CC-B");
-    expect(result.rows).toBeGreaterThan(0);
-  });
+    const result = encodeGS1Composite("(17)260101(10)BATCH01", "CC-B")
+    expect(result.type).toBe("CC-B")
+    expect(result.rows).toBeGreaterThan(0)
+  })
 
   it("encodes CC-C (PDF417)", () => {
-    const result = encodeGS1Composite("(17)260101(10)BATCH01(21)SERIAL001", "CC-C");
-    expect(result.type).toBe("CC-C");
-    expect(result.rows).toBeGreaterThan(0);
-  });
+    const result = encodeGS1Composite("(17)260101(10)BATCH01(21)SERIAL001", "CC-C")
+    expect(result.type).toBe("CC-C")
+    expect(result.rows).toBeGreaterThan(0)
+  })
 
   it("default type is CC-A", () => {
-    const result = encodeGS1Composite("(10)LOT123");
-    expect(result.type).toBe("CC-A");
-  });
+    const result = encodeGS1Composite("(10)LOT123")
+    expect(result.type).toBe("CC-A")
+  })
 
   it("produces boolean matrix", () => {
-    const result = encodeGS1Composite("(10)TEST");
+    const result = encodeGS1Composite("(10)TEST")
     for (const row of result.composite) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("throws on empty", () => {
-    expect(() => encodeGS1Composite("")).toThrow();
-  });
+    expect(() => encodeGS1Composite("")).toThrow()
+  })
 
   it("different data produces different output", () => {
-    const a = encodeGS1Composite("(10)AAA");
-    const b = encodeGS1Composite("(10)BBB");
-    const aStr = a.composite.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const bStr = b.composite.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
-});
+    const a = encodeGS1Composite("(10)AAA")
+    const b = encodeGS1Composite("(10)BBB")
+    const aStr = a.composite.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const bStr = b.composite.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
+})

--- a/test/encoders-gs1-databar.test.ts
+++ b/test/encoders-gs1-databar.test.ts
@@ -1,189 +1,189 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   encodeGS1DataBarOmni,
   encodeGS1DataBarLimited,
   encodeGS1DataBarExpanded,
-} from "../src/encoders/gs1-databar";
-import { barcode } from "../src/index";
+} from "../src/encoders/gs1-databar"
+import { barcode } from "../src/index"
 
 describe("GS1 DataBar Omnidirectional", () => {
   it("encodes 14-digit GTIN", () => {
-    const bars = encodeGS1DataBarOmni("01234567890128");
-    expect(bars.length).toBeGreaterThan(0);
-    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1);
-  });
+    const bars = encodeGS1DataBarOmni("01234567890128")
+    expect(bars.length).toBeGreaterThan(0)
+    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1)
+  })
 
   it("encodes 13-digit GTIN (auto check digit)", () => {
-    const bars = encodeGS1DataBarOmni("0123456789012");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1DataBarOmni("0123456789012")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("produces exactly 46 elements totaling 96 modules", () => {
-    const bars = encodeGS1DataBarOmni("01234567890128");
-    expect(bars).toHaveLength(46);
-    expect(bars.reduce((a, b) => a + b, 0)).toBe(96);
-  });
+    const bars = encodeGS1DataBarOmni("01234567890128")
+    expect(bars).toHaveLength(46)
+    expect(bars.reduce((a, b) => a + b, 0)).toBe(96)
+  })
 
   it("has correct guard patterns", () => {
-    const bars = encodeGS1DataBarOmni("01234567890128");
-    expect(bars[0]).toBe(1);
-    expect(bars[1]).toBe(1);
-    expect(bars[44]).toBe(1);
-    expect(bars[45]).toBe(1);
-  });
+    const bars = encodeGS1DataBarOmni("01234567890128")
+    expect(bars[0]).toBe(1)
+    expect(bars[1]).toBe(1)
+    expect(bars[44]).toBe(1)
+    expect(bars[45]).toBe(1)
+  })
 
   it("all elements are between 1 and 9", () => {
-    const bars = encodeGS1DataBarOmni("5901234123457");
+    const bars = encodeGS1DataBarOmni("5901234123457")
     for (const b of bars) {
-      expect(b).toBeGreaterThanOrEqual(1);
-      expect(b).toBeLessThanOrEqual(9);
+      expect(b).toBeGreaterThanOrEqual(1)
+      expect(b).toBeLessThanOrEqual(9)
     }
-  });
+  })
 
   it("same input produces same output (deterministic)", () => {
-    const a = encodeGS1DataBarOmni("01234567890128");
-    const b = encodeGS1DataBarOmni("01234567890128");
-    expect(a).toEqual(b);
-  });
+    const a = encodeGS1DataBarOmni("01234567890128")
+    const b = encodeGS1DataBarOmni("01234567890128")
+    expect(a).toEqual(b)
+  })
 
   it("different GTINs produce different output", () => {
-    const a = encodeGS1DataBarOmni("01234567890128");
-    const b = encodeGS1DataBarOmni("5901234123457");
-    expect(a).not.toEqual(b);
-  });
+    const a = encodeGS1DataBarOmni("01234567890128")
+    const b = encodeGS1DataBarOmni("5901234123457")
+    expect(a).not.toEqual(b)
+  })
 
   it("13-digit and 14-digit (with check) produce same output", () => {
-    const a = encodeGS1DataBarOmni("0123456789012");
-    const b = encodeGS1DataBarOmni("01234567890128");
-    expect(a).toEqual(b);
-  });
+    const a = encodeGS1DataBarOmni("0123456789012")
+    const b = encodeGS1DataBarOmni("01234567890128")
+    expect(a).toEqual(b)
+  })
 
   it("throws on non-numeric", () => {
-    expect(() => encodeGS1DataBarOmni("ABC")).toThrow();
-  });
+    expect(() => encodeGS1DataBarOmni("ABC")).toThrow()
+  })
 
   it("throws on wrong length", () => {
-    expect(() => encodeGS1DataBarOmni("12345")).toThrow();
-  });
+    expect(() => encodeGS1DataBarOmni("12345")).toThrow()
+  })
 
   it("throws on invalid check digit", () => {
-    expect(() => encodeGS1DataBarOmni("01234567890129")).toThrow(/check digit/i);
-  });
+    expect(() => encodeGS1DataBarOmni("01234567890129")).toThrow(/check digit/i)
+  })
 
   it("works via barcode()", () => {
-    const svg = barcode("01234567890128", { type: "gs1-databar" });
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = barcode("01234567890128", { type: "gs1-databar" })
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("GS1 DataBar Limited", () => {
   it("encodes GTIN starting with 0", () => {
-    const bars = encodeGS1DataBarLimited("01234567890128");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1DataBarLimited("01234567890128")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes GTIN starting with 1", () => {
-    const bars = encodeGS1DataBarLimited("11234567890125");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1DataBarLimited("11234567890125")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("produces exactly 47 elements", () => {
-    const bars = encodeGS1DataBarLimited("01234567890128");
-    expect(bars).toHaveLength(47);
-  });
+    const bars = encodeGS1DataBarLimited("01234567890128")
+    expect(bars).toHaveLength(47)
+  })
 
   it("has correct guard patterns and terminator", () => {
-    const bars = encodeGS1DataBarLimited("01234567890128");
-    expect(bars[0]).toBe(1);
-    expect(bars[1]).toBe(1);
-    expect(bars[44]).toBe(1);
-    expect(bars[45]).toBe(1);
-    expect(bars[46]).toBe(5); // terminator bar
-  });
+    const bars = encodeGS1DataBarLimited("01234567890128")
+    expect(bars[0]).toBe(1)
+    expect(bars[1]).toBe(1)
+    expect(bars[44]).toBe(1)
+    expect(bars[45]).toBe(1)
+    expect(bars[46]).toBe(5) // terminator bar
+  })
 
   it("data pairs each sum to 26 modules", () => {
-    const bars = encodeGS1DataBarLimited("01234567890128");
+    const bars = encodeGS1DataBarLimited("01234567890128")
     // Left pair: elements 2-15 (14 elements)
-    const leftPairSum = bars.slice(2, 16).reduce((a, b) => a + b, 0);
-    expect(leftPairSum).toBe(26);
+    const leftPairSum = bars.slice(2, 16).reduce((a, b) => a + b, 0)
+    expect(leftPairSum).toBe(26)
     // Right pair: elements 30-43 (14 elements)
-    const rightPairSum = bars.slice(30, 44).reduce((a, b) => a + b, 0);
-    expect(rightPairSum).toBe(26);
-  });
+    const rightPairSum = bars.slice(30, 44).reduce((a, b) => a + b, 0)
+    expect(rightPairSum).toBe(26)
+  })
 
   it("all elements are between 1 and 9", () => {
-    const bars = encodeGS1DataBarLimited("01234567890128");
+    const bars = encodeGS1DataBarLimited("01234567890128")
     // Skip terminator bar (index 46 = 5)
     for (let i = 0; i < 46; i++) {
-      expect(bars[i]).toBeGreaterThanOrEqual(1);
-      expect(bars[i]).toBeLessThanOrEqual(9);
+      expect(bars[i]).toBeGreaterThanOrEqual(1)
+      expect(bars[i]).toBeLessThanOrEqual(9)
     }
-  });
+  })
 
   it("throws on GTIN starting with 2+", () => {
-    expect(() => encodeGS1DataBarLimited("21234567890122")).toThrow();
-  });
+    expect(() => encodeGS1DataBarLimited("21234567890122")).toThrow()
+  })
 
   it("throws on invalid check digit", () => {
-    expect(() => encodeGS1DataBarLimited("01234567890121")).toThrow(/check digit/i);
-  });
+    expect(() => encodeGS1DataBarLimited("01234567890121")).toThrow(/check digit/i)
+  })
 
   it("works via barcode()", () => {
-    const svg = barcode("01234567890128", { type: "gs1-databar-limited" });
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = barcode("01234567890128", { type: "gs1-databar-limited" })
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("GS1 DataBar Expanded", () => {
   it("encodes AI data", () => {
-    const bars = encodeGS1DataBarExpanded("(01)12345678901234");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1DataBarExpanded("(01)12345678901234")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes plain text", () => {
-    const bars = encodeGS1DataBarExpanded("HELLO123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeGS1DataBarExpanded("HELLO123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("has correct guard patterns", () => {
-    const bars = encodeGS1DataBarExpanded("(01)12345678901234");
-    expect(bars[0]).toBe(1);
-    expect(bars[1]).toBe(1);
-    expect(bars[bars.length - 2]).toBe(1);
-    expect(bars[bars.length - 1]).toBe(1);
-  });
+    const bars = encodeGS1DataBarExpanded("(01)12345678901234")
+    expect(bars[0]).toBe(1)
+    expect(bars[1]).toBe(1)
+    expect(bars[bars.length - 2]).toBe(1)
+    expect(bars[bars.length - 1]).toBe(1)
+  })
 
   it("all elements are >= 1", () => {
-    const bars = encodeGS1DataBarExpanded("(01)12345678901234");
+    const bars = encodeGS1DataBarExpanded("(01)12345678901234")
     for (const b of bars) {
-      expect(b).toBeGreaterThanOrEqual(1);
+      expect(b).toBeGreaterThanOrEqual(1)
     }
-  });
+  })
 
   it("longer data produces more elements", () => {
-    const short = encodeGS1DataBarExpanded("(01)12345678901234");
-    const long = encodeGS1DataBarExpanded("(01)12345678901234(10)ABC123");
-    expect(long.length).toBeGreaterThan(short.length);
-  });
+    const short = encodeGS1DataBarExpanded("(01)12345678901234")
+    const long = encodeGS1DataBarExpanded("(01)12345678901234(10)ABC123")
+    expect(long.length).toBeGreaterThan(short.length)
+  })
 
   it("throws on empty", () => {
-    expect(() => encodeGS1DataBarExpanded("")).toThrow();
-  });
+    expect(() => encodeGS1DataBarExpanded("")).toThrow()
+  })
 
   it("works via barcode()", () => {
-    const svg = barcode("(01)12345678901234", { type: "gs1-databar-expanded" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("(01)12345678901234", { type: "gs1-databar-expanded" })
+    expect(svg).toContain("<svg")
+  })
 
   it("different data produces different output", () => {
-    const a = encodeGS1DataBarExpanded("(01)12345678901234");
-    const b = encodeGS1DataBarExpanded("(01)98765432109876");
-    expect(a).not.toEqual(b);
-  });
+    const a = encodeGS1DataBarExpanded("(01)12345678901234")
+    const b = encodeGS1DataBarExpanded("(01)98765432109876")
+    expect(a).not.toEqual(b)
+  })
 
   it("deterministic encoding", () => {
-    const a = encodeGS1DataBarExpanded("(01)12345678901234");
-    const b = encodeGS1DataBarExpanded("(01)12345678901234");
-    expect(a).toEqual(b);
-  });
-});
+    const a = encodeGS1DataBarExpanded("(01)12345678901234")
+    const b = encodeGS1DataBarExpanded("(01)12345678901234")
+    expect(a).toEqual(b)
+  })
+})

--- a/test/encoders-hanxin.test.ts
+++ b/test/encoders-hanxin.test.ts
@@ -1,57 +1,57 @@
-import { describe, expect, it } from "vitest";
-import { encodeHanXin } from "../src/encoders/hanxin";
+import { describe, expect, it } from "vitest"
+import { encodeHanXin } from "../src/encoders/hanxin"
 
 describe("Han Xin Code", () => {
   it("encodes short text", () => {
-    const matrix = encodeHanXin("Hello");
-    expect(matrix.length).toBeGreaterThanOrEqual(23);
-    expect(matrix[0]!.length).toBe(matrix.length); // square
-  });
+    const matrix = encodeHanXin("Hello")
+    expect(matrix.length).toBeGreaterThanOrEqual(23)
+    expect(matrix[0]!.length).toBe(matrix.length) // square
+  })
 
   it("4 finder patterns at corners", () => {
-    const matrix = encodeHanXin("Test");
-    const size = matrix.length;
+    const matrix = encodeHanXin("Test")
+    const size = matrix.length
     // Top-left (chevron pattern, not QR square)
-    expect(matrix[0]![0]).toBe(true);
+    expect(matrix[0]![0]).toBe(true)
     // Top-right
-    expect(matrix[0]![size - 1]).toBe(true);
+    expect(matrix[0]![size - 1]).toBe(true)
     // Bottom-left
-    expect(matrix[size - 1]![0]).toBe(true);
+    expect(matrix[size - 1]![0]).toBe(true)
     // Bottom-right (Han Xin has 4th finder, unlike QR)
-    expect(matrix[size - 1]![size - 1]).toBe(true);
-  });
+    expect(matrix[size - 1]![size - 1]).toBe(true)
+  })
 
   it("produces boolean matrix", () => {
-    const matrix = encodeHanXin("Data");
+    const matrix = encodeHanXin("Data")
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("supports EC levels", () => {
     for (const ecLevel of [1, 2, 3, 4] as const) {
-      const matrix = encodeHanXin("Test", { ecLevel });
-      expect(matrix.length).toBeGreaterThanOrEqual(23);
+      const matrix = encodeHanXin("Test", { ecLevel })
+      expect(matrix.length).toBeGreaterThanOrEqual(23)
     }
-  });
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeHanXin("")).toThrow();
-  });
+    expect(() => encodeHanXin("")).toThrow()
+  })
 
   it("larger data produces larger matrix", () => {
-    const small = encodeHanXin("Hi");
-    const large = encodeHanXin("A".repeat(100));
-    expect(large.length).toBeGreaterThan(small.length);
-  });
+    const small = encodeHanXin("Hi")
+    const large = encodeHanXin("A".repeat(100))
+    expect(large.length).toBeGreaterThan(small.length)
+  })
 
   it("different data produces different output", () => {
-    const a = encodeHanXin("Hello");
-    const b = encodeHanXin("World");
-    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
-});
+    const a = encodeHanXin("Hello")
+    const b = encodeHanXin("World")
+    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
+})

--- a/test/encoders-hibc.test.ts
+++ b/test/encoders-hibc.test.ts
@@ -1,86 +1,86 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   encodeHIBCPrimary,
   encodeHIBCSecondary,
   encodeHIBCConcatenated,
-} from "../src/encoders/hibc";
+} from "../src/encoders/hibc"
 
 describe("HIBC Primary", () => {
   it("encodes LIC + product", () => {
-    const result = encodeHIBCPrimary("A123", "PROD456");
-    expect(result).toMatch(/^\+A123PROD4560.$/); // + LIC PRODUCT UOM CHECK
-  });
+    const result = encodeHIBCPrimary("A123", "PROD456")
+    expect(result).toMatch(/^\+A123PROD4560.$/) // + LIC PRODUCT UOM CHECK
+  })
 
   it("starts with +", () => {
-    const result = encodeHIBCPrimary("B999", "XYZ", 1);
-    expect(result[0]).toBe("+");
-  });
+    const result = encodeHIBCPrimary("B999", "XYZ", 1)
+    expect(result[0]).toBe("+")
+  })
 
   it("includes unit of measure", () => {
-    const result = encodeHIBCPrimary("A123", "ITEM", 5);
-    expect(result).toContain("ITEM5");
-  });
+    const result = encodeHIBCPrimary("A123", "ITEM", 5)
+    expect(result).toContain("ITEM5")
+  })
 
   it("throws on invalid LIC", () => {
-    expect(() => encodeHIBCPrimary("123", "PROD")).toThrow();
-    expect(() => encodeHIBCPrimary("AB", "PROD")).toThrow();
-  });
+    expect(() => encodeHIBCPrimary("123", "PROD")).toThrow()
+    expect(() => encodeHIBCPrimary("AB", "PROD")).toThrow()
+  })
 
   it("throws on empty product", () => {
-    expect(() => encodeHIBCPrimary("A123", "")).toThrow();
-  });
+    expect(() => encodeHIBCPrimary("A123", "")).toThrow()
+  })
 
   it("throws on product > 18 chars", () => {
-    expect(() => encodeHIBCPrimary("A123", "A".repeat(19))).toThrow();
-  });
+    expect(() => encodeHIBCPrimary("A123", "A".repeat(19))).toThrow()
+  })
 
   it("check digit is valid HIBC character", () => {
-    const result = encodeHIBCPrimary("A123", "PROD");
-    const check = result[result.length - 1]!;
-    expect("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%").toContain(check);
-  });
-});
+    const result = encodeHIBCPrimary("A123", "PROD")
+    const check = result[result.length - 1]!
+    expect("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%").toContain(check)
+  })
+})
 
 describe("HIBC Secondary", () => {
   it("encodes expiry YYMMDD", () => {
-    const result = encodeHIBCSecondary("260101");
-    expect(result).toMatch(/^\+\$\$3260101.$/);
-  });
+    const result = encodeHIBCSecondary("260101")
+    expect(result).toMatch(/^\+\$\$3260101.$/)
+  })
 
   it("encodes expiry YYMM", () => {
-    const result = encodeHIBCSecondary("2601");
-    expect(result).toMatch(/^\+\$\$22601.$/);
-  });
+    const result = encodeHIBCSecondary("2601")
+    expect(result).toMatch(/^\+\$\$22601.$/)
+  })
 
   it("encodes lot only", () => {
-    const result = encodeHIBCSecondary(undefined, "LOT001");
-    expect(result).toContain("LOT001");
-  });
+    const result = encodeHIBCSecondary(undefined, "LOT001")
+    expect(result).toContain("LOT001")
+  })
 
   it("encodes expiry + lot", () => {
-    const result = encodeHIBCSecondary("260101", "LOT001");
-    expect(result).toContain("260101");
-    expect(result).toContain("LOT001");
-  });
+    const result = encodeHIBCSecondary("260101", "LOT001")
+    expect(result).toContain("260101")
+    expect(result).toContain("LOT001")
+  })
 
   it("throws on invalid expiry format", () => {
-    expect(() => encodeHIBCSecondary("123")).toThrow();
-  });
-});
+    expect(() => encodeHIBCSecondary("123")).toThrow()
+  })
+})
 
 describe("HIBC Concatenated", () => {
   it("combines primary and secondary", () => {
     const result = encodeHIBCConcatenated("A123", "PROD", {
       expiry: "260101",
       lot: "LOT01",
-    });
-    expect(result).toContain("A123");
-    expect(result).toContain("PROD");
-    expect(result).toContain("/");
-  });
+    })
+    expect(result).toContain("A123")
+    expect(result).toContain("PROD")
+    expect(result).toContain("/")
+  })
 
   it("works without secondary", () => {
-    const result = encodeHIBCConcatenated("A123", "PROD");
-    expect(result).toContain("+A123PROD");
-  });
-});
+    const result = encodeHIBCConcatenated("A123", "PROD")
+    expect(result).toContain("+A123PROD")
+  })
+})

--- a/test/encoders-imb.test.ts
+++ b/test/encoders-imb.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { encodeIMb } from "../src/encoders/imb";
+import { describe, expect, it } from "vitest"
+import { encodeIMb } from "../src/encoders/imb"
 
 describe("USPS Intelligent Mail barcode", () => {
   // USPS-B-3200 spec Example 4:
@@ -7,72 +7,72 @@ describe("USPS Intelligent Mail barcode", () => {
   // tracking = "01234567094987654321", routing = "01234567891" (11-digit delivery point)
   // Expected output: AADTFFDFTDADTAADAATFDTDDAAADDTDTTDAFADADDDTFFFDDTTTADFAAADFTDAADA
   it("encodes USPS-B-3200 spec example 4 correctly", () => {
-    const bars = encodeIMb("01234567094987654321", "01234567891");
-    expect(bars.join("")).toBe("AADTFFDFTDADTAADAATFDTDDAAADDTDTTDAFADADDDTFFFDDTTTADFAAADFTDAADA");
-  });
+    const bars = encodeIMb("01234567094987654321", "01234567891")
+    expect(bars.join("")).toBe("AADTFFDFTDADTAADAATFDTDDAAADDTDTTDAFADADDDTFFFDDTTTADFAAADFTDAADA")
+  })
 
   it("returns 65 bars for tracking code only", () => {
-    const bars = encodeIMb("01234567094987654321");
-    expect(bars.length).toBe(65);
-  });
+    const bars = encodeIMb("01234567094987654321")
+    expect(bars.length).toBe(65)
+  })
 
   it("returns 65 bars for tracking + 5-digit ZIP", () => {
-    const bars = encodeIMb("01234567094987654321", "12345");
-    expect(bars.length).toBe(65);
-  });
+    const bars = encodeIMb("01234567094987654321", "12345")
+    expect(bars.length).toBe(65)
+  })
 
   it("returns 65 bars for tracking + 9-digit ZIP+4", () => {
-    const bars = encodeIMb("01234567094987654321", "123456789");
-    expect(bars.length).toBe(65);
-  });
+    const bars = encodeIMb("01234567094987654321", "123456789")
+    expect(bars.length).toBe(65)
+  })
 
   it("returns 65 bars for tracking + 11-digit delivery point", () => {
-    const bars = encodeIMb("01234567094987654321", "12345678901");
-    expect(bars.length).toBe(65);
-  });
+    const bars = encodeIMb("01234567094987654321", "12345678901")
+    expect(bars.length).toBe(65)
+  })
 
   it("all values are valid 4-state (T/A/D/F)", () => {
-    const bars = encodeIMb("01234567094987654321", "12345");
+    const bars = encodeIMb("01234567094987654321", "12345")
     for (const b of bars) {
-      expect(["T", "A", "D", "F"]).toContain(b);
+      expect(["T", "A", "D", "F"]).toContain(b)
     }
-  });
+  })
 
   it("strips spaces and dashes from routing", () => {
-    const a = encodeIMb("01234567094987654321", "12345-6789");
-    const b = encodeIMb("01234567094987654321", "123456789");
-    expect(a).toEqual(b);
-  });
+    const a = encodeIMb("01234567094987654321", "12345-6789")
+    const b = encodeIMb("01234567094987654321", "123456789")
+    expect(a).toEqual(b)
+  })
 
   it("throws on wrong tracking length", () => {
-    expect(() => encodeIMb("12345")).toThrow();
-    expect(() => encodeIMb("123456789012345678901")).toThrow();
-  });
+    expect(() => encodeIMb("12345")).toThrow()
+    expect(() => encodeIMb("123456789012345678901")).toThrow()
+  })
 
   it("throws on wrong routing length", () => {
-    expect(() => encodeIMb("01234567094987654321", "123")).toThrow();
-    expect(() => encodeIMb("01234567094987654321", "1234567")).toThrow();
-  });
+    expect(() => encodeIMb("01234567094987654321", "123")).toThrow()
+    expect(() => encodeIMb("01234567094987654321", "1234567")).toThrow()
+  })
 
   it("throws on non-digit tracking", () => {
-    expect(() => encodeIMb("0123456709498765ABCD")).toThrow();
-  });
+    expect(() => encodeIMb("0123456709498765ABCD")).toThrow()
+  })
 
   it("different tracking codes produce different bars", () => {
-    const a = encodeIMb("01234567094987654321");
-    const b = encodeIMb("99999999999999999999");
-    expect(a).not.toEqual(b);
-  });
+    const a = encodeIMb("01234567094987654321")
+    const b = encodeIMb("99999999999999999999")
+    expect(a).not.toEqual(b)
+  })
 
   it("different routing codes produce different bars", () => {
-    const a = encodeIMb("01234567094987654321", "12345");
-    const b = encodeIMb("01234567094987654321", "54321");
-    expect(a).not.toEqual(b);
-  });
+    const a = encodeIMb("01234567094987654321", "12345")
+    const b = encodeIMb("01234567094987654321", "54321")
+    expect(a).not.toEqual(b)
+  })
 
   it("empty routing produces different result from non-empty", () => {
-    const a = encodeIMb("01234567094987654321");
-    const b = encodeIMb("01234567094987654321", "01234");
-    expect(a).not.toEqual(b);
-  });
-});
+    const a = encodeIMb("01234567094987654321")
+    const b = encodeIMb("01234567094987654321", "01234")
+    expect(a).not.toEqual(b)
+  })
+})

--- a/test/encoders-isbt128.test.ts
+++ b/test/encoders-isbt128.test.ts
@@ -1,89 +1,89 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   encodeISBT128DIN,
   encodeISBT128Component,
   encodeISBT128Expiry,
   encodeISBT128BloodGroup,
   iso7064Mod37_2,
-} from "../src/encoders/isbt128";
-import { barcode } from "../src/index";
+} from "../src/encoders/isbt128"
+import { barcode } from "../src/index"
 
 describe("ISBT 128 DIN", () => {
   it("formats donation identification number with check character", () => {
-    const result = encodeISBT128DIN("US", "12345", "26", "000001");
-    expect(result).toBe("=US12345260000019");
-  });
+    const result = encodeISBT128DIN("US", "12345", "26", "000001")
+    expect(result).toBe("=US12345260000019")
+  })
 
   it("pads facility and donation numbers with check character", () => {
-    const result = encodeISBT128DIN("GB", "1", "26", "1");
-    expect(result).toBe("=GB0000126000001O");
-  });
+    const result = encodeISBT128DIN("GB", "1", "26", "1")
+    expect(result).toBe("=GB0000126000001O")
+  })
 
   it("throws on invalid country code", () => {
-    expect(() => encodeISBT128DIN("USA", "12345", "26", "1")).toThrow();
-  });
+    expect(() => encodeISBT128DIN("USA", "12345", "26", "1")).toThrow()
+  })
 
   it("throws on long facility number", () => {
-    expect(() => encodeISBT128DIN("US", "123456", "26", "1")).toThrow();
-  });
+    expect(() => encodeISBT128DIN("US", "123456", "26", "1")).toThrow()
+  })
 
   it("can be encoded as Code 128 barcode", () => {
-    const din = encodeISBT128DIN("US", "12345", "26", "000001");
-    const svg = barcode(din, { type: "code128" });
-    expect(svg).toContain("<svg");
-  });
-});
+    const din = encodeISBT128DIN("US", "12345", "26", "000001")
+    const svg = barcode(din, { type: "code128" })
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("ISBT 128 Component", () => {
   it("formats product code", () => {
-    expect(encodeISBT128Component("E0791")).toBe("=E0791");
-  });
+    expect(encodeISBT128Component("E0791")).toBe("=E0791")
+  })
 
   it("throws on wrong length", () => {
-    expect(() => encodeISBT128Component("E07")).toThrow();
-  });
-});
+    expect(() => encodeISBT128Component("E07")).toThrow()
+  })
+})
 
 describe("ISBT 128 Expiry", () => {
   it("formats expiry date", () => {
-    expect(encodeISBT128Expiry("260115")).toBe("&260115");
-  });
+    expect(encodeISBT128Expiry("260115")).toBe("&260115")
+  })
 
   it("throws on non-digits", () => {
-    expect(() => encodeISBT128Expiry("26Jan1")).toThrow();
-  });
-});
+    expect(() => encodeISBT128Expiry("26Jan1")).toThrow()
+  })
+})
 
 describe("ISBT 128 Blood Group", () => {
   it("formats blood group code", () => {
-    expect(encodeISBT128BloodGroup("51")).toBe("%51");
-  });
+    expect(encodeISBT128BloodGroup("51")).toBe("%51")
+  })
 
   it("throws on empty", () => {
-    expect(() => encodeISBT128BloodGroup("")).toThrow();
-  });
-});
+    expect(() => encodeISBT128BloodGroup("")).toThrow()
+  })
+})
 
 describe("ISO 7064 Mod 37-2 check character", () => {
   it("computes correct check for numeric input", () => {
-    expect(iso7064Mod37_2("0000000000")).toBe("0");
-  });
+    expect(iso7064Mod37_2("0000000000")).toBe("0")
+  })
 
   it("computes correct check for alphanumeric DIN data", () => {
-    expect(iso7064Mod37_2("US1234526000001")).toBe("9");
-  });
+    expect(iso7064Mod37_2("US1234526000001")).toBe("9")
+  })
 
   it("computes correct check for another DIN", () => {
-    expect(iso7064Mod37_2("GB0000126000001")).toBe("O");
-  });
+    expect(iso7064Mod37_2("GB0000126000001")).toBe("O")
+  })
 
   it("throws on invalid character", () => {
-    expect(() => iso7064Mod37_2("us12345")).toThrow();
-  });
+    expect(() => iso7064Mod37_2("us12345")).toThrow()
+  })
 
   it("handles asterisk in character set", () => {
     // * has value 36 in the Mod 37-2 character set
-    const result = iso7064Mod37_2("*");
-    expect(result).toMatch(/^[0-9A-Z*]$/);
-  });
-});
+    const result = iso7064Mod37_2("*")
+    expect(result).toMatch(/^[0-9A-Z*]$/)
+  })
+})

--- a/test/encoders-itf.test.ts
+++ b/test/encoders-itf.test.ts
@@ -1,145 +1,145 @@
-import { describe, expect, it } from "vitest";
-import { encodeITF, encodeITF14 } from "../src/encoders/itf";
+import { describe, expect, it } from "vitest"
+import { encodeITF, encodeITF14 } from "../src/encoders/itf"
 
 describe("encodeITF", () => {
   // --- Valid encoding ---
 
   it("encodes an even number of digits", () => {
-    const bars = encodeITF("1234");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeITF("1234")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it("encodes two digits (minimum even input)", () => {
-    const bars = encodeITF("00");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeITF("00")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("prepends a leading zero for odd-length input", () => {
-    const barsOdd = encodeITF("123");
-    const barsEven = encodeITF("0123");
+    const barsOdd = encodeITF("123")
+    const barsEven = encodeITF("0123")
     // After prepending 0, '123' becomes '0123', so they should be identical
-    expect(barsOdd).toEqual(barsEven);
-  });
+    expect(barsOdd).toEqual(barsEven)
+  })
 
   it("encodes a single digit by prepending zero", () => {
-    const bars = encodeITF("5");
-    const barsExplicit = encodeITF("05");
-    expect(bars).toEqual(barsExplicit);
-  });
+    const bars = encodeITF("5")
+    const barsExplicit = encodeITF("05")
+    expect(bars).toEqual(barsExplicit)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1 narrow, 3 wide)", () => {
-    const bars = encodeITF("12345678");
+    const bars = encodeITF("12345678")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(3);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(3)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("output length matches expected structure", () => {
     // For N digit pairs: start(4) + N * 10 (interleaved pair) + stop(3)
     // 4 digits = 2 pairs: 4 + 2*10 + 3 = 27
-    const bars = encodeITF("1234");
-    expect(bars.length).toBe(27);
-  });
+    const bars = encodeITF("1234")
+    expect(bars.length).toBe(27)
+  })
 
   it("output length scales with input length", () => {
-    const bars2 = encodeITF("12");
-    const bars4 = encodeITF("1234");
-    const bars8 = encodeITF("12345678");
-    expect(bars4.length).toBeGreaterThan(bars2.length);
-    expect(bars8.length).toBeGreaterThan(bars4.length);
-  });
+    const bars2 = encodeITF("12")
+    const bars4 = encodeITF("1234")
+    const bars8 = encodeITF("12345678")
+    expect(bars4.length).toBeGreaterThan(bars2.length)
+    expect(bars8.length).toBeGreaterThan(bars4.length)
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeITF("1234");
-    const bars2 = encodeITF("5678");
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeITF("1234")
+    const bars2 = encodeITF("5678")
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same input produces same output", () => {
-    const bars1 = encodeITF("9876");
-    const bars2 = encodeITF("9876");
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeITF("9876")
+    const bars2 = encodeITF("9876")
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on non-digit characters", () => {
-    expect(() => encodeITF("12A4")).toThrow("digits only");
-  });
+    expect(() => encodeITF("12A4")).toThrow("digits only")
+  })
 
   it("throws on letters", () => {
-    expect(() => encodeITF("ABCD")).toThrow("digits only");
-  });
+    expect(() => encodeITF("ABCD")).toThrow("digits only")
+  })
 
   it("throws on special characters", () => {
-    expect(() => encodeITF("12-34")).toThrow("digits only");
-  });
-});
+    expect(() => encodeITF("12-34")).toThrow("digits only")
+  })
+})
 
 describe("encodeITF14", () => {
   // --- Valid encoding ---
 
   it("encodes 13 digits with auto-calculated check digit", () => {
-    const bars = encodeITF14("1234567890123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeITF14("1234567890123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes 14 digits (with provided check digit)", () => {
     // First encode 13 digits, then use the full 14 that includes the check
-    const bars = encodeITF14("00012345600012");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeITF14("00012345600012")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("output length is fixed for all ITF-14 (14 digits = 7 pairs)", () => {
-    const bars = encodeITF14("1234567890123");
+    const bars = encodeITF14("1234567890123")
     // 14 digits = 7 pairs: start(4) + 7*10 + stop(3) = 77
-    expect(bars.length).toBe(77);
-  });
+    expect(bars.length).toBe(77)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths", () => {
-    const bars = encodeITF14("1234567890123");
+    const bars = encodeITF14("1234567890123")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(3);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(3)
     }
-  });
+  })
 
   // --- Check digit calculation ---
 
   it("13-digit and 14-digit inputs produce same result when check digit is correct", () => {
     // Use a known ITF-14: 1234567890128 (check digit 8)
     // Verify by encoding both forms
-    const bars13 = encodeITF14("1234567890128");
+    const bars13 = encodeITF14("1234567890128")
     // If check digit auto-calc gives 8, then 14-digit version with 8 should match
     // Since we do not know the check digit a priori, just verify both produce output
-    expect(bars13.length).toBeGreaterThan(0);
-  });
+    expect(bars13.length).toBeGreaterThan(0)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on wrong length (not 13 or 14)", () => {
-    expect(() => encodeITF14("12345")).toThrow("13 or 14 digits");
-    expect(() => encodeITF14("123456789012345")).toThrow("13 or 14 digits");
-  });
+    expect(() => encodeITF14("12345")).toThrow("13 or 14 digits")
+    expect(() => encodeITF14("123456789012345")).toThrow("13 or 14 digits")
+  })
 
   it("throws on non-digit input", () => {
-    expect(() => encodeITF14("123456789012A")).toThrow("digits only");
-  });
+    expect(() => encodeITF14("123456789012A")).toThrow("digits only")
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeITF14("1234567890123");
-    const bars2 = encodeITF14("9876543210987");
-    expect(bars1).not.toEqual(bars2);
-  });
-});
+    const bars1 = encodeITF14("1234567890123")
+    const bars2 = encodeITF14("9876543210987")
+    expect(bars1).not.toEqual(bars2)
+  })
+})

--- a/test/encoders-jabcode.test.ts
+++ b/test/encoders-jabcode.test.ts
@@ -1,57 +1,57 @@
-import { describe, expect, it } from "vitest";
-import { encodeJABCode, JAB_COLORS_4, JAB_COLORS_8 } from "../src/encoders/jabcode";
+import { describe, expect, it } from "vitest"
+import { encodeJABCode, JAB_COLORS_4, JAB_COLORS_8 } from "../src/encoders/jabcode"
 
 describe("JAB Code", () => {
   it("encodes with 4 colors (default)", () => {
-    const result = encodeJABCode("Hello");
-    expect(result.matrix.length).toBeGreaterThan(0);
-    expect(result.palette).toBe(JAB_COLORS_4);
+    const result = encodeJABCode("Hello")
+    expect(result.matrix.length).toBeGreaterThan(0)
+    expect(result.palette).toBe(JAB_COLORS_4)
     // All values should be 0-3
     for (const row of result.matrix) {
       for (const cell of row) {
-        expect(cell).toBeGreaterThanOrEqual(0);
-        expect(cell).toBeLessThanOrEqual(3);
+        expect(cell).toBeGreaterThanOrEqual(0)
+        expect(cell).toBeLessThanOrEqual(3)
       }
     }
-  });
+  })
 
   it("encodes with 8 colors", () => {
-    const result = encodeJABCode("Hello", { colors: 8 });
-    expect(result.palette).toBe(JAB_COLORS_8);
+    const result = encodeJABCode("Hello", { colors: 8 })
+    expect(result.palette).toBe(JAB_COLORS_8)
     for (const row of result.matrix) {
       for (const cell of row) {
-        expect(cell).toBeGreaterThanOrEqual(0);
-        expect(cell).toBeLessThanOrEqual(7);
+        expect(cell).toBeGreaterThanOrEqual(0)
+        expect(cell).toBeLessThanOrEqual(7)
       }
     }
-  });
+  })
 
   it("8-color is more compact than 4-color", () => {
-    const c4 = encodeJABCode("Hello World Test Data", { colors: 4 });
-    const c8 = encodeJABCode("Hello World Test Data", { colors: 8 });
-    expect(c8.rows).toBeLessThanOrEqual(c4.rows);
-  });
+    const c4 = encodeJABCode("Hello World Test Data", { colors: 4 })
+    const c8 = encodeJABCode("Hello World Test Data", { colors: 8 })
+    expect(c8.rows).toBeLessThanOrEqual(c4.rows)
+  })
 
   it("square matrix", () => {
-    const result = encodeJABCode("Test");
-    expect(result.rows).toBe(result.cols);
-  });
+    const result = encodeJABCode("Test")
+    expect(result.rows).toBe(result.cols)
+  })
 
   it("throws on empty", () => {
-    expect(() => encodeJABCode("")).toThrow();
-  });
+    expect(() => encodeJABCode("")).toThrow()
+  })
 
   it("different data produces different output", () => {
-    const a = encodeJABCode("Hello");
-    const b = encodeJABCode("World");
-    const aStr = a.matrix.map((r) => r.join("")).join("");
-    const bStr = b.matrix.map((r) => r.join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
+    const a = encodeJABCode("Hello")
+    const b = encodeJABCode("World")
+    const aStr = a.matrix.map((r) => r.join("")).join("")
+    const bStr = b.matrix.map((r) => r.join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
 
   it("returns color palette", () => {
-    const result = encodeJABCode("Test");
-    expect(result.palette.length).toBe(4);
-    expect(result.palette[0]).toBe("#000000");
-  });
-});
+    const result = encodeJABCode("Test")
+    expect(result.palette.length).toBe(4)
+    expect(result.palette[0]).toBe("#000000")
+  })
+})

--- a/test/encoders-maxicode.test.ts
+++ b/test/encoders-maxicode.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { encodeMaxiCode } from "../src/encoders/maxicode";
+import { describe, expect, it } from "vitest"
+import { encodeMaxiCode } from "../src/encoders/maxicode"
 
 describe("MaxiCode", () => {
   it("encodes mode 4 (standard)", () => {
-    const matrix = encodeMaxiCode("Hello World");
-    expect(matrix.length).toBe(33);
-    expect(matrix[0]!.length).toBe(30);
-  });
+    const matrix = encodeMaxiCode("Hello World")
+    expect(matrix.length).toBe(33)
+    expect(matrix[0]!.length).toBe(30)
+  })
 
   it("encodes mode 2 (US structured carrier)", () => {
     const matrix = encodeMaxiCode("UPS TRACKING DATA", {
@@ -14,9 +14,9 @@ describe("MaxiCode", () => {
       postalCode: "123456789",
       countryCode: 840,
       serviceClass: 1,
-    });
-    expect(matrix.length).toBe(33);
-  });
+    })
+    expect(matrix.length).toBe(33)
+  })
 
   it("encodes mode 3 (international structured)", () => {
     const matrix = encodeMaxiCode("DHL DATA", {
@@ -24,52 +24,52 @@ describe("MaxiCode", () => {
       postalCode: "EC1A1B",
       countryCode: 826,
       serviceClass: 1,
-    });
-    expect(matrix.length).toBe(33);
-  });
+    })
+    expect(matrix.length).toBe(33)
+  })
 
   it("produces boolean matrix", () => {
-    const matrix = encodeMaxiCode("Test");
+    const matrix = encodeMaxiCode("Test")
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("has data in matrix", () => {
-    const matrix = encodeMaxiCode("Test");
+    const matrix = encodeMaxiCode("Test")
     // Matrix should contain both dark and light modules
-    let hasDark = false;
-    let hasLight = false;
+    let hasDark = false
+    let hasLight = false
     for (const row of matrix) {
       for (const cell of row) {
-        if (cell) hasDark = true;
-        else hasLight = true;
+        if (cell) hasDark = true
+        else hasLight = true
       }
     }
-    expect(hasDark).toBe(true);
-    expect(hasLight).toBe(true);
-  });
+    expect(hasDark).toBe(true)
+    expect(hasLight).toBe(true)
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeMaxiCode("")).toThrow();
-  });
+    expect(() => encodeMaxiCode("")).toThrow()
+  })
 
   it("different data produces different matrix", () => {
-    const a = encodeMaxiCode("Hello");
-    const b = encodeMaxiCode("World");
-    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
+    const a = encodeMaxiCode("Hello")
+    const b = encodeMaxiCode("World")
+    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
 
   it("always 33x30", () => {
-    const short = encodeMaxiCode("Hi");
-    const long = encodeMaxiCode("This is a longer MaxiCode message for testing");
-    expect(short.length).toBe(33);
-    expect(short[0]!.length).toBe(30);
-    expect(long.length).toBe(33);
-    expect(long[0]!.length).toBe(30);
-  });
-});
+    const short = encodeMaxiCode("Hi")
+    const long = encodeMaxiCode("This is a longer MaxiCode message for testing")
+    expect(short.length).toBe(33)
+    expect(short[0]!.length).toBe(30)
+    expect(long.length).toBe(33)
+    expect(long[0]!.length).toBe(30)
+  })
+})

--- a/test/encoders-micro-qr.test.ts
+++ b/test/encoders-micro-qr.test.ts
@@ -1,70 +1,70 @@
-import { describe, expect, it } from "vitest";
-import { encodeMicroQR } from "../src/encoders/qr/micro";
+import { describe, expect, it } from "vitest"
+import { encodeMicroQR } from "../src/encoders/qr/micro"
 
 describe("Micro QR Code", () => {
   it("encodes M1 (numeric only, 11x11)", () => {
-    const matrix = encodeMicroQR("12345");
-    expect(matrix.length).toBe(11);
-    expect(matrix[0]!.length).toBe(11);
-  });
+    const matrix = encodeMicroQR("12345")
+    expect(matrix.length).toBe(11)
+    expect(matrix[0]!.length).toBe(11)
+  })
 
   it("encodes M2 (alphanumeric, 13x13)", () => {
-    const matrix = encodeMicroQR("AB12");
-    expect(matrix.length).toBe(13);
-  });
+    const matrix = encodeMicroQR("AB12")
+    expect(matrix.length).toBe(13)
+  })
 
   it("encodes M3 (byte mode, 15x15)", () => {
-    const matrix = encodeMicroQR("hello");
-    expect(matrix.length).toBe(15);
-  });
+    const matrix = encodeMicroQR("hello")
+    expect(matrix.length).toBe(15)
+  })
 
   it("encodes M4 (larger byte, 17x17)", () => {
-    const matrix = encodeMicroQR("Hello World!!");
-    expect(matrix.length).toBe(17);
-  });
+    const matrix = encodeMicroQR("Hello World!!")
+    expect(matrix.length).toBe(17)
+  })
 
   it("produces boolean matrix", () => {
-    const matrix = encodeMicroQR("123");
+    const matrix = encodeMicroQR("123")
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("has finder pattern at top-left", () => {
-    const matrix = encodeMicroQR("123");
-    expect(matrix[0]![0]).toBe(true);
-    expect(matrix[0]![6]).toBe(true);
-    expect(matrix[6]![0]).toBe(true);
-    expect(matrix[3]![3]).toBe(true);
-  });
+    const matrix = encodeMicroQR("123")
+    expect(matrix[0]![0]).toBe(true)
+    expect(matrix[0]![6]).toBe(true)
+    expect(matrix[6]![0]).toBe(true)
+    expect(matrix[3]![3]).toBe(true)
+  })
 
   it("has NO finder at other corners (single finder)", () => {
-    const _matrix = encodeMicroQR("123");
+    const _matrix = encodeMicroQR("123")
     // const size = matrix.length;
     // Bottom-right should not have a finder
     // (unlike standard QR which has 3 finders)
-  });
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeMicroQR("")).toThrow();
-  });
+    expect(() => encodeMicroQR("")).toThrow()
+  })
 
   it("throws on data too long", () => {
-    expect(() => encodeMicroQR("A".repeat(100))).toThrow();
-  });
+    expect(() => encodeMicroQR("A".repeat(100))).toThrow()
+  })
 
   it("supports explicit version", () => {
-    const matrix = encodeMicroQR("12", { version: 2 });
-    expect(matrix.length).toBe(13);
-  });
+    const matrix = encodeMicroQR("12", { version: 2 })
+    expect(matrix.length).toBe(13)
+  })
 
   it("different data produces different matrices", () => {
-    const a = encodeMicroQR("123");
-    const b = encodeMicroQR("456");
-    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
-});
+    const a = encodeMicroQR("123")
+    const b = encodeMicroQR("456")
+    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
+})

--- a/test/encoders-micropdf417.test.ts
+++ b/test/encoders-micropdf417.test.ts
@@ -1,46 +1,46 @@
-import { describe, expect, it } from "vitest";
-import { encodeMicroPDF417 } from "../src/encoders/micropdf417";
+import { describe, expect, it } from "vitest"
+import { encodeMicroPDF417 } from "../src/encoders/micropdf417"
 
 describe("MicroPDF417", () => {
   it("encodes short text", () => {
-    const result = encodeMicroPDF417("Hello");
-    expect(result.matrix.length).toBeGreaterThan(0);
-    expect(result.rows).toBeGreaterThan(0);
-    expect(result.cols).toBeGreaterThan(0);
-  });
+    const result = encodeMicroPDF417("Hello")
+    expect(result.matrix.length).toBeGreaterThan(0)
+    expect(result.rows).toBeGreaterThan(0)
+    expect(result.cols).toBeGreaterThan(0)
+  })
 
   it("produces boolean matrix", () => {
-    const result = encodeMicroPDF417("Test");
+    const result = encodeMicroPDF417("Test")
     for (const row of result.matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("respects column count", () => {
-    const r1 = encodeMicroPDF417("Hi", { columns: 1 });
-    const r2 = encodeMicroPDF417("Hi", { columns: 2 });
+    const r1 = encodeMicroPDF417("Hi", { columns: 1 })
+    const r2 = encodeMicroPDF417("Hi", { columns: 2 })
     // Different column count should produce different row counts
-    expect(r1.rows).not.toBe(r2.rows);
-  });
+    expect(r1.rows).not.toBe(r2.rows)
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeMicroPDF417("")).toThrow();
-  });
+    expect(() => encodeMicroPDF417("")).toThrow()
+  })
 
   it("all rows have same width", () => {
-    const result = encodeMicroPDF417("Hello World");
-    const widths = result.matrix.map((r) => r.length);
-    const unique = new Set(widths);
-    expect(unique.size).toBe(1);
-  });
+    const result = encodeMicroPDF417("Hello World")
+    const widths = result.matrix.map((r) => r.length)
+    const unique = new Set(widths)
+    expect(unique.size).toBe(1)
+  })
 
   it("different data produces different output", () => {
-    const a = encodeMicroPDF417("Hello");
-    const b = encodeMicroPDF417("World");
-    const aStr = a.matrix.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const bStr = b.matrix.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
-});
+    const a = encodeMicroPDF417("Hello")
+    const b = encodeMicroPDF417("World")
+    const aStr = a.matrix.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const bStr = b.matrix.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
+})

--- a/test/encoders-modes-roundtrip.test.ts
+++ b/test/encoders-modes-roundtrip.test.ts
@@ -8,45 +8,45 @@
  * executed.
  */
 
-import { describe, expect, it } from "vitest";
-import { readBarcodes } from "zxing-wasm/reader";
-import { encodeAztec } from "../src/encoders/aztec/index";
-import { encodePDF417 } from "../src/encoders/pdf417/index";
-import { encodeDataMatrix } from "../src/encoders/datamatrix/index";
-import { encodeHighLevel, bitsToCodewords } from "../src/encoders/aztec/encoder";
+import { describe, expect, it } from "vitest"
+import { readBarcodes } from "zxing-wasm/reader"
+import { encodeAztec } from "../src/encoders/aztec/index"
+import { encodePDF417 } from "../src/encoders/pdf417/index"
+import { encodeDataMatrix } from "../src/encoders/datamatrix/index"
+import { encodeHighLevel, bitsToCodewords } from "../src/encoders/aztec/encoder"
 
 function matrixToImageData(
   matrix: boolean[][],
   scale = 6,
   margin = 6,
 ): { data: Uint8ClampedArray; width: number; height: number } {
-  const rows = matrix.length;
-  const cols = matrix[0]?.length ?? 0;
-  const width = (cols + margin * 2) * scale;
-  const height = (rows + margin * 2) * scale;
-  const data = new Uint8ClampedArray(width * height * 4);
-  data.fill(255);
+  const rows = matrix.length
+  const cols = matrix[0]?.length ?? 0
+  const width = (cols + margin * 2) * scale
+  const height = (rows + margin * 2) * scale
+  const data = new Uint8ClampedArray(width * height * 4)
+  data.fill(255)
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const mr = Math.floor(y / scale) - margin;
-      const mc = Math.floor(x / scale) - margin;
+      const mr = Math.floor(y / scale) - margin
+      const mc = Math.floor(x / scale) - margin
       if (mr >= 0 && mr < rows && mc >= 0 && mc < cols && matrix[mr]![mc]) {
-        const idx = (y * width + x) * 4;
-        data[idx] = 0;
-        data[idx + 1] = 0;
-        data[idx + 2] = 0;
-        data[idx + 3] = 255;
+        const idx = (y * width + x) * 4
+        data[idx] = 0
+        data[idx + 1] = 0
+        data[idx + 2] = 0
+        data[idx + 3] = 255
       }
     }
   }
-  return { data, width, height };
+  return { data, width, height }
 }
 
 async function decode(matrix: boolean[][], scale = 6): Promise<string | null> {
-  const { data, width, height } = matrixToImageData(matrix, scale);
-  const results = await readBarcodes({ data, width, height } as ImageData, { tryHarder: true });
-  return results.length > 0 ? results[0]!.text : null;
+  const { data, width, height } = matrixToImageData(matrix, scale)
+  const results = await readBarcodes({ data, width, height } as ImageData, { tryHarder: true })
+  return results.length > 0 ? results[0]!.text : null
 }
 
 /**
@@ -58,14 +58,14 @@ async function decode(matrix: boolean[][], scale = 6): Promise<string | null> {
  * is responsible for.
  */
 async function decodeBytes(matrix: boolean[][], scale = 6): Promise<number[] | null> {
-  const { data, width, height } = matrixToImageData(matrix, scale);
-  const results = await readBarcodes({ data, width, height } as ImageData, { tryHarder: true });
-  return results.length > 0 ? [...results[0]!.bytes] : null;
+  const { data, width, height } = matrixToImageData(matrix, scale)
+  const results = await readBarcodes({ data, width, height } as ImageData, { tryHarder: true })
+  return results.length > 0 ? [...results[0]!.bytes] : null
 }
 
 /** Latin-1 bytes of a string, as the 2D encoders treat their input. */
 function latin1(text: string): number[] {
-  return [...text].map((c) => c.charCodeAt(0));
+  return [...text].map((c) => c.charCodeAt(0))
 }
 
 describe("Aztec encoding modes (round-trip)", () => {
@@ -90,83 +90,83 @@ describe("Aztec encoding modes (round-trip)", () => {
     ["digits and punctuation", "12.34, 56.78"],
     ["url-like", "https://example.com/path?a=1&b=2"],
     ["all ASCII printable", "ABCdef123 .,:;!?"],
-  ];
+  ]
 
   for (const [name, text] of cases) {
     it(`round-trips ${name}`, async () => {
-      expect(await decode(encodeAztec(text)), name).toBe(text);
-    });
+      expect(await decode(encodeAztec(text)), name).toBe(text)
+    })
   }
 
   it("round-trips a binary-shift run longer than the 5-bit length field", async () => {
     // Runs over 31 bytes use the extended 11-bit length field
-    const text = "é".repeat(40);
-    expect(await decodeBytes(encodeAztec(text))).toEqual(latin1(text));
-  });
+    const text = "é".repeat(40)
+    expect(await decodeBytes(encodeAztec(text))).toEqual(latin1(text))
+  })
 
   it("round-trips a binary-shift run longer than 62 bytes", async () => {
-    const text = "é".repeat(70);
-    expect(await decodeBytes(encodeAztec(text), 5)).toEqual(latin1(text));
-  });
+    const text = "é".repeat(70)
+    expect(await decodeBytes(encodeAztec(text), 5)).toEqual(latin1(text))
+  })
 
   it("round-trips a binary-shift run spanning the extended field range", async () => {
-    const text = "ü".repeat(200);
-    expect(await decodeBytes(encodeAztec(text), 4)).toEqual(latin1(text));
-  });
+    const text = "ü".repeat(200)
+    expect(await decodeBytes(encodeAztec(text), 4)).toEqual(latin1(text))
+  })
 
   it("round-trips across error correction levels", async () => {
     for (const ecPercent of [5, 23, 50, 80]) {
-      const text = "EC LEVEL TEST 123";
-      expect(await decode(encodeAztec(text, { ecPercent })), String(ecPercent)).toBe(text);
+      const text = "EC LEVEL TEST 123"
+      expect(await decode(encodeAztec(text, { ecPercent })), String(ecPercent)).toBe(text)
     }
-  });
+  })
 
   it("round-trips forced layer counts", async () => {
     for (const layers of [1, 2, 3, 4]) {
-      const text = "LAYERS";
-      expect(await decode(encodeAztec(text, { layers })), String(layers)).toBe(text);
+      const text = "LAYERS"
+      expect(await decode(encodeAztec(text, { layers })), String(layers)).toBe(text)
     }
-  });
+  })
 
   it("round-trips full-range (non-compact) symbols", async () => {
-    const text = "FULL RANGE AZTEC SYMBOL TEST";
-    expect(await decode(encodeAztec(text, { compact: false }))).toBe(text);
-  });
+    const text = "FULL RANGE AZTEC SYMBOL TEST"
+    expect(await decode(encodeAztec(text, { compact: false }))).toBe(text)
+  })
 
   it("round-trips a large payload", async () => {
-    const text = "AZTEC LARGE PAYLOAD " + "0123456789".repeat(20);
-    expect(await decode(encodeAztec(text), 4)).toBe(text);
-  });
-});
+    const text = "AZTEC LARGE PAYLOAD " + "0123456789".repeat(20)
+    expect(await decode(encodeAztec(text), 4)).toBe(text)
+  })
+})
 
 describe("Aztec high-level encoder", () => {
   it("returns no bits for empty input", () => {
-    expect(encodeHighLevel("")).toEqual([]);
-  });
+    expect(encodeHighLevel("")).toEqual([])
+  })
 
   it("emits fewer bits for digits than for the same count of letters", () => {
     // Digit mode is 4 bits/char vs 5 for upper
-    expect(encodeHighLevel("12345678").length).toBeLessThan(encodeHighLevel("ABCDEFGH").length);
-  });
+    expect(encodeHighLevel("12345678").length).toBeLessThan(encodeHighLevel("ABCDEFGH").length)
+  })
 
   it("uses punctuation pairs rather than two separate shifts", () => {
     // ". " as a pair costs less than "." + " " encoded separately
-    const pair = encodeHighLevel("A. B");
-    const separate = encodeHighLevel("A.XB");
-    expect(pair.length).toBeLessThanOrEqual(separate.length);
-  });
+    const pair = encodeHighLevel("A. B")
+    const separate = encodeHighLevel("A.XB")
+    expect(pair.length).toBeLessThanOrEqual(separate.length)
+  })
 
   it("packs bits into codewords of the requested size", () => {
-    const bits = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0];
-    expect(bitsToCodewords(bits, 6)).toEqual([0b101010, 0b101010]);
-    expect(bitsToCodewords(bits, 4)).toEqual([0b1010, 0b1010, 0b1010]);
-  });
+    const bits = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
+    expect(bitsToCodewords(bits, 6)).toEqual([0b101010, 0b101010])
+    expect(bitsToCodewords(bits, 4)).toEqual([0b1010, 0b1010, 0b1010])
+  })
 
   it("pads the final codeword with 1-bits", () => {
     // 5 bits at word size 4 → second word is 1 followed by three pad bits
-    expect(bitsToCodewords([0, 0, 0, 0, 1], 4)).toEqual([0b0000, 0b1111]);
-  });
-});
+    expect(bitsToCodewords([0, 0, 0, 0, 1], 4)).toEqual([0b0000, 0b1111])
+  })
+})
 
 describe("PDF417 compaction modes (round-trip)", () => {
   const cases: Array<[string, string]> = [
@@ -182,43 +182,43 @@ describe("PDF417 compaction modes (round-trip)", () => {
     ["mode switching", "ABC123def!@#456GHI"],
     ["url", "https://example.com/a/b?c=1"],
     ["whitespace", "line one\nline two\ttabbed"],
-  ];
+  ]
 
   for (const [name, text] of cases) {
     it(`round-trips ${name}`, async () => {
-      const result = encodePDF417(text);
-      expect(await decode(result.matrix, 4), name).toBe(text);
-    });
+      const result = encodePDF417(text)
+      expect(await decode(result.matrix, 4), name).toBe(text)
+    })
   }
 
   it("round-trips high-range bytes via byte compaction", async () => {
-    const text = "dataÀÁÂend";
-    const result = encodePDF417(text);
-    expect(await decodeBytes(result.matrix, 4)).toEqual(latin1(text));
-  });
+    const text = "dataÀÁÂend"
+    const result = encodePDF417(text)
+    expect(await decodeBytes(result.matrix, 4)).toEqual(latin1(text))
+  })
 
   it("round-trips across error correction levels", async () => {
     for (const ecLevel of [0, 1, 2, 3, 4, 5]) {
-      const text = "PDF417 EC " + ecLevel;
-      const result = encodePDF417(text, { ecLevel });
-      expect(await decode(result.matrix, 4), `ec ${ecLevel}`).toBe(text);
+      const text = "PDF417 EC " + ecLevel
+      const result = encodePDF417(text, { ecLevel })
+      expect(await decode(result.matrix, 4), `ec ${ecLevel}`).toBe(text)
     }
-  });
+  })
 
   it("round-trips across column counts", async () => {
     for (const columns of [1, 2, 4, 6, 10]) {
-      const text = "PDF417 COLUMNS TEST";
-      const result = encodePDF417(text, { columns });
-      expect(await decode(result.matrix, 4), `columns ${columns}`).toBe(text);
+      const text = "PDF417 COLUMNS TEST"
+      const result = encodePDF417(text, { columns })
+      expect(await decode(result.matrix, 4), `columns ${columns}`).toBe(text)
     }
-  });
+  })
 
   it("round-trips a large payload", async () => {
-    const text = "PDF417 LARGE " + "ABCDEFGHIJ0123456789".repeat(15);
-    const result = encodePDF417(text);
-    expect(await decode(result.matrix, 4)).toBe(text);
-  });
-});
+    const text = "PDF417 LARGE " + "ABCDEFGHIJ0123456789".repeat(15)
+    const result = encodePDF417(text)
+    expect(await decode(result.matrix, 4)).toBe(text)
+  })
+})
 
 describe("Data Matrix encoding modes (round-trip)", () => {
   const cases: Array<[string, string]> = [
@@ -230,11 +230,11 @@ describe("Data Matrix encoding modes (round-trip)", () => {
     ["long numeric", "9".repeat(50)],
     ["long text", "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG"],
     ["punctuation", "a.b,c;d:e!f?g"],
-  ];
+  ]
 
   for (const [name, text] of cases) {
     it(`round-trips ${name}`, async () => {
-      expect(await decode(encodeDataMatrix(text)), name).toBe(text);
-    });
+      expect(await decode(encodeDataMatrix(text)), name).toBe(text)
+    })
   }
-});
+})

--- a/test/encoders-msi.test.ts
+++ b/test/encoders-msi.test.ts
@@ -1,132 +1,132 @@
-import { describe, expect, it } from "vitest";
-import { encodeMSI } from "../src/encoders/msi";
-import type { MSICheckDigitType } from "../src/encoders/msi";
+import { describe, expect, it } from "vitest"
+import { encodeMSI } from "../src/encoders/msi"
+import type { MSICheckDigitType } from "../src/encoders/msi"
 
 describe("encodeMSI", () => {
   // --- Valid encoding ---
 
   it("encodes a simple numeric string", () => {
-    const bars = encodeMSI("12345");
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodeMSI("12345")
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it("encodes a single digit", () => {
-    const bars = encodeMSI("0");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeMSI("0")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes all digits 0-9", () => {
-    const bars = encodeMSI("0123456789");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeMSI("0123456789")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1 narrow, 2 wide)", () => {
-    const bars = encodeMSI("12345");
+    const bars = encodeMSI("12345")
     for (const w of bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(2);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(2)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("output length matches expected structure with mod10 (default)", () => {
     // Structure: start(2) + (N+1 digits) * 8 bits + stop(3)
     // Each digit is 4 BCD bits, each bit is 2 elements (bar+space) = 8 elements per digit
     // With mod10: 1 extra check digit
     // 3 data digits + 1 check = 4 digits: 2 + 4*8 + 3 = 37
-    const bars = encodeMSI("123");
-    expect(bars.length).toBe(37);
-  });
+    const bars = encodeMSI("123")
+    expect(bars.length).toBe(37)
+  })
 
   // --- Check digit algorithm variants ---
 
   it('supports "none" check digit type', () => {
-    const bars = encodeMSI("123", { checkDigit: "none" });
+    const bars = encodeMSI("123", { checkDigit: "none" })
     // No check digit: 2 + 3*8 + 3 = 29
-    expect(bars.length).toBe(29);
-  });
+    expect(bars.length).toBe(29)
+  })
 
   it('supports "mod10" check digit type (default)', () => {
-    const barsDefault = encodeMSI("123");
-    const barsExplicit = encodeMSI("123", { checkDigit: "mod10" });
-    expect(barsDefault).toEqual(barsExplicit);
-  });
+    const barsDefault = encodeMSI("123")
+    const barsExplicit = encodeMSI("123", { checkDigit: "mod10" })
+    expect(barsDefault).toEqual(barsExplicit)
+  })
 
   it('supports "mod11" check digit type', () => {
-    const bars = encodeMSI("123", { checkDigit: "mod11" });
+    const bars = encodeMSI("123", { checkDigit: "mod11" })
     // 3 data + 1 check = 4 digits: 2 + 4*8 + 3 = 37
-    expect(bars.length).toBe(37);
-  });
+    expect(bars.length).toBe(37)
+  })
 
   it('supports "mod1010" check digit type (two check digits)', () => {
-    const bars = encodeMSI("123", { checkDigit: "mod1010" });
+    const bars = encodeMSI("123", { checkDigit: "mod1010" })
     // 3 data + 2 checks = 5 digits: 2 + 5*8 + 3 = 45
-    expect(bars.length).toBe(45);
-  });
+    expect(bars.length).toBe(45)
+  })
 
   it('supports "mod1110" check digit type (two check digits)', () => {
-    const bars = encodeMSI("123", { checkDigit: "mod1110" });
+    const bars = encodeMSI("123", { checkDigit: "mod1110" })
     // 3 data + 2 checks = 5 digits: 2 + 5*8 + 3 = 45
-    expect(bars.length).toBe(45);
-  });
+    expect(bars.length).toBe(45)
+  })
 
   it("different check digit types produce different outputs", () => {
-    const checkTypes: MSICheckDigitType[] = ["none", "mod10", "mod11", "mod1010", "mod1110"];
-    const results = checkTypes.map((t) => encodeMSI("12345", { checkDigit: t }));
+    const checkTypes: MSICheckDigitType[] = ["none", "mod10", "mod11", "mod1010", "mod1110"]
+    const results = checkTypes.map((t) => encodeMSI("12345", { checkDigit: t }))
     // At least some should differ
-    const unique = new Set(results.map((r) => JSON.stringify(r)));
-    expect(unique.size).toBeGreaterThan(1);
-  });
+    const unique = new Set(results.map((r) => JSON.stringify(r)))
+    expect(unique.size).toBeGreaterThan(1)
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different outputs", () => {
-    const bars1 = encodeMSI("123");
-    const bars2 = encodeMSI("456");
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodeMSI("123")
+    const bars2 = encodeMSI("456")
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same input produces same output", () => {
-    const bars1 = encodeMSI("9876");
-    const bars2 = encodeMSI("9876");
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodeMSI("9876")
+    const bars2 = encodeMSI("9876")
+    expect(bars1).toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on empty input", () => {
-    expect(() => encodeMSI("")).toThrow("must not be empty");
-  });
+    expect(() => encodeMSI("")).toThrow("must not be empty")
+  })
 
   it("throws on non-digit characters", () => {
-    expect(() => encodeMSI("12A34")).toThrow("digits only");
-  });
+    expect(() => encodeMSI("12A34")).toThrow("digits only")
+  })
 
   it("throws on letters", () => {
-    expect(() => encodeMSI("ABCD")).toThrow("digits only");
-  });
+    expect(() => encodeMSI("ABCD")).toThrow("digits only")
+  })
 
   it("throws on special characters", () => {
-    expect(() => encodeMSI("12-34")).toThrow("digits only");
-  });
+    expect(() => encodeMSI("12-34")).toThrow("digits only")
+  })
 
   // --- Edge cases ---
 
   it("encodes a long numeric string", () => {
-    const bars = encodeMSI("1234567890123456789");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeMSI("1234567890123456789")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes all zeros", () => {
-    const bars = encodeMSI("0000");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeMSI("0000")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes all nines", () => {
-    const bars = encodeMSI("9999");
-    expect(bars.length).toBeGreaterThan(0);
-  });
-});
+    const bars = encodeMSI("9999")
+    expect(bars.length).toBeGreaterThan(0)
+  })
+})

--- a/test/encoders-pdf417-encoding.test.ts
+++ b/test/encoders-pdf417-encoding.test.ts
@@ -1,47 +1,47 @@
-import { describe, expect, it } from "vitest";
-import { encodePDF417 } from "../src/encoders/pdf417/index";
+import { describe, expect, it } from "vitest"
+import { encodePDF417 } from "../src/encoders/pdf417/index"
 
 describe("PDF417 encoding support", () => {
   it("encodes basic ASCII text", () => {
-    const result = encodePDF417("Hello World");
-    expect(result.matrix.length).toBeGreaterThan(0);
-  });
+    const result = encodePDF417("Hello World")
+    expect(result.matrix.length).toBeGreaterThan(0)
+  })
 
   it("encodes Euro sign (€) via ISO-8859-15", () => {
-    const result = encodePDF417("Price: 50€");
-    expect(result.matrix.length).toBeGreaterThan(0);
-  });
+    const result = encodePDF417("Price: 50€")
+    expect(result.matrix.length).toBeGreaterThan(0)
+  })
 
   it("encodes Š/š (ISO-8859-15 specific)", () => {
-    const result = encodePDF417("Škoda");
-    expect(result.matrix.length).toBeGreaterThan(0);
-  });
+    const result = encodePDF417("Škoda")
+    expect(result.matrix.length).toBeGreaterThan(0)
+  })
 
   it("encodes Ž/ž (ISO-8859-15 specific)", () => {
-    const result = encodePDF417("Žilina");
-    expect(result.matrix.length).toBeGreaterThan(0);
-  });
+    const result = encodePDF417("Žilina")
+    expect(result.matrix.length).toBeGreaterThan(0)
+  })
 
   it("encodes Œ/œ (ISO-8859-15 specific)", () => {
-    const result = encodePDF417("œuvre");
-    expect(result.matrix.length).toBeGreaterThan(0);
-  });
+    const result = encodePDF417("œuvre")
+    expect(result.matrix.length).toBeGreaterThan(0)
+  })
 
   it("encodes Ÿ (ISO-8859-15 specific)", () => {
-    const result = encodePDF417("Ÿvette");
-    expect(result.matrix.length).toBeGreaterThan(0);
-  });
+    const result = encodePDF417("Ÿvette")
+    expect(result.matrix.length).toBeGreaterThan(0)
+  })
 
   it("encodes mixed Latin-1 and ISO-8859-15", () => {
-    const result = encodePDF417("Café 50€ — Škoda Œuvre");
-    expect(result.matrix.length).toBeGreaterThan(0);
-  });
+    const result = encodePDF417("Café 50€ — Škoda Œuvre")
+    expect(result.matrix.length).toBeGreaterThan(0)
+  })
 
   it("different text produces different matrix", () => {
-    const a = encodePDF417("Hello");
-    const b = encodePDF417("World");
-    const aStr = a.matrix.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const bStr = b.matrix.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
-});
+    const a = encodePDF417("Hello")
+    const b = encodePDF417("World")
+    const aStr = a.matrix.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const bStr = b.matrix.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
+})

--- a/test/encoders-pharmacode.test.ts
+++ b/test/encoders-pharmacode.test.ts
@@ -1,128 +1,128 @@
-import { describe, expect, it } from "vitest";
-import { encodePharmacode } from "../src/encoders/pharmacode";
+import { describe, expect, it } from "vitest"
+import { encodePharmacode } from "../src/encoders/pharmacode"
 
 describe("encodePharmacode", () => {
   // --- Valid encoding ---
 
   it("encodes minimum value (3)", () => {
-    const bars = encodePharmacode(3);
-    expect(bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(bars)).toBe(true);
-  });
+    const bars = encodePharmacode(3)
+    expect(bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(bars)).toBe(true)
+  })
 
   it("encodes maximum value (131070)", () => {
-    const bars = encodePharmacode(131070);
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodePharmacode(131070)
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes a typical value", () => {
-    const bars = encodePharmacode(1234);
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodePharmacode(1234)
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes small values near the minimum", () => {
-    const bars3 = encodePharmacode(3);
-    const bars4 = encodePharmacode(4);
-    const bars5 = encodePharmacode(5);
-    expect(bars3.length).toBeGreaterThan(0);
-    expect(bars4.length).toBeGreaterThan(0);
-    expect(bars5.length).toBeGreaterThan(0);
-  });
+    const bars3 = encodePharmacode(3)
+    const bars4 = encodePharmacode(4)
+    const bars5 = encodePharmacode(5)
+    expect(bars3.length).toBeGreaterThan(0)
+    expect(bars4.length).toBeGreaterThan(0)
+    expect(bars5.length).toBeGreaterThan(0)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (2 thin, 4 thick for bars; 2 for gaps)", () => {
-    const bars = encodePharmacode(12345);
+    const bars = encodePharmacode(12345)
     for (const w of bars) {
-      expect([2, 4]).toContain(w);
-      expect(Number.isInteger(w)).toBe(true);
+      expect([2, 4]).toContain(w)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("alternates between bar widths and gap widths", () => {
-    const bars = encodePharmacode(1234);
+    const bars = encodePharmacode(1234)
     for (let i = 0; i < bars.length; i++) {
       if (i % 2 === 0) {
         // Even indices are bars (thin=2 or thick=4)
-        expect([2, 4]).toContain(bars[i]);
+        expect([2, 4]).toContain(bars[i])
       } else {
         // Odd indices are gaps (always 2)
-        expect(bars[i]).toBe(2);
+        expect(bars[i]).toBe(2)
       }
     }
-  });
+  })
 
   it("output length is always odd (bars separated by gaps)", () => {
     // N bars separated by N-1 gaps: total = 2N - 1 (odd)
     for (const val of [3, 10, 100, 1000, 10000]) {
-      const bars = encodePharmacode(val);
-      expect(bars.length % 2).toBe(1);
+      const bars = encodePharmacode(val)
+      expect(bars.length % 2).toBe(1)
     }
-  });
+  })
 
   // --- Output length scales with value ---
 
   it("larger values generally produce longer outputs", () => {
-    const small = encodePharmacode(3);
-    const medium = encodePharmacode(1000);
-    const large = encodePharmacode(100000);
-    expect(medium.length).toBeGreaterThanOrEqual(small.length);
-    expect(large.length).toBeGreaterThanOrEqual(medium.length);
-  });
+    const small = encodePharmacode(3)
+    const medium = encodePharmacode(1000)
+    const large = encodePharmacode(100000)
+    expect(medium.length).toBeGreaterThanOrEqual(small.length)
+    expect(large.length).toBeGreaterThanOrEqual(medium.length)
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different values produce different outputs", () => {
-    const bars1 = encodePharmacode(100);
-    const bars2 = encodePharmacode(200);
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodePharmacode(100)
+    const bars2 = encodePharmacode(200)
+    expect(bars1).not.toEqual(bars2)
+  })
 
   it("same value produces same output", () => {
-    const bars1 = encodePharmacode(5678);
-    const bars2 = encodePharmacode(5678);
-    expect(bars1).toEqual(bars2);
-  });
+    const bars1 = encodePharmacode(5678)
+    const bars2 = encodePharmacode(5678)
+    expect(bars1).toEqual(bars2)
+  })
 
   it("consecutive values produce different outputs", () => {
-    const bars1 = encodePharmacode(99);
-    const bars2 = encodePharmacode(100);
-    expect(bars1).not.toEqual(bars2);
-  });
+    const bars1 = encodePharmacode(99)
+    const bars2 = encodePharmacode(100)
+    expect(bars1).not.toEqual(bars2)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on value below minimum (< 3)", () => {
-    expect(() => encodePharmacode(0)).toThrow("between 3 and 131070");
-    expect(() => encodePharmacode(1)).toThrow("between 3 and 131070");
-    expect(() => encodePharmacode(2)).toThrow("between 3 and 131070");
-  });
+    expect(() => encodePharmacode(0)).toThrow("between 3 and 131070")
+    expect(() => encodePharmacode(1)).toThrow("between 3 and 131070")
+    expect(() => encodePharmacode(2)).toThrow("between 3 and 131070")
+  })
 
   it("throws on value above maximum (> 131070)", () => {
-    expect(() => encodePharmacode(131071)).toThrow("between 3 and 131070");
-    expect(() => encodePharmacode(200000)).toThrow("between 3 and 131070");
-  });
+    expect(() => encodePharmacode(131071)).toThrow("between 3 and 131070")
+    expect(() => encodePharmacode(200000)).toThrow("between 3 and 131070")
+  })
 
   it("throws on non-integer value", () => {
-    expect(() => encodePharmacode(3.5)).toThrow("must be an integer");
-    expect(() => encodePharmacode(100.1)).toThrow("must be an integer");
-  });
+    expect(() => encodePharmacode(3.5)).toThrow("must be an integer")
+    expect(() => encodePharmacode(100.1)).toThrow("must be an integer")
+  })
 
   it("throws on negative value", () => {
-    expect(() => encodePharmacode(-1)).toThrow("between 3 and 131070");
-  });
+    expect(() => encodePharmacode(-1)).toThrow("between 3 and 131070")
+  })
 
   // --- Edge cases ---
 
   it("encodes boundary value 3 correctly (produces thin bars only)", () => {
-    const bars = encodePharmacode(3);
+    const bars = encodePharmacode(3)
     // Value 3: odd -> thin (1), (3-1)/2=1 -> odd -> thin (0)
     // So two thin bars separated by a gap: [2, 2, 2]
-    expect(bars.length).toBe(3);
-  });
+    expect(bars.length).toBe(3)
+  })
 
   it("encodes boundary value 131070 (produces output without error)", () => {
-    const bars = encodePharmacode(131070);
-    expect(bars.length).toBeGreaterThan(0);
-  });
-});
+    const bars = encodePharmacode(131070)
+    expect(bars.length).toBeGreaterThan(0)
+  })
+})

--- a/test/encoders-plessey.test.ts
+++ b/test/encoders-plessey.test.ts
@@ -1,50 +1,50 @@
-import { describe, expect, it } from "vitest";
-import { encodePlessey } from "../src/encoders/plessey";
-import { barcode } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { encodePlessey } from "../src/encoders/plessey"
+import { barcode } from "../src/index"
 
 describe("Plessey", () => {
   it("encodes hex digits", () => {
-    const bars = encodePlessey("1234AB");
-    expect(bars.length).toBeGreaterThan(0);
-    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1);
-  });
+    const bars = encodePlessey("1234AB")
+    expect(bars.length).toBeGreaterThan(0)
+    for (const b of bars) expect(b).toBeGreaterThanOrEqual(1)
+  })
 
   it("accepts lowercase hex", () => {
-    const a = encodePlessey("abcdef");
-    const b = encodePlessey("ABCDEF");
-    expect(a).toEqual(b);
-  });
+    const a = encodePlessey("abcdef")
+    const b = encodePlessey("ABCDEF")
+    expect(a).toEqual(b)
+  })
 
   it("all bar widths are 1 or 2", () => {
-    const bars = encodePlessey("0123456789ABCDEF");
+    const bars = encodePlessey("0123456789ABCDEF")
     for (const b of bars) {
-      expect(b === 1 || b === 2).toBe(true);
+      expect(b === 1 || b === 2).toBe(true)
     }
-  });
+  })
 
   it("throws on non-hex characters", () => {
-    expect(() => encodePlessey("GHIJ")).toThrow();
-  });
+    expect(() => encodePlessey("GHIJ")).toThrow()
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodePlessey("")).toThrow();
-  });
+    expect(() => encodePlessey("")).toThrow()
+  })
 
   it("different data produces different output", () => {
-    const a = encodePlessey("1234");
-    const b = encodePlessey("5678");
-    expect(a).not.toEqual(b);
-  });
+    const a = encodePlessey("1234")
+    const b = encodePlessey("5678")
+    expect(a).not.toEqual(b)
+  })
 
   it("includes 2 CRC check digits (output is longer)", () => {
     // 4 data digits + 2 check digits = 6 digits encoded
     // Each digit = 4 pairs = 8 elements. 6 digits = 48 elements + start(4) + stop(2) = 54
-    const bars = encodePlessey("1234");
-    expect(bars.length).toBe(54);
-  });
+    const bars = encodePlessey("1234")
+    expect(bars.length).toBe(54)
+  })
 
   it("works via barcode() function", () => {
-    const svg = barcode("1234AB", { type: "plessey" });
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = barcode("1234AB", { type: "plessey" })
+    expect(svg).toContain("<svg")
+  })
+})

--- a/test/encoders-postnet.test.ts
+++ b/test/encoders-postnet.test.ts
@@ -1,81 +1,81 @@
-import { describe, expect, it } from "vitest";
-import { encodePOSTNET, encodePLANET } from "../src/encoders/postnet";
-import { barcode } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { encodePOSTNET, encodePLANET } from "../src/encoders/postnet"
+import { barcode } from "../src/index"
 
 describe("POSTNET", () => {
   it("encodes 5-digit ZIP", () => {
-    const bars = encodePOSTNET("12345");
+    const bars = encodePOSTNET("12345")
     // (5+1 check) × 5 + 2 frame = 32
-    expect(bars.length).toBe(32);
-    expect(bars[0]).toBe(1); // start frame bar
-    expect(bars[bars.length - 1]).toBe(1); // end frame bar
-  });
+    expect(bars.length).toBe(32)
+    expect(bars[0]).toBe(1) // start frame bar
+    expect(bars[bars.length - 1]).toBe(1) // end frame bar
+  })
 
   it("encodes 9-digit ZIP+4", () => {
-    const bars = encodePOSTNET("123456789");
-    expect(bars.length).toBe(52); // (9+1) × 5 + 2 = 52
-  });
+    const bars = encodePOSTNET("123456789")
+    expect(bars.length).toBe(52) // (9+1) × 5 + 2 = 52
+  })
 
   it("encodes 11-digit delivery point", () => {
-    const bars = encodePOSTNET("12345678901");
-    expect(bars.length).toBe(62); // (11+1) × 5 + 2 = 62
-  });
+    const bars = encodePOSTNET("12345678901")
+    expect(bars.length).toBe(62) // (11+1) × 5 + 2 = 62
+  })
 
   it("strips dashes and spaces", () => {
-    const a = encodePOSTNET("12345-6789");
-    const b = encodePOSTNET("123456789");
-    expect(a).toEqual(b);
-  });
+    const a = encodePOSTNET("12345-6789")
+    const b = encodePOSTNET("123456789")
+    expect(a).toEqual(b)
+  })
 
   it("throws on non-digits", () => {
-    expect(() => encodePOSTNET("ABCDE")).toThrow();
-  });
+    expect(() => encodePOSTNET("ABCDE")).toThrow()
+  })
 
   it("throws on wrong length", () => {
-    expect(() => encodePOSTNET("1234")).toThrow();
-    expect(() => encodePOSTNET("123456")).toThrow();
-  });
+    expect(() => encodePOSTNET("1234")).toThrow()
+    expect(() => encodePOSTNET("123456")).toThrow()
+  })
 
   it("all values are 0 or 1", () => {
-    const bars = encodePOSTNET("12345");
+    const bars = encodePOSTNET("12345")
     for (const b of bars) {
-      expect(b === 0 || b === 1).toBe(true);
+      expect(b === 0 || b === 1).toBe(true)
     }
-  });
+  })
 
   it("works via barcode() function", () => {
-    const svg = barcode("12345", { type: "postnet" });
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = barcode("12345", { type: "postnet" })
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("PLANET", () => {
   it("encodes 11-digit code", () => {
-    const bars = encodePLANET("12345678901");
-    expect(bars.length).toBe(62);
-  });
+    const bars = encodePLANET("12345678901")
+    expect(bars.length).toBe(62)
+  })
 
   it("encodes 13-digit code", () => {
-    const bars = encodePLANET("1234567890123");
-    expect(bars.length).toBe(72); // (13+1) × 5 + 2 = 72
-  });
+    const bars = encodePLANET("1234567890123")
+    expect(bars.length).toBe(72) // (13+1) × 5 + 2 = 72
+  })
 
   it("PLANET is inverted POSTNET", () => {
     // For same digit patterns, PLANET should have inverted heights (except frame bars)
-    const postnet = encodePOSTNET("12345678901");
-    const planet = encodePLANET("12345678901");
+    const postnet = encodePOSTNET("12345678901")
+    const planet = encodePLANET("12345678901")
     // Inner bars (excluding frame) should be inverted
     for (let i = 1; i < postnet.length - 1; i++) {
-      expect(planet[i]).toBe(postnet[i] === 1 ? 0 : 1);
+      expect(planet[i]).toBe(postnet[i] === 1 ? 0 : 1)
     }
-  });
+  })
 
   it("throws on wrong length", () => {
-    expect(() => encodePLANET("12345")).toThrow();
-  });
+    expect(() => encodePLANET("12345")).toThrow()
+  })
 
   it("works via barcode() function", () => {
-    const svg = barcode("12345678901", { type: "planet" });
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = barcode("12345678901", { type: "planet" })
+    expect(svg).toContain("<svg")
+  })
+})

--- a/test/encoders-qr-format.test.ts
+++ b/test/encoders-qr-format.test.ts
@@ -1,39 +1,39 @@
-import { describe, expect, it } from "vitest";
-import { generateFormatInfo } from "../src/encoders/qr/format";
+import { describe, expect, it } from "vitest"
+import { generateFormatInfo } from "../src/encoders/qr/format"
 
 describe("QR format info", () => {
   it("generates 15-bit format info", () => {
-    const info = generateFormatInfo("M", 0);
+    const info = generateFormatInfo("M", 0)
     // Format info should be a 15-bit value
-    expect(info).toBeGreaterThanOrEqual(0);
-    expect(info).toBeLessThan(1 << 15);
-  });
+    expect(info).toBeGreaterThanOrEqual(0)
+    expect(info).toBeLessThan(1 << 15)
+  })
 
   it("generates different info for different masks", () => {
-    const infos = new Set<number>();
+    const infos = new Set<number>()
     for (let m = 0; m < 8; m++) {
-      infos.add(generateFormatInfo("M", m));
+      infos.add(generateFormatInfo("M", m))
     }
-    expect(infos.size).toBe(8);
-  });
+    expect(infos.size).toBe(8)
+  })
 
   it("generates different info for different EC levels", () => {
-    const levels = ["L", "M", "Q", "H"] as const;
-    const infos = new Set<number>();
+    const levels = ["L", "M", "Q", "H"] as const
+    const infos = new Set<number>()
     for (const level of levels) {
-      infos.add(generateFormatInfo(level, 0));
+      infos.add(generateFormatInfo(level, 0))
     }
-    expect(infos.size).toBe(4);
-  });
+    expect(infos.size).toBe(4)
+  })
 
   // Known format info values for EC M, mask 0
   // EC M = 00, mask 0 = 000, data = 00000
   // After BCH and XOR with 0x5412:
   it("generates known value for EC M mask 0", () => {
-    const info = generateFormatInfo("M", 0);
+    const info = generateFormatInfo("M", 0)
     // EC M (00) << 3 | mask 0 (000) = 0b00000 = 0
     // BCH(0) = 0, so raw = 0
     // XOR with 0x5412 = 0x5412 = 21522
-    expect(info).toBe(0x5412);
-  });
-});
+    expect(info).toBe(0x5412)
+  })
+})

--- a/test/encoders-qr-integration.test.ts
+++ b/test/encoders-qr-integration.test.ts
@@ -1,139 +1,139 @@
-import { describe, expect, it } from "vitest";
-import { encodeQR } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { encodeQR } from "../src/index"
 
 describe("QR code integration", () => {
   it("encodes short text (version 1)", () => {
-    const matrix = encodeQR("Hello");
-    expect(matrix.length).toBe(21); // Version 1 = 21x21
-    expect(matrix[0]!.length).toBe(21);
-  });
+    const matrix = encodeQR("Hello")
+    expect(matrix.length).toBe(21) // Version 1 = 21x21
+    expect(matrix[0]!.length).toBe(21)
+  })
 
   it("produces square matrix", () => {
-    const matrix = encodeQR("Test");
-    expect(matrix.length).toBe(matrix[0]!.length);
-  });
+    const matrix = encodeQR("Test")
+    expect(matrix.length).toBe(matrix[0]!.length)
+  })
 
   it("matrix contains only boolean values", () => {
-    const matrix = encodeQR("Data");
+    const matrix = encodeQR("Data")
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("has finder patterns in correct corners", () => {
-    const matrix = encodeQR("Test");
-    const size = matrix.length;
+    const matrix = encodeQR("Test")
+    const size = matrix.length
 
     // Top-left finder: 7x7, outer ring dark
-    expect(matrix[0]![0]).toBe(true); // Top-left corner of finder
-    expect(matrix[0]![6]).toBe(true); // Top-right corner of finder
-    expect(matrix[6]![0]).toBe(true); // Bottom-left corner of finder
-    expect(matrix[6]![6]).toBe(true); // Bottom-right corner of finder
-    expect(matrix[3]![3]).toBe(true); // Center of finder
+    expect(matrix[0]![0]).toBe(true) // Top-left corner of finder
+    expect(matrix[0]![6]).toBe(true) // Top-right corner of finder
+    expect(matrix[6]![0]).toBe(true) // Bottom-left corner of finder
+    expect(matrix[6]![6]).toBe(true) // Bottom-right corner of finder
+    expect(matrix[3]![3]).toBe(true) // Center of finder
 
     // White row between finder and rest
-    expect(matrix[0]![7]).toBe(false); // Separator
+    expect(matrix[0]![7]).toBe(false) // Separator
 
     // Top-right finder
-    expect(matrix[0]![size - 1]).toBe(true);
-    expect(matrix[0]![size - 7]).toBe(true);
+    expect(matrix[0]![size - 1]).toBe(true)
+    expect(matrix[0]![size - 7]).toBe(true)
 
     // Bottom-left finder
-    expect(matrix[size - 1]![0]).toBe(true);
-    expect(matrix[size - 7]![0]).toBe(true);
-  });
+    expect(matrix[size - 1]![0]).toBe(true)
+    expect(matrix[size - 7]![0]).toBe(true)
+  })
 
   it("scales version with data length", () => {
-    const short = encodeQR("Hi");
-    const long = encodeQR("This is a much longer text that needs more capacity");
-    expect(long.length).toBeGreaterThan(short.length);
-  });
+    const short = encodeQR("Hi")
+    const long = encodeQR("This is a much longer text that needs more capacity")
+    expect(long.length).toBeGreaterThan(short.length)
+  })
 
   it("supports all EC levels", () => {
     for (const ecLevel of ["L", "M", "Q", "H"] as const) {
-      const matrix = encodeQR("Test", { ecLevel });
-      expect(matrix.length).toBeGreaterThanOrEqual(21); // At least version 1
-      expect(matrix[0]!.length).toBe(matrix.length); // Square
+      const matrix = encodeQR("Test", { ecLevel })
+      expect(matrix.length).toBeGreaterThanOrEqual(21) // At least version 1
+      expect(matrix[0]!.length).toBe(matrix.length) // Square
     }
-  });
+  })
 
   it("supports numeric mode", () => {
-    const matrix = encodeQR("1234567890", { mode: "numeric" });
-    expect(matrix.length).toBeGreaterThanOrEqual(21);
-  });
+    const matrix = encodeQR("1234567890", { mode: "numeric" })
+    expect(matrix.length).toBeGreaterThanOrEqual(21)
+  })
 
   it("supports alphanumeric mode", () => {
-    const matrix = encodeQR("HELLO WORLD", { mode: "alphanumeric" });
-    expect(matrix.length).toBeGreaterThanOrEqual(21);
-  });
+    const matrix = encodeQR("HELLO WORLD", { mode: "alphanumeric" })
+    expect(matrix.length).toBeGreaterThanOrEqual(21)
+  })
 
   it("supports byte mode", () => {
-    const matrix = encodeQR("hello world", { mode: "byte" });
-    expect(matrix.length).toBeGreaterThanOrEqual(21);
-  });
+    const matrix = encodeQR("hello world", { mode: "byte" })
+    expect(matrix.length).toBeGreaterThanOrEqual(21)
+  })
 
   it("auto mode detection works", () => {
     // Should auto-detect numeric
-    const numeric = encodeQR("12345");
+    const numeric = encodeQR("12345")
     // Should auto-detect alphanumeric
-    const alpha = encodeQR("HELLO");
+    const alpha = encodeQR("HELLO")
     // Should auto-detect byte
-    const byte = encodeQR("hello");
+    const byte = encodeQR("hello")
 
     // All should produce valid matrices
-    expect(numeric.length).toBeGreaterThanOrEqual(21);
-    expect(alpha.length).toBeGreaterThanOrEqual(21);
-    expect(byte.length).toBeGreaterThanOrEqual(21);
-  });
+    expect(numeric.length).toBeGreaterThanOrEqual(21)
+    expect(alpha.length).toBeGreaterThanOrEqual(21)
+    expect(byte.length).toBeGreaterThanOrEqual(21)
+  })
 
   it("supports explicit version selection", () => {
-    const matrix = encodeQR("Hi", { version: 5 });
-    expect(matrix.length).toBe(5 * 4 + 17); // 37
-  });
+    const matrix = encodeQR("Hi", { version: 5 })
+    expect(matrix.length).toBe(5 * 4 + 17) // 37
+  })
 
   it("supports explicit mask selection", () => {
     // Different masks should produce different matrices
-    const m0 = encodeQR("Test", { mask: 0 });
-    const m1 = encodeQR("Test", { mask: 1 });
+    const m0 = encodeQR("Test", { mask: 0 })
+    const m1 = encodeQR("Test", { mask: 1 })
 
     // Same size
-    expect(m0.length).toBe(m1.length);
+    expect(m0.length).toBe(m1.length)
 
     // But different content (at least some modules differ)
-    let diffs = 0;
+    let diffs = 0
     for (let r = 0; r < m0.length; r++) {
       for (let c = 0; c < m0[r]!.length; c++) {
-        if (m0[r]![c] !== m1[r]![c]) diffs++;
+        if (m0[r]![c] !== m1[r]![c]) diffs++
       }
     }
-    expect(diffs).toBeGreaterThan(0);
-  });
+    expect(diffs).toBeGreaterThan(0)
+  })
 
   it("encodes URLs", () => {
-    const matrix = encodeQR("https://example.com/path?query=value");
-    expect(matrix.length).toBeGreaterThanOrEqual(21);
-  });
+    const matrix = encodeQR("https://example.com/path?query=value")
+    expect(matrix.length).toBeGreaterThanOrEqual(21)
+  })
 
   it("encodes emoji (multi-byte UTF-8)", () => {
-    const matrix = encodeQR("Hello 👋");
-    expect(matrix.length).toBeGreaterThanOrEqual(21);
-  });
+    const matrix = encodeQR("Hello 👋")
+    expect(matrix.length).toBeGreaterThanOrEqual(21)
+  })
 
   it("produces larger version for more data", () => {
-    const small = encodeQR("A".repeat(10), { ecLevel: "L" });
-    const large = encodeQR("A".repeat(200), { ecLevel: "L" });
-    expect(large.length).toBeGreaterThan(small.length);
-  });
+    const small = encodeQR("A".repeat(10), { ecLevel: "L" })
+    const large = encodeQR("A".repeat(200), { ecLevel: "L" })
+    expect(large.length).toBeGreaterThan(small.length)
+  })
 
   it("timing patterns present", () => {
-    const matrix = encodeQR("Test");
+    const matrix = encodeQR("Test")
     // Row 6 (timing pattern) should alternate between dark and light
     // Starting from column 8 to size-9
-    const size = matrix.length;
+    const size = matrix.length
     for (let c = 8; c < size - 8; c++) {
-      expect(matrix[6]![c]).toBe(c % 2 === 0);
+      expect(matrix[6]![c]).toBe(c % 2 === 0)
     }
-  });
-});
+  })
+})

--- a/test/encoders-qr-kanji.test.ts
+++ b/test/encoders-qr-kanji.test.ts
@@ -1,53 +1,53 @@
-import { describe, expect, it } from "vitest";
-import { encodeKanjiData, unicodeToShiftJIS } from "../src/encoders/qr/mode";
-import { encodeQR } from "../src/encoders/qr/index";
+import { describe, expect, it } from "vitest"
+import { encodeKanjiData, unicodeToShiftJIS } from "../src/encoders/qr/mode"
+import { encodeQR } from "../src/encoders/qr/index"
 
 describe("Kanji encoding", () => {
   it("encodeKanjiData produces 13 bits per character", () => {
     // SJIS value 0x8140 (first valid)
-    const bits = encodeKanjiData([0x8140]);
-    expect(bits.length).toBe(13);
-  });
+    const bits = encodeKanjiData([0x8140])
+    expect(bits.length).toBe(13)
+  })
 
   it("encodeKanjiData produces correct bits for known value", () => {
     // 0x8140: adjusted = 0, hi=0, lo=0, value = 0*0xC0 + 0 = 0
-    const bits = encodeKanjiData([0x8140]);
-    expect(bits.every((b) => b === 0)).toBe(true); // all zeros for value 0
-  });
+    const bits = encodeKanjiData([0x8140])
+    expect(bits.every((b) => b === 0)).toBe(true) // all zeros for value 0
+  })
 
   it("unicodeToShiftJIS converts CJK characters", () => {
     // U+3042 (あ) should map to SJIS range
-    const values = unicodeToShiftJIS("あ");
-    expect(values.length).toBe(1);
-    expect(values[0]).toBeGreaterThanOrEqual(0x8140);
-  });
+    const values = unicodeToShiftJIS("あ")
+    expect(values.length).toBe(1)
+    expect(values[0]).toBeGreaterThanOrEqual(0x8140)
+  })
 
   it("unicodeToShiftJIS throws for non-CJK", () => {
-    expect(() => unicodeToShiftJIS("A")).toThrow();
-  });
+    expect(() => unicodeToShiftJIS("A")).toThrow()
+  })
 
   it("encodeQR with kanji mode produces valid matrix", () => {
     // Use CJK character that falls in supported range
-    const matrix = encodeQR("あいう", { mode: "kanji" });
-    expect(matrix.length).toBeGreaterThanOrEqual(21);
-    expect(matrix[0]!.length).toBe(matrix.length);
-  });
+    const matrix = encodeQR("あいう", { mode: "kanji" })
+    expect(matrix.length).toBeGreaterThanOrEqual(21)
+    expect(matrix[0]!.length).toBe(matrix.length)
+  })
 
   it("kanji matrix contains only booleans", () => {
-    const matrix = encodeQR("あいう", { mode: "kanji" });
+    const matrix = encodeQR("あいう", { mode: "kanji" })
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("kanji mode produces different output than byte mode", () => {
-    const kanji = encodeQR("あいう", { mode: "kanji" });
-    const byte = encodeQR("あいう", { mode: "byte" });
+    const kanji = encodeQR("あいう", { mode: "kanji" })
+    const byte = encodeQR("あいう", { mode: "byte" })
     // Size might differ (kanji is more compact for CJK)
-    const kanjiStr = kanji.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const byteStr = byte.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(kanjiStr).not.toBe(byteStr);
-  });
-});
+    const kanjiStr = kanji.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const byteStr = byte.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(kanjiStr).not.toBe(byteStr)
+  })
+})

--- a/test/encoders-qr-mask.test.ts
+++ b/test/encoders-qr-mask.test.ts
@@ -1,121 +1,121 @@
-import { describe, expect, it } from "vitest";
-import { getMaskFn, evaluatePenalty } from "../src/encoders/qr/mask";
+import { describe, expect, it } from "vitest"
+import { getMaskFn, evaluatePenalty } from "../src/encoders/qr/mask"
 
 describe("QR mask patterns", () => {
   it("mask 0: (r+c) % 2 === 0", () => {
-    const fn = getMaskFn(0);
-    expect(fn(0, 0)).toBe(true);
-    expect(fn(0, 1)).toBe(false);
-    expect(fn(1, 0)).toBe(false);
-    expect(fn(1, 1)).toBe(true);
-  });
+    const fn = getMaskFn(0)
+    expect(fn(0, 0)).toBe(true)
+    expect(fn(0, 1)).toBe(false)
+    expect(fn(1, 0)).toBe(false)
+    expect(fn(1, 1)).toBe(true)
+  })
 
   it("mask 1: r % 2 === 0", () => {
-    const fn = getMaskFn(1);
-    expect(fn(0, 0)).toBe(true);
-    expect(fn(0, 5)).toBe(true);
-    expect(fn(1, 0)).toBe(false);
-    expect(fn(2, 3)).toBe(true);
-  });
+    const fn = getMaskFn(1)
+    expect(fn(0, 0)).toBe(true)
+    expect(fn(0, 5)).toBe(true)
+    expect(fn(1, 0)).toBe(false)
+    expect(fn(2, 3)).toBe(true)
+  })
 
   it("mask 2: c % 3 === 0", () => {
-    const fn = getMaskFn(2);
-    expect(fn(0, 0)).toBe(true);
-    expect(fn(0, 1)).toBe(false);
-    expect(fn(0, 2)).toBe(false);
-    expect(fn(0, 3)).toBe(true);
-  });
+    const fn = getMaskFn(2)
+    expect(fn(0, 0)).toBe(true)
+    expect(fn(0, 1)).toBe(false)
+    expect(fn(0, 2)).toBe(false)
+    expect(fn(0, 3)).toBe(true)
+  })
 
   it("mask 3: (r+c) % 3 === 0", () => {
-    const fn = getMaskFn(3);
-    expect(fn(0, 0)).toBe(true);
-    expect(fn(0, 1)).toBe(false);
-    expect(fn(1, 2)).toBe(true);
-  });
+    const fn = getMaskFn(3)
+    expect(fn(0, 0)).toBe(true)
+    expect(fn(0, 1)).toBe(false)
+    expect(fn(1, 2)).toBe(true)
+  })
 
   it("mask 4: (floor(r/2) + floor(c/3)) % 2 === 0", () => {
-    const fn = getMaskFn(4);
-    expect(fn(0, 0)).toBe(true);
-    expect(fn(0, 3)).toBe(false);
-    expect(fn(2, 0)).toBe(false);
-  });
+    const fn = getMaskFn(4)
+    expect(fn(0, 0)).toBe(true)
+    expect(fn(0, 3)).toBe(false)
+    expect(fn(2, 0)).toBe(false)
+  })
 
   it("mask 5: (r*c)%2 + (r*c)%3 === 0", () => {
-    const fn = getMaskFn(5);
-    expect(fn(0, 0)).toBe(true); // 0*0=0, 0%2+0%3=0
-    expect(fn(1, 1)).toBe(false); // 1%2+1%3=1+1=2
-  });
+    const fn = getMaskFn(5)
+    expect(fn(0, 0)).toBe(true) // 0*0=0, 0%2+0%3=0
+    expect(fn(1, 1)).toBe(false) // 1%2+1%3=1+1=2
+  })
 
   it("mask 6: ((r*c)%2 + (r*c)%3) % 2 === 0", () => {
-    const fn = getMaskFn(6);
-    expect(fn(0, 0)).toBe(true); // 0%2=0
-    expect(fn(1, 1)).toBe(true); // (1%2+1%3)%2 = 2%2 = 0
-  });
+    const fn = getMaskFn(6)
+    expect(fn(0, 0)).toBe(true) // 0%2=0
+    expect(fn(1, 1)).toBe(true) // (1%2+1%3)%2 = 2%2 = 0
+  })
 
   it("mask 7: ((r+c)%2 + (r*c)%3) % 2 === 0", () => {
-    const fn = getMaskFn(7);
-    expect(fn(0, 0)).toBe(true); // (0%2+0%3)%2=0
-  });
+    const fn = getMaskFn(7)
+    expect(fn(0, 0)).toBe(true) // (0%2+0%3)%2=0
+  })
 
   it("all 8 masks produce different patterns on a 10x10 grid", () => {
-    const patterns: string[] = [];
+    const patterns: string[] = []
     for (let m = 0; m < 8; m++) {
-      const fn = getMaskFn(m);
-      let pat = "";
+      const fn = getMaskFn(m)
+      let pat = ""
       for (let r = 0; r < 10; r++) {
         for (let c = 0; c < 10; c++) {
-          pat += fn(r, c) ? "1" : "0";
+          pat += fn(r, c) ? "1" : "0"
         }
       }
-      patterns.push(pat);
+      patterns.push(pat)
     }
     // All patterns should be unique
-    const unique = new Set(patterns);
-    expect(unique.size).toBe(8);
-  });
-});
+    const unique = new Set(patterns)
+    expect(unique.size).toBe(8)
+  })
+})
 
 describe("QR penalty evaluation", () => {
   it("returns 0 for perfectly alternating pattern", () => {
     // A checkerboard pattern should have low penalty
-    const size = 10;
+    const size = 10
     const matrix: (boolean | null)[][] = Array.from({ length: size }, (_, r) =>
       Array.from({ length: size }, (_, c) => (r + c) % 2 === 0),
-    );
-    const penalty = evaluatePenalty(matrix, size);
+    )
+    const penalty = evaluatePenalty(matrix, size)
     // Checkerboard has no consecutive runs, no 2x2 blocks
     // Rule 1: no runs of 5+ (score = 0)
     // Rule 2: no 2x2 blocks (score = 0)
     // Rule 3: may or may not match patterns
     // Rule 4: exactly 50% dark (score = 0)
-    expect(penalty).toBeGreaterThanOrEqual(0);
-  });
+    expect(penalty).toBeGreaterThanOrEqual(0)
+  })
 
   it("penalizes all-dark matrix", () => {
-    const size = 10;
+    const size = 10
     const allDark: (boolean | null)[][] = Array.from({ length: size }, () =>
       Array.from({ length: size }, () => true),
-    );
+    )
     const _allLight: (boolean | null)[][] = Array.from({ length: size }, () =>
       Array.from({ length: size }, () => false),
-    );
+    )
     const checkerboard: (boolean | null)[][] = Array.from({ length: size }, (_, r) =>
       Array.from({ length: size }, (_, c) => (r + c) % 2 === 0),
-    );
+    )
 
-    const darkPenalty = evaluatePenalty(allDark, size);
-    const checkPenalty = evaluatePenalty(checkerboard, size);
+    const darkPenalty = evaluatePenalty(allDark, size)
+    const checkPenalty = evaluatePenalty(checkerboard, size)
 
     // All-dark should have much higher penalty than checkerboard
-    expect(darkPenalty).toBeGreaterThan(checkPenalty);
-  });
+    expect(darkPenalty).toBeGreaterThan(checkPenalty)
+  })
 
   it("returns non-negative penalty", () => {
-    const size = 21;
+    const size = 21
     const matrix: (boolean | null)[][] = Array.from({ length: size }, () =>
       Array.from({ length: size }, () => Math.random() > 0.5),
-    );
-    const penalty = evaluatePenalty(matrix, size);
-    expect(penalty).toBeGreaterThanOrEqual(0);
-  });
-});
+    )
+    const penalty = evaluatePenalty(matrix, size)
+    expect(penalty).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/test/encoders-qr-mode.test.ts
+++ b/test/encoders-qr-mode.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   isNumeric,
   isAlphanumeric,
@@ -7,94 +7,94 @@ import {
   encodeAlphanumericData,
   encodeByteData,
   getAlphanumericValue,
-} from "../src/encoders/qr/mode";
+} from "../src/encoders/qr/mode"
 
 describe("QR mode detection", () => {
   it("detects numeric mode", () => {
-    expect(isNumeric("12345")).toBe(true);
-    expect(isNumeric("0")).toBe(true);
-    expect(isNumeric("")).toBe(false); // regex test fails on empty
-    expect(isNumeric("12a34")).toBe(false);
-    expect(detectMode("12345")).toBe("numeric");
-  });
+    expect(isNumeric("12345")).toBe(true)
+    expect(isNumeric("0")).toBe(true)
+    expect(isNumeric("")).toBe(false) // regex test fails on empty
+    expect(isNumeric("12a34")).toBe(false)
+    expect(detectMode("12345")).toBe("numeric")
+  })
 
   it("detects alphanumeric mode", () => {
-    expect(isAlphanumeric("HELLO")).toBe(true);
-    expect(isAlphanumeric("HELLO 123")).toBe(true);
-    expect(isAlphanumeric("hello")).toBe(false); // lowercase not in alphanumeric
-    expect(detectMode("HELLO 123")).toBe("alphanumeric");
-  });
+    expect(isAlphanumeric("HELLO")).toBe(true)
+    expect(isAlphanumeric("HELLO 123")).toBe(true)
+    expect(isAlphanumeric("hello")).toBe(false) // lowercase not in alphanumeric
+    expect(detectMode("HELLO 123")).toBe("alphanumeric")
+  })
 
   it("falls back to byte mode", () => {
-    expect(detectMode("hello world")).toBe("byte");
-    expect(detectMode("日本語")).toBe("byte");
-    expect(detectMode("https://example.com")).toBe("byte"); // lowercase
-  });
-});
+    expect(detectMode("hello world")).toBe("byte")
+    expect(detectMode("日本語")).toBe("byte")
+    expect(detectMode("https://example.com")).toBe("byte") // lowercase
+  })
+})
 
 describe("QR numeric encoding", () => {
   it("encodes groups of 3 digits as 10 bits", () => {
-    const bits = encodeNumericData("123");
-    expect(bits.length).toBe(10);
+    const bits = encodeNumericData("123")
+    expect(bits.length).toBe(10)
     // 123 in 10 bits = 0001111011
-    expect(bits).toEqual([0, 0, 0, 1, 1, 1, 1, 0, 1, 1]);
-  });
+    expect(bits).toEqual([0, 0, 0, 1, 1, 1, 1, 0, 1, 1])
+  })
 
   it("encodes remainder 2 digits as 7 bits", () => {
-    const bits = encodeNumericData("12");
-    expect(bits.length).toBe(7);
+    const bits = encodeNumericData("12")
+    expect(bits.length).toBe(7)
     // 12 in 7 bits = 0001100
-    expect(bits).toEqual([0, 0, 0, 1, 1, 0, 0]);
-  });
+    expect(bits).toEqual([0, 0, 0, 1, 1, 0, 0])
+  })
 
   it("encodes remainder 1 digit as 4 bits", () => {
-    const bits = encodeNumericData("5");
-    expect(bits.length).toBe(4);
+    const bits = encodeNumericData("5")
+    expect(bits.length).toBe(4)
     // 5 in 4 bits = 0101
-    expect(bits).toEqual([0, 1, 0, 1]);
-  });
+    expect(bits).toEqual([0, 1, 0, 1])
+  })
 
   it("encodes 6 digits as 20 bits (2 groups of 3)", () => {
-    const bits = encodeNumericData("123456");
-    expect(bits.length).toBe(20);
-  });
-});
+    const bits = encodeNumericData("123456")
+    expect(bits.length).toBe(20)
+  })
+})
 
 describe("QR alphanumeric encoding", () => {
   it("returns correct values for known characters", () => {
-    expect(getAlphanumericValue("0")).toBe(0);
-    expect(getAlphanumericValue("9")).toBe(9);
-    expect(getAlphanumericValue("A")).toBe(10);
-    expect(getAlphanumericValue("Z")).toBe(35);
-    expect(getAlphanumericValue(" ")).toBe(36);
-  });
+    expect(getAlphanumericValue("0")).toBe(0)
+    expect(getAlphanumericValue("9")).toBe(9)
+    expect(getAlphanumericValue("A")).toBe(10)
+    expect(getAlphanumericValue("Z")).toBe(35)
+    expect(getAlphanumericValue(" ")).toBe(36)
+  })
 
   it("encodes pairs as 11 bits", () => {
-    const bits = encodeAlphanumericData("AB");
-    expect(bits.length).toBe(11);
+    const bits = encodeAlphanumericData("AB")
+    expect(bits.length).toBe(11)
     // A=10, B=11 → 10*45+11 = 461 in 11 bits
-  });
+  })
 
   it("encodes single char as 6 bits", () => {
-    const bits = encodeAlphanumericData("A");
-    expect(bits.length).toBe(6);
-  });
+    const bits = encodeAlphanumericData("A")
+    expect(bits.length).toBe(6)
+  })
 
   it("throws for invalid alphanumeric characters", () => {
-    expect(() => getAlphanumericValue("a")).toThrow();
-  });
-});
+    expect(() => getAlphanumericValue("a")).toThrow()
+  })
+})
 
 describe("QR byte encoding", () => {
   it("encodes each byte as 8 bits", () => {
-    const data = new Uint8Array([72, 101, 108, 108, 111]); // Hello
-    const bits = encodeByteData(data);
-    expect(bits.length).toBe(40);
-  });
+    const data = new Uint8Array([72, 101, 108, 108, 111]) // Hello
+    const bits = encodeByteData(data)
+    expect(bits.length).toBe(40)
+  })
 
   it("encodes ASCII correctly", () => {
-    const data = new Uint8Array([65]); // 'A' = 01000001
-    const bits = encodeByteData(data);
-    expect(bits).toEqual([0, 1, 0, 0, 0, 0, 0, 1]);
-  });
-});
+    const data = new Uint8Array([65]) // 'A' = 01000001
+    const bits = encodeByteData(data)
+    expect(bits).toEqual([0, 1, 0, 0, 0, 0, 0, 1])
+  })
+})

--- a/test/encoders-qr-reed-solomon.test.ts
+++ b/test/encoders-qr-reed-solomon.test.ts
@@ -1,91 +1,91 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   gfMultiply,
   generateECCodewords,
   addErrorCorrection,
-} from "../src/encoders/qr/reed-solomon";
+} from "../src/encoders/qr/reed-solomon"
 
 describe("GF(256) arithmetic", () => {
   it("multiply by 0 returns 0", () => {
-    expect(gfMultiply(0, 0)).toBe(0);
-    expect(gfMultiply(123, 0)).toBe(0);
-    expect(gfMultiply(0, 123)).toBe(0);
-  });
+    expect(gfMultiply(0, 0)).toBe(0)
+    expect(gfMultiply(123, 0)).toBe(0)
+    expect(gfMultiply(0, 123)).toBe(0)
+  })
 
   it("multiply by 1 returns same value", () => {
-    expect(gfMultiply(1, 1)).toBe(1);
-    expect(gfMultiply(100, 1)).toBe(100);
-    expect(gfMultiply(1, 200)).toBe(200);
-  });
+    expect(gfMultiply(1, 1)).toBe(1)
+    expect(gfMultiply(100, 1)).toBe(100)
+    expect(gfMultiply(1, 200)).toBe(200)
+  })
 
   it("multiplication is commutative", () => {
-    expect(gfMultiply(3, 7)).toBe(gfMultiply(7, 3));
-    expect(gfMultiply(100, 200)).toBe(gfMultiply(200, 100));
-  });
+    expect(gfMultiply(3, 7)).toBe(gfMultiply(7, 3))
+    expect(gfMultiply(100, 200)).toBe(gfMultiply(200, 100))
+  })
 
   it("results are in range 0-255", () => {
     for (let a = 1; a < 256; a += 17) {
       for (let b = 1; b < 256; b += 19) {
-        const result = gfMultiply(a, b);
-        expect(result).toBeGreaterThanOrEqual(0);
-        expect(result).toBeLessThanOrEqual(255);
+        const result = gfMultiply(a, b)
+        expect(result).toBeGreaterThanOrEqual(0)
+        expect(result).toBeLessThanOrEqual(255)
       }
     }
-  });
-});
+  })
+})
 
 describe("Reed-Solomon EC generation", () => {
   it("generates correct number of EC codewords", () => {
-    const data = [32, 91, 11, 120, 209, 114, 220, 77, 67, 64, 236, 17, 236, 17, 236, 17];
-    const ec = generateECCodewords(data, 10);
-    expect(ec.length).toBe(10);
-  });
+    const data = [32, 91, 11, 120, 209, 114, 220, 77, 67, 64, 236, 17, 236, 17, 236, 17]
+    const ec = generateECCodewords(data, 10)
+    expect(ec.length).toBe(10)
+  })
 
   it("EC codewords are in range 0-255", () => {
-    const data = [1, 2, 3, 4, 5];
-    const ec = generateECCodewords(data, 7);
+    const data = [1, 2, 3, 4, 5]
+    const ec = generateECCodewords(data, 7)
     for (const byte of ec) {
-      expect(byte).toBeGreaterThanOrEqual(0);
-      expect(byte).toBeLessThanOrEqual(255);
+      expect(byte).toBeGreaterThanOrEqual(0)
+      expect(byte).toBeLessThanOrEqual(255)
     }
-  });
+  })
 
   it("different data produces different EC", () => {
-    const ec1 = generateECCodewords([1, 2, 3], 5);
-    const ec2 = generateECCodewords([4, 5, 6], 5);
-    expect(ec1).not.toEqual(ec2);
-  });
-});
+    const ec1 = generateECCodewords([1, 2, 3], 5)
+    const ec2 = generateECCodewords([4, 5, 6], 5)
+    expect(ec1).not.toEqual(ec2)
+  })
+})
 
 describe("Error correction with interleaving", () => {
   it("produces correct total length for single block", () => {
-    const data = Array.from({ length: 16 }, () => 0).map((_, i) => i);
-    const result = addErrorCorrection(data, 10, 1, 16, 0, 0);
+    const data = Array.from({ length: 16 }, () => 0).map((_, i) => i)
+    const result = addErrorCorrection(data, 10, 1, 16, 0, 0)
     // 16 data + 10 EC = 26 total
-    expect(result.length).toBe(26);
-  });
+    expect(result.length).toBe(26)
+  })
 
   it("produces correct total length for multiple blocks", () => {
-    const data = Array.from({ length: 64 }, () => 0).map((_, i) => i % 256);
+    const data = Array.from({ length: 64 }, () => 0).map((_, i) => i % 256)
     // 2 blocks of 32 each, 18 EC per block
-    const result = addErrorCorrection(data, 18, 2, 32, 0, 0);
+    const result = addErrorCorrection(data, 18, 2, 32, 0, 0)
     // 64 data + 2*18 EC = 100 total
-    expect(result.length).toBe(100);
-  });
+    expect(result.length).toBe(100)
+  })
 
   it("handles two group types", () => {
-    const data = Array.from({ length: 86 }, () => 0).map((_, i) => i % 256);
+    const data = Array.from({ length: 86 }, () => 0).map((_, i) => i % 256)
     // 2 blocks of 43, 0 group 2 blocks, 24 EC per block
-    const result = addErrorCorrection(data, 24, 2, 43, 0, 0);
-    expect(result.length).toBe(86 + 2 * 24);
-  });
+    const result = addErrorCorrection(data, 24, 2, 43, 0, 0)
+    expect(result.length).toBe(86 + 2 * 24)
+  })
 
   it("all output bytes are in range 0-255", () => {
-    const data = Array.from({ length: 44 }, () => 0).map((_, i) => (i * 7) % 256);
-    const result = addErrorCorrection(data, 26, 1, 44, 0, 0);
+    const data = Array.from({ length: 44 }, () => 0).map((_, i) => (i * 7) % 256)
+    const result = addErrorCorrection(data, 26, 1, 44, 0, 0)
     for (const byte of result) {
-      expect(byte).toBeGreaterThanOrEqual(0);
-      expect(byte).toBeLessThanOrEqual(255);
+      expect(byte).toBeGreaterThanOrEqual(0)
+      expect(byte).toBeLessThanOrEqual(255)
     }
-  });
-});
+  })
+})

--- a/test/encoders-qr-segment.test.ts
+++ b/test/encoders-qr-segment.test.ts
@@ -1,64 +1,64 @@
-import { describe, expect, it } from "vitest";
-import { optimizeSegments } from "../src/encoders/qr/segment";
+import { describe, expect, it } from "vitest"
+import { optimizeSegments } from "../src/encoders/qr/segment"
 
 describe("QR segment optimization", () => {
   it("returns empty for empty string", () => {
-    expect(optimizeSegments("", 1)).toEqual([]);
-  });
+    expect(optimizeSegments("", 1)).toEqual([])
+  })
 
   it("pure numeric → single numeric segment", () => {
-    const segs = optimizeSegments("12345678", 1);
-    expect(segs.length).toBe(1);
-    expect(segs[0]!.mode).toBe("numeric");
-    expect(segs[0]!.charCount).toBe(8);
-  });
+    const segs = optimizeSegments("12345678", 1)
+    expect(segs.length).toBe(1)
+    expect(segs[0]!.mode).toBe("numeric")
+    expect(segs[0]!.charCount).toBe(8)
+  })
 
   it("pure alphanumeric → single alphanumeric segment", () => {
-    const segs = optimizeSegments("HELLO WORLD", 1);
-    expect(segs.length).toBe(1);
-    expect(segs[0]!.mode).toBe("alphanumeric");
-  });
+    const segs = optimizeSegments("HELLO WORLD", 1)
+    expect(segs.length).toBe(1)
+    expect(segs[0]!.mode).toBe("alphanumeric")
+  })
 
   it("pure byte → single byte segment", () => {
-    const segs = optimizeSegments("hello world", 1);
-    expect(segs.length).toBe(1);
-    expect(segs[0]!.mode).toBe("byte");
-  });
+    const segs = optimizeSegments("hello world", 1)
+    expect(segs.length).toBe(1)
+    expect(segs[0]!.mode).toBe("byte")
+  })
 
   it("long numeric run after text switches to numeric", () => {
     // 20 digits is long enough to justify a mode switch
-    const segs = optimizeSegments("ABC" + "1".repeat(20), 1);
-    expect(segs.length).toBe(2);
-    expect(segs[0]!.mode).toBe("alphanumeric");
-    expect(segs[1]!.mode).toBe("numeric");
-  });
+    const segs = optimizeSegments("ABC" + "1".repeat(20), 1)
+    expect(segs.length).toBe(2)
+    expect(segs[0]!.mode).toBe("alphanumeric")
+    expect(segs[1]!.mode).toBe("numeric")
+  })
 
   it("short numeric run in alphanumeric stays alphanumeric", () => {
     // "AB12CD" — the "12" is too short to justify switching to numeric
-    const segs = optimizeSegments("AB12CD", 1);
+    const segs = optimizeSegments("AB12CD", 1)
     // Should be 1 or 2 segments, but 12 should NOT be a separate numeric segment
     // because alphanumeric can encode digits too
-    const modes = segs.map((s) => s.mode);
-    expect(modes).not.toContain("numeric");
-  });
+    const modes = segs.map((s) => s.mode)
+    expect(modes).not.toContain("numeric")
+  })
 
   it("preserves all characters", () => {
-    const text = "ABC123def456";
-    const segs = optimizeSegments(text, 1);
-    const reconstructed = segs.map((s) => new TextDecoder().decode(s.data as Uint8Array)).join("");
-    expect(reconstructed).toBe(text);
-  });
+    const text = "ABC123def456"
+    const segs = optimizeSegments(text, 1)
+    const reconstructed = segs.map((s) => new TextDecoder().decode(s.data as Uint8Array)).join("")
+    expect(reconstructed).toBe(text)
+  })
 
   it("works at higher versions", () => {
-    const segs = optimizeSegments("12345ABCDE", 20);
-    expect(segs.length).toBeGreaterThanOrEqual(1);
-  });
+    const segs = optimizeSegments("12345ABCDE", 20)
+    expect(segs.length).toBeGreaterThanOrEqual(1)
+  })
 
   it("all segments have valid modes", () => {
-    const segs = optimizeSegments("Hello 123 World!", 5);
+    const segs = optimizeSegments("Hello 123 World!", 5)
     for (const seg of segs) {
-      expect(["numeric", "alphanumeric", "byte"]).toContain(seg.mode);
-      expect(seg.charCount).toBeGreaterThan(0);
+      expect(["numeric", "alphanumeric", "byte"]).toContain(seg.mode)
+      expect(seg.charCount).toBeGreaterThan(0)
     }
-  });
-});
+  })
+})

--- a/test/encoders-qr-version.test.ts
+++ b/test/encoders-qr-version.test.ts
@@ -1,62 +1,62 @@
-import { describe, expect, it } from "vitest";
-import { selectVersion, getModuleCount, getDataCapacityBits } from "../src/encoders/qr/version";
+import { describe, expect, it } from "vitest"
+import { selectVersion, getModuleCount, getDataCapacityBits } from "../src/encoders/qr/version"
 
 describe("QR version selection", () => {
   it("selects version 1 for short numeric text", () => {
-    const v = selectVersion("12345", "M", "numeric");
-    expect(v).toBe(1);
-    expect(getModuleCount(v)).toBe(21);
-  });
+    const v = selectVersion("12345", "M", "numeric")
+    expect(v).toBe(1)
+    expect(getModuleCount(v)).toBe(21)
+  })
 
   it("selects version 1 for short byte text", () => {
-    const v = selectVersion("Hi", "M", "byte");
-    expect(v).toBe(1);
-  });
+    const v = selectVersion("Hi", "M", "byte")
+    expect(v).toBe(1)
+  })
 
   it("selects larger version for longer text", () => {
-    const short = selectVersion("Hi", "M");
-    const long = selectVersion("This is a much longer string that needs more space", "M");
-    expect(long).toBeGreaterThan(short);
-  });
+    const short = selectVersion("Hi", "M")
+    const long = selectVersion("This is a much longer string that needs more space", "M")
+    expect(long).toBeGreaterThan(short)
+  })
 
   it("selects larger version for higher EC level", () => {
-    const text = "Hello World Test String";
-    const vL = selectVersion(text, "L");
-    const vH = selectVersion(text, "H");
-    expect(vH).toBeGreaterThanOrEqual(vL);
-  });
+    const text = "Hello World Test String"
+    const vL = selectVersion(text, "L")
+    const vH = selectVersion(text, "H")
+    expect(vH).toBeGreaterThanOrEqual(vL)
+  })
 
   it("respects requested version when sufficient", () => {
-    const v = selectVersion("Hi", "M", "byte", 5);
-    expect(v).toBe(5);
-  });
+    const v = selectVersion("Hi", "M", "byte", 5)
+    expect(v).toBe(5)
+  })
 
   it("throws when requested version is too small", () => {
-    expect(() => selectVersion("A".repeat(200), "H", "byte", 1)).toThrow();
-  });
+    expect(() => selectVersion("A".repeat(200), "H", "byte", 1)).toThrow()
+  })
 
   it("throws when data exceeds all versions", () => {
-    expect(() => selectVersion("A".repeat(10000), "H")).toThrow();
-  });
+    expect(() => selectVersion("A".repeat(10000), "H")).toThrow()
+  })
 
   it("returns correct module count for each version", () => {
-    expect(getModuleCount(1)).toBe(21);
-    expect(getModuleCount(10)).toBe(57);
-    expect(getModuleCount(20)).toBe(97);
-    expect(getModuleCount(40)).toBe(177);
-  });
+    expect(getModuleCount(1)).toBe(21)
+    expect(getModuleCount(10)).toBe(57)
+    expect(getModuleCount(20)).toBe(97)
+    expect(getModuleCount(40)).toBe(177)
+  })
 
   it("data capacity increases with version", () => {
     for (let v = 2; v <= 40; v++) {
-      expect(getDataCapacityBits(v, "M")).toBeGreaterThan(getDataCapacityBits(v - 1, "M"));
+      expect(getDataCapacityBits(v, "M")).toBeGreaterThan(getDataCapacityBits(v - 1, "M"))
     }
-  });
+  })
 
   it("data capacity decreases with EC level", () => {
     for (let v = 1; v <= 40; v++) {
-      const capL = getDataCapacityBits(v, "L");
-      const capH = getDataCapacityBits(v, "H");
-      expect(capL).toBeGreaterThan(capH);
+      const capL = getDataCapacityBits(v, "L")
+      const capH = getDataCapacityBits(v, "H")
+      expect(capL).toBeGreaterThan(capH)
     }
-  });
-});
+  })
+})

--- a/test/encoders-rmqr.test.ts
+++ b/test/encoders-rmqr.test.ts
@@ -1,57 +1,57 @@
-import { describe, expect, it } from "vitest";
-import { encodeRMQR } from "../src/encoders/rmqr";
+import { describe, expect, it } from "vitest"
+import { encodeRMQR } from "../src/encoders/rmqr"
 
 describe("rMQR (Rectangular Micro QR)", () => {
   it("encodes short text", () => {
-    const matrix = encodeRMQR("Hello");
-    expect(matrix.length).toBeGreaterThan(0);
-    expect(matrix[0]!.length).toBeGreaterThan(matrix.length); // rectangular
-  });
+    const matrix = encodeRMQR("Hello")
+    expect(matrix.length).toBeGreaterThan(0)
+    expect(matrix[0]!.length).toBeGreaterThan(matrix.length) // rectangular
+  })
 
   it("produces rectangular matrix (wider than tall)", () => {
-    const matrix = encodeRMQR("Test data");
-    expect(matrix[0]!.length).toBeGreaterThan(matrix.length);
-  });
+    const matrix = encodeRMQR("Test data")
+    expect(matrix[0]!.length).toBeGreaterThan(matrix.length)
+  })
 
   it("produces boolean matrix", () => {
-    const matrix = encodeRMQR("Data");
+    const matrix = encodeRMQR("Data")
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("has finder at top-left", () => {
-    const matrix = encodeRMQR("Test");
-    expect(matrix[0]![0]).toBe(true);
-    expect(matrix[0]![6]).toBe(true);
-    expect(matrix[3]![3]).toBe(true);
-  });
+    const matrix = encodeRMQR("Test")
+    expect(matrix[0]![0]).toBe(true)
+    expect(matrix[0]![6]).toBe(true)
+    expect(matrix[3]![3]).toBe(true)
+  })
 
   it("supports EC level M", () => {
-    const matrix = encodeRMQR("Test", { ecLevel: "M" });
-    expect(matrix.length).toBeGreaterThan(0);
-  });
+    const matrix = encodeRMQR("Test", { ecLevel: "M" })
+    expect(matrix.length).toBeGreaterThan(0)
+  })
 
   it("supports EC level H", () => {
-    const matrix = encodeRMQR("Test", { ecLevel: "H" });
-    expect(matrix.length).toBeGreaterThan(0);
-  });
+    const matrix = encodeRMQR("Test", { ecLevel: "H" })
+    expect(matrix.length).toBeGreaterThan(0)
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeRMQR("")).toThrow();
-  });
+    expect(() => encodeRMQR("")).toThrow()
+  })
 
   it("throws on too long data", () => {
-    expect(() => encodeRMQR("A".repeat(500))).toThrow();
-  });
+    expect(() => encodeRMQR("A".repeat(500))).toThrow()
+  })
 
   it("different data produces different output", () => {
-    const a = encodeRMQR("Hello");
-    const b = encodeRMQR("World");
-    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
-});
+    const a = encodeRMQR("Hello")
+    const b = encodeRMQR("World")
+    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
+})

--- a/test/encoders-upc.test.ts
+++ b/test/encoders-upc.test.ts
@@ -1,171 +1,171 @@
-import { describe, expect, it } from "vitest";
-import { encodeUPCA, encodeUPCE } from "../src/encoders/upc";
+import { describe, expect, it } from "vitest"
+import { encodeUPCA, encodeUPCE } from "../src/encoders/upc"
 
 describe("encodeUPCA", () => {
   // --- Valid encoding ---
 
   it("encodes 11 digits with auto-calculated check digit", () => {
-    const result = encodeUPCA("03600029145");
-    expect(result.bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(result.bars)).toBe(true);
-    expect(Array.isArray(result.guards)).toBe(true);
-  });
+    const result = encodeUPCA("03600029145")
+    expect(result.bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(result.bars)).toBe(true)
+    expect(Array.isArray(result.guards)).toBe(true)
+  })
 
   it("encodes 12 digits with valid check digit", () => {
-    const result = encodeUPCA("036000291452");
-    expect(result.bars.length).toBeGreaterThan(0);
-  });
+    const result = encodeUPCA("036000291452")
+    expect(result.bars.length).toBeGreaterThan(0)
+  })
 
   it("returns guard positions", () => {
-    const result = encodeUPCA("03600029145");
+    const result = encodeUPCA("03600029145")
     // 3 guard positions: start, center, end
-    expect(result.guards.length).toBe(3);
+    expect(result.guards.length).toBe(3)
     // Guards should be in ascending order
-    expect(result.guards[0]).toBeLessThan(result.guards[1]!);
-    expect(result.guards[1]).toBeLessThan(result.guards[2]!);
-  });
+    expect(result.guards[0]).toBeLessThan(result.guards[1]!)
+    expect(result.guards[1]).toBeLessThan(result.guards[2]!)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1-4)", () => {
-    const result = encodeUPCA("03600029145");
+    const result = encodeUPCA("03600029145")
     for (const w of result.bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(4);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(4)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("output length is fixed for UPC-A", () => {
     // UPC-A: start(3) + 6*4 left + center(5) + 6*4 right + end(3)
     // = 3 + 24 + 5 + 24 + 3 = 59 elements
-    const result = encodeUPCA("03600029145");
-    expect(result.bars.length).toBe(59);
-  });
+    const result = encodeUPCA("03600029145")
+    expect(result.bars.length).toBe(59)
+  })
 
   // --- Check digit validation ---
 
   it("throws on incorrect check digit", () => {
     // 036000291452 is valid; 036000291453 should fail
-    expect(() => encodeUPCA("036000291453")).toThrow("check digit mismatch");
-  });
+    expect(() => encodeUPCA("036000291453")).toThrow("check digit mismatch")
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different bar patterns", () => {
-    const result1 = encodeUPCA("03600029145");
-    const result2 = encodeUPCA("01234567890");
-    expect(result1.bars).not.toEqual(result2.bars);
-  });
+    const result1 = encodeUPCA("03600029145")
+    const result2 = encodeUPCA("01234567890")
+    expect(result1.bars).not.toEqual(result2.bars)
+  })
 
   it("same input produces same output", () => {
-    const result1 = encodeUPCA("03600029145");
-    const result2 = encodeUPCA("03600029145");
-    expect(result1.bars).toEqual(result2.bars);
-  });
+    const result1 = encodeUPCA("03600029145")
+    const result2 = encodeUPCA("03600029145")
+    expect(result1.bars).toEqual(result2.bars)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on wrong length", () => {
-    expect(() => encodeUPCA("12345")).toThrow("11 or 12 digits");
-    expect(() => encodeUPCA("1234567890123")).toThrow("11 or 12 digits");
-  });
+    expect(() => encodeUPCA("12345")).toThrow("11 or 12 digits")
+    expect(() => encodeUPCA("1234567890123")).toThrow("11 or 12 digits")
+  })
 
   it("strips non-digit characters and validates length", () => {
     // The encoder calls replace(/\D/g, ''), so non-digits are stripped
     // "0-36-00029145" has 11 digits after stripping
-    const result = encodeUPCA("0-36-00029145");
-    expect(result.bars.length).toBe(59);
-  });
-});
+    const result = encodeUPCA("0-36-00029145")
+    expect(result.bars.length).toBe(59)
+  })
+})
 
 describe("encodeUPCE", () => {
   // --- Valid encoding ---
 
   it("encodes 6 digits (NS=0 implied, check auto-calculated)", () => {
-    const result = encodeUPCE("123456");
-    expect(result.bars.length).toBeGreaterThan(0);
-    expect(Array.isArray(result.bars)).toBe(true);
-    expect(Array.isArray(result.guards)).toBe(true);
-  });
+    const result = encodeUPCE("123456")
+    expect(result.bars.length).toBeGreaterThan(0)
+    expect(Array.isArray(result.bars)).toBe(true)
+    expect(Array.isArray(result.guards)).toBe(true)
+  })
 
   it("encodes 7 digits starting with 0 (NS=0 + 6 middle)", () => {
-    const result = encodeUPCE("0123456");
-    expect(result.bars.length).toBeGreaterThan(0);
-  });
+    const result = encodeUPCE("0123456")
+    expect(result.bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes 7 digits starting with 1 (NS=1 + 6 middle)", () => {
-    const result = encodeUPCE("1123456");
-    expect(result.bars.length).toBeGreaterThan(0);
-  });
+    const result = encodeUPCE("1123456")
+    expect(result.bars.length).toBeGreaterThan(0)
+  })
 
   it("encodes 8 digits (NS + 6 middle + check)", () => {
     // First get a valid encoding to extract the check digit
-    const result = encodeUPCE("01234565");
-    expect(result.bars.length).toBeGreaterThan(0);
-  });
+    const result = encodeUPCE("01234565")
+    expect(result.bars.length).toBeGreaterThan(0)
+  })
 
   it("returns guard positions", () => {
-    const result = encodeUPCE("123456");
+    const result = encodeUPCE("123456")
     // 2 guard positions: start and end
-    expect(result.guards.length).toBe(2);
-    expect(result.guards[0]).toBeLessThan(result.guards[1]!);
-  });
+    expect(result.guards.length).toBe(2)
+    expect(result.guards[0]).toBeLessThan(result.guards[1]!)
+  })
 
   // --- Bar width validation ---
 
   it("produces only valid widths (1-4)", () => {
-    const result = encodeUPCE("123456");
+    const result = encodeUPCE("123456")
     for (const w of result.bars) {
-      expect(w).toBeGreaterThanOrEqual(1);
-      expect(w).toBeLessThanOrEqual(4);
-      expect(Number.isInteger(w)).toBe(true);
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(4)
+      expect(Number.isInteger(w)).toBe(true)
     }
-  });
+  })
 
   it("output length is fixed for UPC-E", () => {
     // UPC-E: start(3) + 6*4 digits + end_special(6) = 3 + 24 + 6 = 33
-    const result = encodeUPCE("123456");
-    expect(result.bars.length).toBe(33);
-  });
+    const result = encodeUPCE("123456")
+    expect(result.bars.length).toBe(33)
+  })
 
   // --- Check digit validation ---
 
   it("throws on incorrect check digit for 8-digit input", () => {
     // Try with a wrong check digit
-    expect(() => encodeUPCE("01234560")).toThrow("check digit mismatch");
-  });
+    expect(() => encodeUPCE("01234560")).toThrow("check digit mismatch")
+  })
 
   it("throws on invalid number system for 8-digit input", () => {
-    expect(() => encodeUPCE("51234567")).toThrow("number system must be 0 or 1");
-  });
+    expect(() => encodeUPCE("51234567")).toThrow("number system must be 0 or 1")
+  })
 
   // --- Different inputs produce different outputs ---
 
   it("different inputs produce different bar patterns", () => {
-    const result1 = encodeUPCE("123456");
-    const result2 = encodeUPCE("654321");
-    expect(result1.bars).not.toEqual(result2.bars);
-  });
+    const result1 = encodeUPCE("123456")
+    const result2 = encodeUPCE("654321")
+    expect(result1.bars).not.toEqual(result2.bars)
+  })
 
   // --- Invalid input handling ---
 
   it("throws on wrong length", () => {
-    expect(() => encodeUPCE("12345")).toThrow("6, 7, or 8 digits");
-    expect(() => encodeUPCE("123456789")).toThrow("6, 7, or 8 digits");
-  });
+    expect(() => encodeUPCE("12345")).toThrow("6, 7, or 8 digits")
+    expect(() => encodeUPCE("123456789")).toThrow("6, 7, or 8 digits")
+  })
 
   // --- Edge case: UPC-E expansion patterns ---
 
   it("handles last digit 0 expansion correctly", () => {
-    const result = encodeUPCE("120000");
-    expect(result.bars.length).toBe(33);
-  });
+    const result = encodeUPCE("120000")
+    expect(result.bars.length).toBe(33)
+  })
 
   it("handles last digit 5-9 expansion correctly", () => {
-    const result = encodeUPCE("123455");
-    expect(result.bars.length).toBe(33);
-    const result2 = encodeUPCE("123459");
-    expect(result2.bars.length).toBe(33);
-  });
-});
+    const result = encodeUPCE("123455")
+    expect(result.bars.length).toBe(33)
+    const result2 = encodeUPCE("123459")
+    expect(result2.bars.length).toBe(33)
+  })
+})

--- a/test/gs1-datamatrix.test.ts
+++ b/test/gs1-datamatrix.test.ts
@@ -1,48 +1,48 @@
-import { describe, expect, it } from "vitest";
-import { encodeGS1DataMatrix } from "../src/encoders/datamatrix/index";
-import { gs1datamatrix } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { encodeGS1DataMatrix } from "../src/encoders/datamatrix/index"
+import { gs1datamatrix } from "../src/index"
 
 describe("GS1 DataMatrix", () => {
   it("encodes GTIN with AI 01", () => {
-    const matrix = encodeGS1DataMatrix("(01)12345678901234");
-    expect(matrix.length).toBeGreaterThan(0);
-    expect(matrix[0]!.length).toBeGreaterThan(0);
-  });
+    const matrix = encodeGS1DataMatrix("(01)12345678901234")
+    expect(matrix.length).toBeGreaterThan(0)
+    expect(matrix[0]!.length).toBeGreaterThan(0)
+  })
 
   it("encodes multiple AIs", () => {
-    const matrix = encodeGS1DataMatrix("(01)12345678901234(17)260101(10)BATCH01");
-    expect(matrix.length).toBeGreaterThan(0);
-  });
+    const matrix = encodeGS1DataMatrix("(01)12345678901234(17)260101(10)BATCH01")
+    expect(matrix.length).toBeGreaterThan(0)
+  })
 
   it("produces boolean matrix", () => {
-    const matrix = encodeGS1DataMatrix("(01)12345678901234");
+    const matrix = encodeGS1DataMatrix("(01)12345678901234")
     for (const row of matrix) {
       for (const cell of row) {
-        expect(typeof cell).toBe("boolean");
+        expect(typeof cell).toBe("boolean")
       }
     }
-  });
+  })
 
   it("renders to SVG via convenience function", () => {
-    const svg = gs1datamatrix("(01)12345678901234");
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-  });
+    const svg = gs1datamatrix("(01)12345678901234")
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+  })
 
   it("throws on empty input", () => {
-    expect(() => encodeGS1DataMatrix("")).toThrow();
-  });
+    expect(() => encodeGS1DataMatrix("")).toThrow()
+  })
 
   it("throws on invalid AI format", () => {
-    expect(() => encodeGS1DataMatrix("no parens")).toThrow();
-  });
+    expect(() => encodeGS1DataMatrix("no parens")).toThrow()
+  })
 
   it("different AIs produce different matrices", () => {
-    const a = encodeGS1DataMatrix("(01)12345678901234");
-    const b = encodeGS1DataMatrix("(01)98765432109876");
+    const a = encodeGS1DataMatrix("(01)12345678901234")
+    const b = encodeGS1DataMatrix("(01)98765432109876")
     // Different data should produce different matrices
-    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("");
-    expect(aStr).not.toBe(bStr);
-  });
-});
+    const aStr = a.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    const bStr = b.map((r) => r.map((c) => (c ? "1" : "0")).join("")).join("")
+    expect(aStr).not.toBe(bStr)
+  })
+})

--- a/test/gs1-digital-link.test.ts
+++ b/test/gs1-digital-link.test.ts
@@ -1,37 +1,37 @@
-import { describe, expect, it } from "vitest";
-import { gs1DigitalLink } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { gs1DigitalLink } from "../src/index"
 
 describe("GS1 Digital Link", () => {
   it("generates QR with GTIN only", () => {
-    const svg = gs1DigitalLink({ gtin: "09520123456788" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = gs1DigitalLink({ gtin: "09520123456788" })
+    expect(svg).toContain("<svg")
+  })
 
   it("generates QR with GTIN + batch + serial", () => {
     const svg = gs1DigitalLink({
       gtin: "09520123456788",
       batch: "ABC123",
       serial: "12345",
-    });
-    expect(svg).toContain("<svg");
-  });
+    })
+    expect(svg).toContain("<svg")
+  })
 
   it("generates QR with custom domain", () => {
-    const svg = gs1DigitalLink({ gtin: "09520123456788" }, { domain: "https://example.com" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = gs1DigitalLink({ gtin: "09520123456788" }, { domain: "https://example.com" })
+    expect(svg).toContain("<svg")
+  })
 
   it("generates QR with expiry and weight", () => {
     const svg = gs1DigitalLink({
       gtin: "09520123456788",
       expiry: "260101",
       weight: "001500",
-    });
-    expect(svg).toContain("<svg");
-  });
+    })
+    expect(svg).toContain("<svg")
+  })
 
   it("accepts QR options", () => {
-    const svg = gs1DigitalLink({ gtin: "09520123456788" }, { size: 300, ecLevel: "H" });
-    expect(svg).toContain('width="300"');
-  });
-});
+    const svg = gs1DigitalLink({ gtin: "09520123456788" }, { size: 300, ecLevel: "H" })
+    expect(svg).toContain('width="300"')
+  })
+})

--- a/test/helpers-full.test.ts
+++ b/test/helpers-full.test.ts
@@ -3,7 +3,7 @@
  * field is asserted to reach the encoded payload.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   wifi,
   url,
@@ -16,91 +16,91 @@ import {
   event,
   swissQR,
   gs1DigitalLink,
-} from "../src/_helpers";
-import { qrcode, qrcodeTerminal, qrcodeDataURI, qrcodeBase64 } from "../src/_qrcode";
-import { encodeQR } from "../src/encoders/qr/index";
-import { renderText } from "../src/renderers/text";
+} from "../src/_helpers"
+import { qrcode, qrcodeTerminal, qrcodeDataURI, qrcodeBase64 } from "../src/_qrcode"
+import { encodeQR } from "../src/encoders/qr/index"
+import { renderText } from "../src/renderers/text"
 
 /**
  * Recover the payload a helper encoded by decoding the QR matrix it produced.
  * Comparing against a directly-encoded reference proves the exact text.
  */
 function encodes(svg: string, expectedText: string): boolean {
-  return svg === qrcodeFromText(expectedText);
+  return svg === qrcodeFromText(expectedText)
 }
 
 function qrcodeFromText(text: string): string {
-  return qrcode(text);
+  return qrcode(text)
 }
 
 describe("wifi()", () => {
   it("builds a WIFI payload with WPA by default", () => {
-    expect(encodes(wifi("Net", "pass"), "WIFI:T:WPA;S:Net;P:pass;;")).toBe(true);
-  });
+    expect(encodes(wifi("Net", "pass"), "WIFI:T:WPA;S:Net;P:pass;;")).toBe(true)
+  })
 
   it("honours the encryption option", () => {
     expect(encodes(wifi("Net", "pass", { encryption: "WEP" }), "WIFI:T:WEP;S:Net;P:pass;;")).toBe(
       true,
-    );
+    )
     expect(encodes(wifi("Net", "", { encryption: "nopass" }), "WIFI:T:nopass;S:Net;P:;;")).toBe(
       true,
-    );
-  });
+    )
+  })
 
   it("marks hidden networks", () => {
     expect(encodes(wifi("Net", "pass", { hidden: true }), "WIFI:T:WPA;S:Net;P:pass;H:true;;")).toBe(
       true,
-    );
-  });
+    )
+  })
 
   it("escapes special characters in SSID and password", () => {
-    expect(encodes(wifi("My;Net", 'pa"ss', {}), 'WIFI:T:WPA;S:My\\;Net;P:pa\\"ss;;')).toBe(true);
-  });
+    expect(encodes(wifi("My;Net", 'pa"ss', {}), 'WIFI:T:WPA;S:My\\;Net;P:pa\\"ss;;')).toBe(true)
+  })
 
   it("escapes backslashes, commas and colons", () => {
-    expect(encodes(wifi("a\\b,c:d", "p"), "WIFI:T:WPA;S:a\\\\b\\,c\\:d;P:p;;")).toBe(true);
-  });
-});
+    expect(encodes(wifi("a\\b,c:d", "p"), "WIFI:T:WPA;S:a\\\\b\\,c\\:d;P:p;;")).toBe(true)
+  })
+})
 
 describe("simple helpers", () => {
   it("url() encodes the URL verbatim", () => {
-    expect(encodes(url("https://example.com"), "https://example.com")).toBe(true);
-  });
+    expect(encodes(url("https://example.com"), "https://example.com")).toBe(true)
+  })
 
   it("email() builds a mailto payload", () => {
-    expect(encodes(email("a@b.c"), "mailto:a@b.c")).toBe(true);
-  });
+    expect(encodes(email("a@b.c"), "mailto:a@b.c")).toBe(true)
+  })
 
   it("phone() builds a tel payload", () => {
-    expect(encodes(phone("+15551234"), "tel:+15551234")).toBe(true);
-  });
+    expect(encodes(phone("+15551234"), "tel:+15551234")).toBe(true)
+  })
 
   it("sms() builds an sms payload with and without a body", () => {
-    expect(encodes(sms("5551234"), "sms:5551234")).toBe(true);
-    expect(encodes(sms("5551234", "hello world"), "sms:5551234?body=hello%20world")).toBe(true);
-  });
+    expect(encodes(sms("5551234"), "sms:5551234")).toBe(true)
+    expect(encodes(sms("5551234", "hello world"), "sms:5551234?body=hello%20world")).toBe(true)
+  })
 
   it("geo() builds a geo payload", () => {
-    expect(encodes(geo(41.0082, 28.9784), "geo:41.0082,28.9784")).toBe(true);
-  });
+    expect(encodes(geo(41.0082, 28.9784), "geo:41.0082,28.9784")).toBe(true)
+  })
 
   it("passes rendering options through", () => {
-    expect(url("https://example.com", { color: "#ff0000" })).toContain('fill="#ff0000"');
-  });
-});
+    expect(url("https://example.com", { color: "#ff0000" })).toContain('fill="#ff0000"')
+  })
+})
 
 describe("vcard()", () => {
   it("encodes a minimal contact", () => {
-    const svg = vcard({ firstName: "Ada" });
-    expect(svg).toBe(qrcodeFromText("BEGIN:VCARD\nVERSION:3.0\nN:;Ada;;;\nFN:Ada\nEND:VCARD"));
-  });
+    const svg = vcard({ firstName: "Ada" })
+    expect(svg).toBe(qrcodeFromText("BEGIN:VCARD\nVERSION:3.0\nN:;Ada;;;\nFN:Ada\nEND:VCARD"))
+  })
 
   it("includes the last name in N and FN", () => {
-    const svg = vcard({ firstName: "Ada", lastName: "Lovelace" });
+    const svg = vcard({ firstName: "Ada", lastName: "Lovelace" })
     expect(svg).toBe(
       qrcodeFromText("BEGIN:VCARD\nVERSION:3.0\nN:Lovelace;Ada;;;\nFN:Ada Lovelace\nEND:VCARD"),
-    );
-  });
+    )
+  })
 
   it("includes every optional field", () => {
     const svg = vcard({
@@ -112,7 +112,7 @@ describe("vcard()", () => {
       title: "Engineer",
       url: "https://example.com",
       address: "1 Main St",
-    });
+    })
     expect(svg).toBe(
       qrcodeFromText(
         [
@@ -129,18 +129,18 @@ describe("vcard()", () => {
           "END:VCARD",
         ].join("\n"),
       ),
-    );
-  });
+    )
+  })
 
   it("omits fields that are not supplied", () => {
-    expect(vcard({ firstName: "Ada", phone: "555" })).not.toBe(vcard({ firstName: "Ada" }));
-  });
-});
+    expect(vcard({ firstName: "Ada", phone: "555" })).not.toBe(vcard({ firstName: "Ada" }))
+  })
+})
 
 describe("mecard()", () => {
   it("encodes a minimal contact", () => {
-    expect(encodes(mecard({ name: "Ada" }), "MECARD:N:Ada;;")).toBe(true);
-  });
+    expect(encodes(mecard({ name: "Ada" }), "MECARD:N:Ada;;")).toBe(true)
+  })
 
   it("includes every optional field", () => {
     expect(
@@ -154,20 +154,20 @@ describe("mecard()", () => {
         }),
         "MECARD:N:Ada;TEL:555;EMAIL:a@b.c;URL:https://x.y;ADR:1 Main St;;",
       ),
-    ).toBe(true);
-  });
-});
+    ).toBe(true)
+  })
+})
 
 describe("event()", () => {
-  const start = new Date(Date.UTC(2026, 0, 15, 9, 30, 0));
-  const end = new Date(Date.UTC(2026, 0, 15, 10, 30, 0));
+  const start = new Date(Date.UTC(2026, 0, 15, 9, 30, 0))
+  const end = new Date(Date.UTC(2026, 0, 15, 10, 30, 0))
 
   it("encodes a minimal event", () => {
-    const svg = event({ title: "Standup", start });
+    const svg = event({ title: "Standup", start })
     expect(svg).toBe(
       qrcodeFromText("BEGIN:VEVENT\nSUMMARY:Standup\nDTSTART:20260115T093000Z\nEND:VEVENT"),
-    );
-  });
+    )
+  })
 
   it("includes every optional field", () => {
     const svg = event({
@@ -176,7 +176,7 @@ describe("event()", () => {
       end,
       location: "Room 1",
       description: "Daily sync",
-    });
+    })
     expect(svg).toBe(
       qrcodeFromText(
         [
@@ -189,16 +189,16 @@ describe("event()", () => {
           "END:VEVENT",
         ].join("\n"),
       ),
-    );
-  });
-});
+    )
+  })
+})
 
 describe("gs1DigitalLink()", () => {
   it("builds a GTIN link", () => {
     expect(gs1DigitalLink({ gtin: "09520123456788" })).toBe(
       qrcodeFromText("https://id.gs1.org/01/09520123456788"),
-    );
-  });
+    )
+  })
 
   it("appends batch, serial, expiry and weight", () => {
     const svg = gs1DigitalLink({
@@ -207,28 +207,28 @@ describe("gs1DigitalLink()", () => {
       serial: "12345",
       expiry: "261231",
       weight: "000195",
-    });
+    })
     expect(svg).toBe(
       qrcodeFromText("https://id.gs1.org/01/09520123456788/10/ABC/21/12345/17/261231/3103/000195"),
-    );
-  });
+    )
+  })
 
   it("appends unknown keys as additional AI segments", () => {
-    const svg = gs1DigitalLink({ gtin: "09520123456788", "422": "056" });
-    expect(svg).toBe(qrcodeFromText("https://id.gs1.org/01/09520123456788/422/056"));
-  });
+    const svg = gs1DigitalLink({ gtin: "09520123456788", "422": "056" })
+    expect(svg).toBe(qrcodeFromText("https://id.gs1.org/01/09520123456788/422/056"))
+  })
 
   it("supports a custom domain via options", () => {
-    const svg = gs1DigitalLink({ gtin: "09520123456788" }, { domain: "https://example.com" });
-    expect(svg).toBe(qrcodeFromText("https://example.com/01/09520123456788"));
-  });
+    const svg = gs1DigitalLink({ gtin: "09520123456788" }, { domain: "https://example.com" })
+    expect(svg).toBe(qrcodeFromText("https://example.com/01/09520123456788"))
+  })
 
   it("treats lot as an alias for batch", () => {
     expect(gs1DigitalLink({ gtin: "09520123456788", lot: "L1" })).toBe(
       gs1DigitalLink({ gtin: "09520123456788", batch: "L1" }),
-    );
-  });
-});
+    )
+  })
+})
 
 describe("swissQR()", () => {
   const base = {
@@ -241,28 +241,28 @@ describe("swissQR()", () => {
       city: "Zurich",
       country: "CH",
     },
-  };
+  }
 
   it("builds a Swiss QR payload with the required header and trailer", () => {
-    const svg = swissQR(base);
-    expect(svg.startsWith("<svg")).toBe(true);
+    const svg = swissQR(base)
+    expect(svg.startsWith("<svg")).toBe(true)
     // Same data must produce a stable symbol
-    expect(swissQR(base)).toBe(svg);
-  });
+    expect(swissQR(base)).toBe(svg)
+  })
 
   it("strips whitespace from the IBAN", () => {
-    expect(swissQR(base)).toBe(swissQR({ ...base, iban: "CH9300762011623852957" }));
-  });
+    expect(swissQR(base)).toBe(swissQR({ ...base, iban: "CH9300762011623852957" }))
+  })
 
   it("formats the amount to two decimals", () => {
-    expect(swissQR({ ...base, amount: 100 })).toBe(swissQR({ ...base, amount: 100.0 }));
-    expect(swissQR({ ...base, amount: 100 })).not.toBe(swissQR({ ...base, amount: 100.5 }));
-  });
+    expect(swissQR({ ...base, amount: 100 })).toBe(swissQR({ ...base, amount: 100.0 }))
+    expect(swissQR({ ...base, amount: 100 })).not.toBe(swissQR({ ...base, amount: 100.5 }))
+  })
 
   it("defaults the currency to CHF", () => {
-    expect(swissQR(base)).toBe(swissQR({ ...base, currency: "CHF" }));
-    expect(swissQR(base)).not.toBe(swissQR({ ...base, currency: "EUR" }));
-  });
+    expect(swissQR(base)).toBe(swissQR({ ...base, currency: "CHF" }))
+    expect(swissQR(base)).not.toBe(swissQR({ ...base, currency: "EUR" }))
+  })
 
   it("includes debtor details when supplied", () => {
     const withDebtor = swissQR({
@@ -275,61 +275,61 @@ describe("swissQR()", () => {
         city: "Bern",
         country: "CH",
       },
-    });
-    expect(withDebtor).not.toBe(swissQR(base));
-  });
+    })
+    expect(withDebtor).not.toBe(swissQR(base))
+  })
 
   it("defaults the reference type to NON and varies with a reference", () => {
-    expect(swissQR(base)).toBe(swissQR({ ...base, referenceType: "NON" }));
+    expect(swissQR(base)).toBe(swissQR({ ...base, referenceType: "NON" }))
     expect(
       swissQR({ ...base, referenceType: "QRR", reference: "210000000003139471430009017" }),
-    ).not.toBe(swissQR(base));
-  });
+    ).not.toBe(swissQR(base))
+  })
 
   it("includes additional information", () => {
-    expect(swissQR({ ...base, additionalInfo: "Invoice 123" })).not.toBe(swissQR(base));
-  });
+    expect(swissQR({ ...base, additionalInfo: "Invoice 123" })).not.toBe(swissQR(base))
+  })
 
   it("allows the EC level to be overridden", () => {
-    expect(swissQR(base, { ecLevel: "H" })).not.toBe(swissQR(base));
-  });
-});
+    expect(swissQR(base, { ecLevel: "H" })).not.toBe(swissQR(base))
+  })
+})
 
 describe("qrcode wrapper", () => {
   it("matches the raw encoder for the same input", () => {
-    const matrix = encodeQR("HELLO");
-    expect(qrcode("HELLO")).toContain("<path");
-    expect(matrix.length).toBeGreaterThan(0);
-  });
+    const matrix = encodeQR("HELLO")
+    expect(qrcode("HELLO")).toContain("<path")
+    expect(matrix.length).toBeGreaterThan(0)
+  })
 
   it("auto-upgrades EC level to H when a logo is present", () => {
-    const withLogo = qrcode("HELLO", { logo: { path: "M0,0h100v100h-100z" } });
-    const explicitH = qrcode("HELLO", { ecLevel: "H", logo: { path: "M0,0h100v100h-100z" } });
-    expect(withLogo).toBe(explicitH);
-  });
+    const withLogo = qrcode("HELLO", { logo: { path: "M0,0h100v100h-100z" } })
+    const explicitH = qrcode("HELLO", { ecLevel: "H", logo: { path: "M0,0h100v100h-100z" } })
+    expect(withLogo).toBe(explicitH)
+  })
 
   it("respects an explicit EC level even with a logo", () => {
-    const explicitL = qrcode("HELLO", { ecLevel: "L", logo: { path: "M0,0h100v100h-100z" } });
-    const autoH = qrcode("HELLO", { logo: { path: "M0,0h100v100h-100z" } });
-    expect(explicitL).not.toBe(autoH);
-  });
+    const explicitL = qrcode("HELLO", { ecLevel: "L", logo: { path: "M0,0h100v100h-100z" } })
+    const autoH = qrcode("HELLO", { logo: { path: "M0,0h100v100h-100z" } })
+    expect(explicitL).not.toBe(autoH)
+  })
 
   it("renders a terminal representation", () => {
-    const out = qrcodeTerminal("HI");
-    expect(out).toBe(renderText(encodeQR("HI")));
-    expect(out.length).toBeGreaterThan(0);
-  });
+    const out = qrcodeTerminal("HI")
+    expect(out).toBe(renderText(encodeQR("HI")))
+    expect(out.length).toBeGreaterThan(0)
+  })
 
   it("passes encoder options to the terminal renderer", () => {
-    expect(qrcodeTerminal("HI", { ecLevel: "L" })).not.toBe(qrcodeTerminal("HI", { ecLevel: "H" }));
-  });
+    expect(qrcodeTerminal("HI", { ecLevel: "L" })).not.toBe(qrcodeTerminal("HI", { ecLevel: "H" }))
+  })
 
   it("produces data URI and base64 output", () => {
-    expect(qrcodeDataURI("HELLO")).toMatch(/^data:image\/svg\+xml/);
-    expect(qrcodeBase64("HELLO")).toMatch(/^data:image\/svg\+xml;base64,/);
-  });
+    expect(qrcodeDataURI("HELLO")).toMatch(/^data:image\/svg\+xml/)
+    expect(qrcodeBase64("HELLO")).toMatch(/^data:image\/svg\+xml;base64,/)
+  })
 
   it("forwards rendering options through the data URI variants", () => {
-    expect(qrcodeDataURI("HELLO", { size: 100 })).not.toBe(qrcodeDataURI("HELLO", { size: 400 }));
-  });
-});
+    expect(qrcodeDataURI("HELLO", { size: 100 })).not.toBe(qrcodeDataURI("HELLO", { size: 400 }))
+  })
+})

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,106 +1,106 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest"
 
-let capturedText = "";
+let capturedText = ""
 
 vi.mock("../src/encoders/qr/index", () => ({
   encodeQR: (text: string) => {
-    capturedText = text;
+    capturedText = text
     // Return a minimal 1x1 matrix so the renderer can produce valid SVG
-    return [[1]];
+    return [[1]]
   },
-}));
+}))
 
-import { wifi, email, sms, geo, phone, vcard, mecard, event } from "../src/index";
+import { wifi, email, sms, geo, phone, vcard, mecard, event } from "../src/index"
 
 describe("wifi", () => {
   it("defaults to WPA encryption", () => {
-    wifi("MyNetwork", "secret123");
-    expect(capturedText).toContain("T:WPA");
-  });
+    wifi("MyNetwork", "secret123")
+    expect(capturedText).toContain("T:WPA")
+  })
 
   it("supports WEP encryption", () => {
-    wifi("MyNetwork", "secret123", { encryption: "WEP" });
-    expect(capturedText).toContain("T:WEP");
-  });
+    wifi("MyNetwork", "secret123", { encryption: "WEP" })
+    expect(capturedText).toContain("T:WEP")
+  })
 
   it("supports nopass encryption", () => {
-    wifi("OpenNetwork", "", { encryption: "nopass" });
-    expect(capturedText).toContain("T:nopass");
-  });
+    wifi("OpenNetwork", "", { encryption: "nopass" })
+    expect(capturedText).toContain("T:nopass")
+  })
 
   it("supports hidden SSID", () => {
-    wifi("HiddenNet", "pass", { hidden: true });
-    expect(capturedText).toContain("H:true");
-  });
+    wifi("HiddenNet", "pass", { hidden: true })
+    expect(capturedText).toContain("H:true")
+  })
 
   it("does not include H:true when hidden is not set", () => {
-    wifi("MyNetwork", "secret123");
-    expect(capturedText).not.toContain("H:true");
-  });
+    wifi("MyNetwork", "secret123")
+    expect(capturedText).not.toContain("H:true")
+  })
 
   it("generates a valid SVG string", () => {
-    const svg = wifi("MyNetwork", "secret123");
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = wifi("MyNetwork", "secret123")
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("email", () => {
   it("generates a valid SVG string", () => {
-    const svg = email("test@example.com");
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = email("test@example.com")
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("sms", () => {
   it("generates a valid SVG string", () => {
-    const svg = sms("+1234567890");
-    expect(svg).toContain("<svg");
-  });
+    const svg = sms("+1234567890")
+    expect(svg).toContain("<svg")
+  })
 
   it("generates a valid SVG string with body", () => {
-    const svg = sms("+1234567890", "Hello there");
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = sms("+1234567890", "Hello there")
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("geo", () => {
   it("generates a valid SVG string", () => {
-    const svg = geo(48.8566, 2.3522);
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = geo(48.8566, 2.3522)
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("phone", () => {
   it("generates a valid SVG string", () => {
-    const svg = phone("+1234567890");
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = phone("+1234567890")
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("vcard", () => {
   it("generates proper BEGIN:VCARD/END:VCARD", () => {
-    vcard({ firstName: "John", lastName: "Doe" });
-    expect(capturedText).toContain("BEGIN:VCARD");
-    expect(capturedText).toContain("END:VCARD");
-  });
+    vcard({ firstName: "John", lastName: "Doe" })
+    expect(capturedText).toContain("BEGIN:VCARD")
+    expect(capturedText).toContain("END:VCARD")
+  })
 
   it("generates a valid SVG string", () => {
-    const svg = vcard({ firstName: "John", lastName: "Doe" });
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = vcard({ firstName: "John", lastName: "Doe" })
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("mecard", () => {
   it("generates MECARD: prefix", () => {
-    mecard({ name: "Doe, John" });
-    expect(capturedText).toContain("MECARD:");
-  });
+    mecard({ name: "Doe, John" })
+    expect(capturedText).toContain("MECARD:")
+  })
 
   it("generates a valid SVG string", () => {
-    const svg = mecard({ name: "Doe, John" });
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = mecard({ name: "Doe, John" })
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("event", () => {
   it("generates BEGIN:VEVENT/END:VEVENT", () => {
@@ -108,17 +108,17 @@ describe("event", () => {
       title: "Meeting",
       start: "2026-04-01T10:00:00Z",
       end: "2026-04-01T11:00:00Z",
-    });
-    expect(capturedText).toContain("BEGIN:VEVENT");
-    expect(capturedText).toContain("END:VEVENT");
-  });
+    })
+    expect(capturedText).toContain("BEGIN:VEVENT")
+    expect(capturedText).toContain("END:VEVENT")
+  })
 
   it("generates a valid SVG string", () => {
     const svg = event({
       title: "Meeting",
       start: "2026-04-01T10:00:00Z",
       end: "2026-04-01T11:00:00Z",
-    });
-    expect(svg).toContain("<svg");
-  });
-});
+    })
+    expect(svg).toContain("<svg")
+  })
+})

--- a/test/ico-formats.test.ts
+++ b/test/ico-formats.test.ts
@@ -6,98 +6,98 @@
  * checking that conversion did not throw.
  */
 
-import { describe, expect, it } from "vitest";
-import { icoToPngDataURI } from "../src/renderers/svg/ico";
+import { describe, expect, it } from "vitest"
+import { icoToPngDataURI } from "../src/renderers/svg/ico"
 
 // ---------------------------------------------------------------------------
 // PNG reading (stored-DEFLATE only — sufficient for this project's encoder)
 // ---------------------------------------------------------------------------
 
 function base64ToUint8(b64: string): Uint8Array {
-  const binary = atob(b64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
 }
 
 interface DecodedPNG {
-  width: number;
-  height: number;
-  colorType: number;
+  width: number
+  height: number
+  colorType: number
   /** RGBA pixel accessor */
-  pixel(x: number, y: number): [number, number, number, number];
+  pixel(x: number, y: number): [number, number, number, number]
 }
 
 /** Concatenate the IDAT payloads and undo the zlib + stored-DEFLATE framing. */
 function inflateStored(zlib: Uint8Array): Uint8Array {
   // Skip the 2-byte zlib header; walk stored blocks until the final one.
-  let pos = 2;
-  const out: number[] = [];
+  let pos = 2
+  const out: number[] = []
   for (;;) {
-    const isFinal = zlib[pos]! & 1;
-    const len = zlib[pos + 1]! | (zlib[pos + 2]! << 8);
-    pos += 5;
-    for (let i = 0; i < len; i++) out.push(zlib[pos + i]!);
-    pos += len;
-    if (isFinal) break;
+    const isFinal = zlib[pos]! & 1
+    const len = zlib[pos + 1]! | (zlib[pos + 2]! << 8)
+    pos += 5
+    for (let i = 0; i < len; i++) out.push(zlib[pos + i]!)
+    pos += len
+    if (isFinal) break
   }
-  return new Uint8Array(out);
+  return new Uint8Array(out)
 }
 
 function decodePNG(data: Uint8Array): DecodedPNG {
-  expect(Array.from(data.slice(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  expect(Array.from(data.slice(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10])
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength)
 
-  let pos = 8;
-  let width = 0;
-  let height = 0;
-  let bitDepth = 0;
-  let colorType = 0;
-  const idat: number[] = [];
+  let pos = 8
+  let width = 0
+  let height = 0
+  let bitDepth = 0
+  let colorType = 0
+  const idat: number[] = []
 
   while (pos < data.length) {
-    const len = view.getUint32(pos);
-    const type = String.fromCharCode(...data.slice(pos + 4, pos + 8));
-    const body = data.subarray(pos + 8, pos + 8 + len);
+    const len = view.getUint32(pos)
+    const type = String.fromCharCode(...data.slice(pos + 4, pos + 8))
+    const body = data.subarray(pos + 8, pos + 8 + len)
 
     if (type === "IHDR") {
-      width = view.getUint32(pos + 8);
-      height = view.getUint32(pos + 12);
-      bitDepth = body[8]!;
-      colorType = body[9]!;
+      width = view.getUint32(pos + 8)
+      height = view.getUint32(pos + 12)
+      bitDepth = body[8]!
+      colorType = body[9]!
     } else if (type === "IDAT") {
-      for (const b of body) idat.push(b);
+      for (const b of body) idat.push(b)
     } else if (type === "IEND") {
-      break;
+      break
     }
-    pos += 12 + len;
+    pos += 12 + len
   }
 
-  expect(bitDepth).toBe(8);
-  const raw = inflateStored(new Uint8Array(idat));
-  const channels = colorType === 6 ? 4 : colorType === 2 ? 3 : 1;
-  const stride = width * channels + 1; // +1 filter byte per scanline
+  expect(bitDepth).toBe(8)
+  const raw = inflateStored(new Uint8Array(idat))
+  const channels = colorType === 6 ? 4 : colorType === 2 ? 3 : 1
+  const stride = width * channels + 1 // +1 filter byte per scanline
 
   return {
     width,
     height,
     colorType,
     pixel(x, y) {
-      const row = y * stride;
-      expect(raw[row], "only filter type 0 is produced").toBe(0);
-      const i = row + 1 + x * channels;
+      const row = y * stride
+      expect(raw[row], "only filter type 0 is produced").toBe(0)
+      const i = row + 1 + x * channels
       if (channels === 4) {
-        return [raw[i]!, raw[i + 1]!, raw[i + 2]!, raw[i + 3]!];
+        return [raw[i]!, raw[i + 1]!, raw[i + 2]!, raw[i + 3]!]
       }
-      return [raw[i]!, raw[i + 1]!, raw[i + 2]!, 255];
+      return [raw[i]!, raw[i + 1]!, raw[i + 2]!, 255]
     },
-  };
+  }
 }
 
 function convert(ico: Uint8Array): DecodedPNG {
-  const uri = icoToPngDataURI(ico);
-  expect(uri.startsWith("data:image/png;base64,")).toBe(true);
-  return decodePNG(base64ToUint8(uri.slice("data:image/png;base64,".length)));
+  const uri = icoToPngDataURI(ico)
+  expect(uri.startsWith("data:image/png;base64,")).toBe(true)
+  return decodePNG(base64ToUint8(uri.slice("data:image/png;base64,".length)))
 }
 
 // ---------------------------------------------------------------------------
@@ -105,101 +105,101 @@ function convert(ico: Uint8Array): DecodedPNG {
 // ---------------------------------------------------------------------------
 
 interface DibSpec {
-  width: number;
-  height: number;
-  bpp: number;
+  width: number
+  height: number
+  bpp: number
   /** BGRA color table entries, for bpp <= 8 */
-  palette?: Array<[number, number, number]>;
+  palette?: Array<[number, number, number]>
   /** Pixel values: color index for indexed, [r,g,b,a] otherwise */
-  pixels: (x: number, y: number) => number | [number, number, number, number];
+  pixels: (x: number, y: number) => number | [number, number, number, number]
   /** AND-mask bit (1 = transparent) */
-  mask?: (x: number, y: number) => number;
-  compression?: number;
+  mask?: (x: number, y: number) => number
+  compression?: number
 }
 
 /** Build a BMP-DIB ICO image body (BITMAPINFOHEADER + palette + pixels + mask). */
 function buildDib(spec: DibSpec): Uint8Array {
-  const { width, height, bpp, compression = 0 } = spec;
-  const headerSize = 40;
-  const paletteEntries = bpp <= 8 ? 1 << bpp : 0;
-  const paletteSize = paletteEntries * 4;
-  const rowStride = Math.ceil((width * bpp) / 32) * 4;
-  const pixelSize = rowStride * height;
-  const maskStride = Math.ceil(width / 32) * 4;
-  const maskSize = maskStride * height;
+  const { width, height, bpp, compression = 0 } = spec
+  const headerSize = 40
+  const paletteEntries = bpp <= 8 ? 1 << bpp : 0
+  const paletteSize = paletteEntries * 4
+  const rowStride = Math.ceil((width * bpp) / 32) * 4
+  const pixelSize = rowStride * height
+  const maskStride = Math.ceil(width / 32) * 4
+  const maskSize = maskStride * height
 
-  const buf = new Uint8Array(headerSize + paletteSize + pixelSize + maskSize);
-  const view = new DataView(buf.buffer);
+  const buf = new Uint8Array(headerSize + paletteSize + pixelSize + maskSize)
+  const view = new DataView(buf.buffer)
 
-  view.setUint32(0, headerSize, true);
-  view.setInt32(4, width, true);
-  view.setInt32(8, height * 2, true); // ICO doubles height (XOR + AND masks)
-  view.setUint16(12, 1, true);
-  view.setUint16(14, bpp, true);
-  view.setUint32(16, compression, true);
-  view.setUint32(32, paletteEntries, true); // colorsUsed
+  view.setUint32(0, headerSize, true)
+  view.setInt32(4, width, true)
+  view.setInt32(8, height * 2, true) // ICO doubles height (XOR + AND masks)
+  view.setUint16(12, 1, true)
+  view.setUint16(14, bpp, true)
+  view.setUint32(16, compression, true)
+  view.setUint32(32, paletteEntries, true) // colorsUsed
 
   // Palette (BGRA)
   if (spec.palette) {
     for (const [i, [r, g, b]] of spec.palette.entries()) {
-      const o = headerSize + i * 4;
-      buf[o] = b;
-      buf[o + 1] = g;
-      buf[o + 2] = r;
-      buf[o + 3] = 0;
+      const o = headerSize + i * 4
+      buf[o] = b
+      buf[o + 1] = g
+      buf[o + 2] = r
+      buf[o + 3] = 0
     }
   }
 
   // Pixels, bottom-up
-  const pixelOff = headerSize + paletteSize;
+  const pixelOff = headerSize + paletteSize
   for (let y = 0; y < height; y++) {
-    const srcY = height - 1 - y; // row 0 of the image sits last in the file
-    const row = pixelOff + srcY * rowStride;
+    const srcY = height - 1 - y // row 0 of the image sits last in the file
+    const row = pixelOff + srcY * rowStride
     for (let x = 0; x < width; x++) {
-      const value = spec.pixels(x, y);
+      const value = spec.pixels(x, y)
       if (bpp === 32) {
-        const [r, g, b, a] = value as [number, number, number, number];
-        const i = row + x * 4;
-        buf[i] = b;
-        buf[i + 1] = g;
-        buf[i + 2] = r;
-        buf[i + 3] = a;
+        const [r, g, b, a] = value as [number, number, number, number]
+        const i = row + x * 4
+        buf[i] = b
+        buf[i + 1] = g
+        buf[i + 2] = r
+        buf[i + 3] = a
       } else if (bpp === 24) {
-        const [r, g, b] = value as [number, number, number, number];
-        const i = row + x * 3;
-        buf[i] = b;
-        buf[i + 1] = g;
-        buf[i + 2] = r;
+        const [r, g, b] = value as [number, number, number, number]
+        const i = row + x * 3
+        buf[i] = b
+        buf[i + 1] = g
+        buf[i + 2] = r
       } else if (bpp === 8) {
-        buf[row + x] = value as number;
+        buf[row + x] = value as number
       } else if (bpp === 4) {
-        const idx = value as number;
-        const i = row + (x >> 1);
-        buf[i] = x & 1 ? (buf[i]! & 0xf0) | (idx & 0x0f) : (buf[i]! & 0x0f) | ((idx & 0x0f) << 4);
+        const idx = value as number
+        const i = row + (x >> 1)
+        buf[i] = x & 1 ? (buf[i]! & 0xf0) | (idx & 0x0f) : (buf[i]! & 0x0f) | ((idx & 0x0f) << 4)
       } else {
-        const idx = value as number;
-        const i = row + (x >> 3);
-        if (idx) buf[i] = buf[i]! | (1 << (7 - (x & 7)));
+        const idx = value as number
+        const i = row + (x >> 3)
+        if (idx) buf[i] = buf[i]! | (1 << (7 - (x & 7)))
       }
     }
   }
 
   // AND mask, bottom-up
   if (spec.mask) {
-    const maskOff = pixelOff + pixelSize;
+    const maskOff = pixelOff + pixelSize
     for (let y = 0; y < height; y++) {
-      const srcY = height - 1 - y;
-      const row = maskOff + srcY * maskStride;
+      const srcY = height - 1 - y
+      const row = maskOff + srcY * maskStride
       for (let x = 0; x < width; x++) {
         if (spec.mask(x, y)) {
-          const i = row + (x >> 3);
-          buf[i] = buf[i]! | (1 << (7 - (x & 7)));
+          const i = row + (x >> 3)
+          buf[i] = buf[i]! | (1 << (7 - (x & 7)))
         }
       }
     }
   }
 
-  return buf;
+  return buf
 }
 
 /** Wrap image bodies in an ICO container. */
@@ -207,45 +207,43 @@ function buildICO(
   images: Array<{ width: number; height: number; bpp: number; body: Uint8Array }>,
   options: { type?: number; reserved?: number; count?: number } = {},
 ): Uint8Array {
-  const dirSize = 6 + images.length * 16;
-  const total = dirSize + images.reduce((sum, img) => sum + img.body.length, 0);
-  const buf = new Uint8Array(total);
-  const view = new DataView(buf.buffer);
+  const dirSize = 6 + images.length * 16
+  const total = dirSize + images.reduce((sum, img) => sum + img.body.length, 0)
+  const buf = new Uint8Array(total)
+  const view = new DataView(buf.buffer)
 
-  view.setUint16(0, options.reserved ?? 0, true);
-  view.setUint16(2, options.type ?? 1, true);
-  view.setUint16(4, options.count ?? images.length, true);
+  view.setUint16(0, options.reserved ?? 0, true)
+  view.setUint16(2, options.type ?? 1, true)
+  view.setUint16(4, options.count ?? images.length, true)
 
-  let offset = dirSize;
+  let offset = dirSize
   for (const [i, img] of images.entries()) {
-    const e = 6 + i * 16;
-    buf[e] = img.width < 256 ? img.width : 0;
-    buf[e + 1] = img.height < 256 ? img.height : 0;
-    view.setUint16(e + 4, 1, true); // planes
-    view.setUint16(e + 6, img.bpp, true);
-    view.setUint32(e + 8, img.body.length, true);
-    view.setUint32(e + 12, offset, true);
-    buf.set(img.body, offset);
-    offset += img.body.length;
+    const e = 6 + i * 16
+    buf[e] = img.width < 256 ? img.width : 0
+    buf[e + 1] = img.height < 256 ? img.height : 0
+    view.setUint16(e + 4, 1, true) // planes
+    view.setUint16(e + 6, img.bpp, true)
+    view.setUint32(e + 8, img.body.length, true)
+    view.setUint32(e + 12, offset, true)
+    buf.set(img.body, offset)
+    offset += img.body.length
   }
 
-  return buf;
+  return buf
 }
 
 function dibICO(spec: DibSpec): Uint8Array {
-  return buildICO([
-    { width: spec.width, height: spec.height, bpp: spec.bpp, body: buildDib(spec) },
-  ]);
+  return buildICO([{ width: spec.width, height: spec.height, bpp: spec.bpp, body: buildDib(spec) }])
 }
 
 describe("ICO — 32bpp BGRA", () => {
   it("converts colors and preserves the alpha channel", () => {
-    const png = convert(dibICO({ width: 4, height: 4, bpp: 32, pixels: () => [10, 20, 30, 128] }));
-    expect(png.width).toBe(4);
-    expect(png.height).toBe(4);
-    expect(png.pixel(0, 0)).toEqual([10, 20, 30, 128]);
-    expect(png.pixel(3, 3)).toEqual([10, 20, 30, 128]);
-  });
+    const png = convert(dibICO({ width: 4, height: 4, bpp: 32, pixels: () => [10, 20, 30, 128] }))
+    expect(png.width).toBe(4)
+    expect(png.height).toBe(4)
+    expect(png.pixel(0, 0)).toEqual([10, 20, 30, 128])
+    expect(png.pixel(3, 3)).toEqual([10, 20, 30, 128])
+  })
 
   it("preserves row order (top-down output from bottom-up BMP)", () => {
     const png = convert(
@@ -255,10 +253,10 @@ describe("ICO — 32bpp BGRA", () => {
         bpp: 32,
         pixels: (_x, y) => (y === 0 ? [255, 0, 0, 255] : [0, 0, 255, 255]),
       }),
-    );
-    expect(png.pixel(0, 0)).toEqual([255, 0, 0, 255]);
-    expect(png.pixel(0, 1)).toEqual([0, 0, 255, 255]);
-  });
+    )
+    expect(png.pixel(0, 0)).toEqual([255, 0, 0, 255])
+    expect(png.pixel(0, 1)).toEqual([0, 0, 255, 255])
+  })
 
   it("preserves column order", () => {
     const png = convert(
@@ -268,19 +266,17 @@ describe("ICO — 32bpp BGRA", () => {
         bpp: 32,
         pixels: (x) => (x === 0 ? [1, 2, 3, 255] : [250, 251, 252, 255]),
       }),
-    );
-    expect(png.pixel(0, 0)).toEqual([1, 2, 3, 255]);
-    expect(png.pixel(1, 0)).toEqual([250, 251, 252, 255]);
-  });
-});
+    )
+    expect(png.pixel(0, 0)).toEqual([1, 2, 3, 255])
+    expect(png.pixel(1, 0)).toEqual([250, 251, 252, 255])
+  })
+})
 
 describe("ICO — 24bpp BGR", () => {
   it("converts colors as fully opaque", () => {
-    const png = convert(
-      dibICO({ width: 4, height: 4, bpp: 24, pixels: () => [200, 100, 50, 255] }),
-    );
-    expect(png.pixel(0, 0)).toEqual([200, 100, 50, 255]);
-  });
+    const png = convert(dibICO({ width: 4, height: 4, bpp: 24, pixels: () => [200, 100, 50, 255] }))
+    expect(png.pixel(0, 0)).toEqual([200, 100, 50, 255])
+  })
 
   it("handles 4-byte row padding", () => {
     // width 3 * 3 bytes = 9 → padded to 12
@@ -291,11 +287,11 @@ describe("ICO — 24bpp BGR", () => {
         bpp: 24,
         pixels: (x) => [x * 10, x * 20, x * 30, 255],
       }),
-    );
-    expect(png.pixel(0, 0)).toEqual([0, 0, 0, 255]);
-    expect(png.pixel(1, 0)).toEqual([10, 20, 30, 255]);
-    expect(png.pixel(2, 0)).toEqual([20, 40, 60, 255]);
-  });
+    )
+    expect(png.pixel(0, 0)).toEqual([0, 0, 0, 255])
+    expect(png.pixel(1, 0)).toEqual([10, 20, 30, 255])
+    expect(png.pixel(2, 0)).toEqual([20, 40, 60, 255])
+  })
 
   it("applies the AND mask for transparency", () => {
     const png = convert(
@@ -306,11 +302,11 @@ describe("ICO — 24bpp BGR", () => {
         pixels: () => [255, 255, 255, 255],
         mask: (x) => (x === 1 ? 1 : 0),
       }),
-    );
-    expect(png.pixel(0, 0)[3]).toBe(255);
-    expect(png.pixel(1, 0)[3]).toBe(0);
-  });
-});
+    )
+    expect(png.pixel(0, 0)[3]).toBe(255)
+    expect(png.pixel(1, 0)[3]).toBe(0)
+  })
+})
 
 describe("ICO — indexed color", () => {
   it("decodes 8bpp via the palette", () => {
@@ -326,10 +322,10 @@ describe("ICO — indexed color", () => {
         ],
         pixels: (x) => x + 1,
       }),
-    );
-    expect(png.pixel(0, 0)).toEqual([255, 0, 0, 255]);
-    expect(png.pixel(1, 0)).toEqual([0, 255, 0, 255]);
-  });
+    )
+    expect(png.pixel(0, 0)).toEqual([255, 0, 0, 255])
+    expect(png.pixel(1, 0)).toEqual([0, 255, 0, 255])
+  })
 
   it("decodes 4bpp packed nibbles", () => {
     const png = convert(
@@ -345,12 +341,12 @@ describe("ICO — indexed color", () => {
         ],
         pixels: (x) => x,
       }),
-    );
-    expect(png.pixel(0, 0)).toEqual([0, 0, 0, 255]);
-    expect(png.pixel(1, 0)).toEqual([255, 0, 0, 255]);
-    expect(png.pixel(2, 0)).toEqual([0, 255, 0, 255]);
-    expect(png.pixel(3, 0)).toEqual([0, 0, 255, 255]);
-  });
+    )
+    expect(png.pixel(0, 0)).toEqual([0, 0, 0, 255])
+    expect(png.pixel(1, 0)).toEqual([255, 0, 0, 255])
+    expect(png.pixel(2, 0)).toEqual([0, 255, 0, 255])
+    expect(png.pixel(3, 0)).toEqual([0, 0, 255, 255])
+  })
 
   it("decodes 1bpp packed bits", () => {
     const png = convert(
@@ -364,12 +360,12 @@ describe("ICO — indexed color", () => {
         ],
         pixels: (x) => x % 2,
       }),
-    );
-    expect(png.pixel(0, 0)).toEqual([0, 0, 0, 255]);
-    expect(png.pixel(1, 0)).toEqual([255, 255, 255, 255]);
-    expect(png.pixel(6, 0)).toEqual([0, 0, 0, 255]);
-    expect(png.pixel(7, 0)).toEqual([255, 255, 255, 255]);
-  });
+    )
+    expect(png.pixel(0, 0)).toEqual([0, 0, 0, 255])
+    expect(png.pixel(1, 0)).toEqual([255, 255, 255, 255])
+    expect(png.pixel(6, 0)).toEqual([0, 0, 0, 255])
+    expect(png.pixel(7, 0)).toEqual([255, 255, 255, 255])
+  })
 
   it("applies the AND mask to indexed images", () => {
     const png = convert(
@@ -384,90 +380,90 @@ describe("ICO — indexed color", () => {
         pixels: () => 1,
         mask: (x) => (x === 0 ? 1 : 0),
       }),
-    );
-    expect(png.pixel(0, 0)[3]).toBe(0);
-    expect(png.pixel(1, 0)).toEqual([10, 20, 30, 255]);
-  });
-});
+    )
+    expect(png.pixel(0, 0)[3]).toBe(0)
+    expect(png.pixel(1, 0)).toEqual([10, 20, 30, 255])
+  })
+})
 
 describe("ICO — entry selection", () => {
   it("picks the largest entry", () => {
-    const small = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [255, 0, 0, 255] });
-    const large = buildDib({ width: 8, height: 8, bpp: 32, pixels: () => [0, 255, 0, 255] });
+    const small = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [255, 0, 0, 255] })
+    const large = buildDib({ width: 8, height: 8, bpp: 32, pixels: () => [0, 255, 0, 255] })
     const png = convert(
       buildICO([
         { width: 2, height: 2, bpp: 32, body: small },
         { width: 8, height: 8, bpp: 32, body: large },
       ]),
-    );
-    expect(png.width).toBe(8);
-    expect(png.pixel(0, 0)).toEqual([0, 255, 0, 255]);
-  });
+    )
+    expect(png.width).toBe(8)
+    expect(png.pixel(0, 0)).toEqual([0, 255, 0, 255])
+  })
 
   it("picks the largest entry regardless of order", () => {
-    const large = buildDib({ width: 8, height: 8, bpp: 32, pixels: () => [0, 255, 0, 255] });
-    const small = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [255, 0, 0, 255] });
+    const large = buildDib({ width: 8, height: 8, bpp: 32, pixels: () => [0, 255, 0, 255] })
+    const small = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [255, 0, 0, 255] })
     const png = convert(
       buildICO([
         { width: 8, height: 8, bpp: 32, body: large },
         { width: 2, height: 2, bpp: 32, body: small },
       ]),
-    );
-    expect(png.width).toBe(8);
-  });
+    )
+    expect(png.width).toBe(8)
+  })
 
   it("treats a stored dimension of 0 as 256", () => {
     // A 256px entry is stored as 0 in the directory; it must win over a 16px one
-    const big = buildDib({ width: 256, height: 256, bpp: 32, pixels: () => [1, 2, 3, 255] });
-    const small = buildDib({ width: 16, height: 16, bpp: 32, pixels: () => [9, 9, 9, 255] });
+    const big = buildDib({ width: 256, height: 256, bpp: 32, pixels: () => [1, 2, 3, 255] })
+    const small = buildDib({ width: 16, height: 16, bpp: 32, pixels: () => [9, 9, 9, 255] })
     const png = convert(
       buildICO([
         { width: 16, height: 16, bpp: 32, body: small },
         { width: 256, height: 256, bpp: 32, body: big },
       ]),
-    );
-    expect(png.width).toBe(256);
-  });
-});
+    )
+    expect(png.width).toBe(256)
+  })
+})
 
 describe("ICO — PNG-embedded entries", () => {
   it("passes an embedded PNG through unchanged", () => {
     // Build a minimal in-ICO PNG payload; the converter should hand it back as-is
-    const inner = new Uint8Array(32);
-    inner.set([137, 80, 78, 71, 13, 10, 26, 10], 0);
-    for (let i = 8; i < inner.length; i++) inner[i] = i;
+    const inner = new Uint8Array(32)
+    inner.set([137, 80, 78, 71, 13, 10, 26, 10], 0)
+    for (let i = 8; i < inner.length; i++) inner[i] = i
 
-    const ico = buildICO([{ width: 32, height: 32, bpp: 32, body: inner }]);
-    const uri = icoToPngDataURI(ico);
-    const decoded = base64ToUint8(uri.slice("data:image/png;base64,".length));
-    expect([...decoded]).toEqual([...inner]);
-  });
-});
+    const ico = buildICO([{ width: 32, height: 32, bpp: 32, body: inner }])
+    const uri = icoToPngDataURI(ico)
+    const decoded = base64ToUint8(uri.slice("data:image/png;base64,".length))
+    expect([...decoded]).toEqual([...inner])
+  })
+})
 
 describe("ICO — error handling", () => {
   it("rejects a non-zero reserved field", () => {
-    const body = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [0, 0, 0, 255] });
-    const ico = buildICO([{ width: 2, height: 2, bpp: 32, body }], { reserved: 1 });
-    expect(() => icoToPngDataURI(ico)).toThrow(/Invalid ICO/);
-  });
+    const body = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [0, 0, 0, 255] })
+    const ico = buildICO([{ width: 2, height: 2, bpp: 32, body }], { reserved: 1 })
+    expect(() => icoToPngDataURI(ico)).toThrow(/Invalid ICO/)
+  })
 
   it("rejects an unknown image type", () => {
-    const body = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [0, 0, 0, 255] });
-    const ico = buildICO([{ width: 2, height: 2, bpp: 32, body }], { type: 7 });
-    expect(() => icoToPngDataURI(ico)).toThrow(/Invalid ICO/);
-  });
+    const body = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [0, 0, 0, 255] })
+    const ico = buildICO([{ width: 2, height: 2, bpp: 32, body }], { type: 7 })
+    expect(() => icoToPngDataURI(ico)).toThrow(/Invalid ICO/)
+  })
 
   it("accepts CUR files (type 2)", () => {
-    const body = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [7, 8, 9, 255] });
-    const ico = buildICO([{ width: 2, height: 2, bpp: 32, body }], { type: 2 });
-    expect(convert(ico).pixel(0, 0)).toEqual([7, 8, 9, 255]);
-  });
+    const body = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [7, 8, 9, 255] })
+    const ico = buildICO([{ width: 2, height: 2, bpp: 32, body }], { type: 2 })
+    expect(convert(ico).pixel(0, 0)).toEqual([7, 8, 9, 255])
+  })
 
   it("rejects a zero image count", () => {
-    const body = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [0, 0, 0, 255] });
-    const ico = buildICO([{ width: 2, height: 2, bpp: 32, body }], { count: 0 });
-    expect(() => icoToPngDataURI(ico)).toThrow(/Invalid ICO/);
-  });
+    const body = buildDib({ width: 2, height: 2, bpp: 32, pixels: () => [0, 0, 0, 255] })
+    const ico = buildICO([{ width: 2, height: 2, bpp: 32, body }], { count: 0 })
+    expect(() => icoToPngDataURI(ico)).toThrow(/Invalid ICO/)
+  })
 
   it("rejects unsupported BMP compression", () => {
     const ico = dibICO({
@@ -476,9 +472,9 @@ describe("ICO — error handling", () => {
       bpp: 32,
       pixels: () => [0, 0, 0, 255],
       compression: 1, // RLE8
-    });
-    expect(() => icoToPngDataURI(ico)).toThrow(/Unsupported BMP compression/);
-  });
+    })
+    expect(() => icoToPngDataURI(ico)).toThrow(/Unsupported BMP compression/)
+  })
 
   it("accepts BITFIELDS compression (3)", () => {
     const ico = dibICO({
@@ -487,12 +483,12 @@ describe("ICO — error handling", () => {
       bpp: 32,
       pixels: () => [4, 5, 6, 255],
       compression: 3,
-    });
-    expect(convert(ico).pixel(0, 0)).toEqual([4, 5, 6, 255]);
-  });
+    })
+    expect(convert(ico).pixel(0, 0)).toEqual([4, 5, 6, 255])
+  })
 
   it("rejects an unsupported bit depth", () => {
-    const ico = dibICO({ width: 2, height: 2, bpp: 16, pixels: () => [0, 0, 0, 255] });
-    expect(() => icoToPngDataURI(ico)).toThrow(/Unsupported BMP bit depth/);
-  });
-});
+    const ico = dibICO({ width: 2, height: 2, bpp: 16, pixels: () => [0, 0, 0, 255] })
+    expect(() => icoToPngDataURI(ico)).toThrow(/Unsupported BMP bit depth/)
+  })
+})

--- a/test/ico.test.ts
+++ b/test/ico.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { icoToPngDataURI } from "../src/renderers/svg/ico";
+import { describe, expect, it } from "vitest"
+import { icoToPngDataURI } from "../src/renderers/svg/ico"
 
 function base64ToUint8(b64: string): Uint8Array {
-  const binary = atob(b64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
 }
 
 /** Create a 32bpp BMP-based ICO */
@@ -17,167 +17,167 @@ function createBmpICO(
   b: number,
   a = 255,
 ): Uint8Array {
-  const bpp = 32;
-  const pixelDataSize = width * height * 4;
-  const andMaskRowStride = Math.ceil(width / 32) * 4;
-  const andMaskSize = andMaskRowStride * height;
-  const headerSize = 40;
-  const imageSize = headerSize + pixelDataSize + andMaskSize;
-  const totalSize = 6 + 16 + imageSize;
+  const bpp = 32
+  const pixelDataSize = width * height * 4
+  const andMaskRowStride = Math.ceil(width / 32) * 4
+  const andMaskSize = andMaskRowStride * height
+  const headerSize = 40
+  const imageSize = headerSize + pixelDataSize + andMaskSize
+  const totalSize = 6 + 16 + imageSize
 
-  const buf = new Uint8Array(totalSize);
-  const view = new DataView(buf.buffer);
+  const buf = new Uint8Array(totalSize)
+  const view = new DataView(buf.buffer)
 
   // ICO header
-  view.setUint16(2, 1, true);
-  view.setUint16(4, 1, true);
+  view.setUint16(2, 1, true)
+  view.setUint16(4, 1, true)
 
   // Directory entry
-  buf[6] = width < 256 ? width : 0;
-  buf[7] = height < 256 ? height : 0;
-  view.setUint16(10, 1, true);
-  view.setUint16(12, bpp, true);
-  view.setUint32(14, imageSize, true);
-  view.setUint32(18, 22, true);
+  buf[6] = width < 256 ? width : 0
+  buf[7] = height < 256 ? height : 0
+  view.setUint16(10, 1, true)
+  view.setUint16(12, bpp, true)
+  view.setUint32(14, imageSize, true)
+  view.setUint32(18, 22, true)
 
   // BITMAPINFOHEADER
-  const imgOff = 22;
-  view.setUint32(imgOff, headerSize, true);
-  view.setInt32(imgOff + 4, width, true);
-  view.setInt32(imgOff + 8, height * 2, true);
-  view.setUint16(imgOff + 12, 1, true);
-  view.setUint16(imgOff + 14, bpp, true);
+  const imgOff = 22
+  view.setUint32(imgOff, headerSize, true)
+  view.setInt32(imgOff + 4, width, true)
+  view.setInt32(imgOff + 8, height * 2, true)
+  view.setUint16(imgOff + 12, 1, true)
+  view.setUint16(imgOff + 14, bpp, true)
 
   // Pixel data (BGRA, bottom-up)
-  const pixelOff = imgOff + headerSize;
+  const pixelOff = imgOff + headerSize
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const i = pixelOff + (y * width + x) * 4;
-      buf[i] = b;
-      buf[i + 1] = g;
-      buf[i + 2] = r;
-      buf[i + 3] = a;
+      const i = pixelOff + (y * width + x) * 4
+      buf[i] = b
+      buf[i + 1] = g
+      buf[i + 2] = r
+      buf[i + 3] = a
     }
   }
 
-  return buf;
+  return buf
 }
 
 /** Create a PNG-embedded ICO */
 function createPngICO(pngData: Uint8Array): Uint8Array {
-  const totalSize = 6 + 16 + pngData.length;
-  const buf = new Uint8Array(totalSize);
-  const view = new DataView(buf.buffer);
+  const totalSize = 6 + 16 + pngData.length
+  const buf = new Uint8Array(totalSize)
+  const view = new DataView(buf.buffer)
 
   // ICO header
-  view.setUint16(2, 1, true);
-  view.setUint16(4, 1, true);
+  view.setUint16(2, 1, true)
+  view.setUint16(4, 1, true)
 
   // Directory entry
-  buf[6] = 16; // width
-  buf[7] = 16; // height
-  view.setUint16(10, 1, true);
-  view.setUint16(12, 32, true);
-  view.setUint32(14, pngData.length, true);
-  view.setUint32(18, 22, true);
+  buf[6] = 16 // width
+  buf[7] = 16 // height
+  view.setUint16(10, 1, true)
+  view.setUint16(12, 32, true)
+  view.setUint32(14, pngData.length, true)
+  view.setUint32(18, 22, true)
 
   // Embedded PNG data
-  buf.set(pngData, 22);
+  buf.set(pngData, 22)
 
-  return buf;
+  return buf
 }
 
 describe("ICO to PNG converter", () => {
   it("converts 32bpp BMP-based ICO to PNG data URI", () => {
-    const ico = createBmpICO(4, 4, 255, 0, 0);
-    const result = icoToPngDataURI(ico);
+    const ico = createBmpICO(4, 4, 255, 0, 0)
+    const result = icoToPngDataURI(ico)
 
-    expect(result).toMatch(/^data:image\/png;base64,/);
+    expect(result).toMatch(/^data:image\/png;base64,/)
 
     // Verify it's a valid PNG by checking the signature
-    const b64 = result.replace("data:image/png;base64,", "");
-    const png = base64ToUint8(b64);
+    const b64 = result.replace("data:image/png;base64,", "")
+    const png = base64ToUint8(b64)
     // PNG signature: 137 80 78 71 13 10 26 10
-    expect(png[0]).toBe(137);
-    expect(png[1]).toBe(80);
-    expect(png[2]).toBe(78);
-    expect(png[3]).toBe(71);
-  });
+    expect(png[0]).toBe(137)
+    expect(png[1]).toBe(80)
+    expect(png[2]).toBe(78)
+    expect(png[3]).toBe(71)
+  })
 
   it("extracts PNG from PNG-embedded ICO", () => {
     // Create a minimal valid PNG to embed
-    const fakePng = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 0]);
-    const ico = createPngICO(fakePng);
-    const result = icoToPngDataURI(ico);
+    const fakePng = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 0])
+    const ico = createPngICO(fakePng)
+    const result = icoToPngDataURI(ico)
 
-    expect(result).toMatch(/^data:image\/png;base64,/);
+    expect(result).toMatch(/^data:image\/png;base64,/)
 
     // The extracted PNG should start with PNG signature
-    const b64 = result.replace("data:image/png;base64,", "");
-    const extracted = base64ToUint8(b64);
-    expect(extracted[0]).toBe(137);
-    expect(extracted[1]).toBe(80);
-  });
+    const b64 = result.replace("data:image/png;base64,", "")
+    const extracted = base64ToUint8(b64)
+    expect(extracted[0]).toBe(137)
+    expect(extracted[1]).toBe(80)
+  })
 
   it("selects the largest entry from multi-entry ICO", () => {
     // Create ICO with 2 entries: 4x4 and 8x8
-    const bpp = 32;
+    const bpp = 32
 
-    const small = createImageData(4, 4, 255, 0, 0);
-    const large = createImageData(8, 8, 0, 255, 0);
+    const small = createImageData(4, 4, 255, 0, 0)
+    const large = createImageData(8, 8, 0, 255, 0)
 
-    const totalSize = 6 + 16 * 2 + small.length + large.length;
-    const buf = new Uint8Array(totalSize);
-    const view = new DataView(buf.buffer);
+    const totalSize = 6 + 16 * 2 + small.length + large.length
+    const buf = new Uint8Array(totalSize)
+    const view = new DataView(buf.buffer)
 
     // Header
-    view.setUint16(2, 1, true);
-    view.setUint16(4, 2, true);
+    view.setUint16(2, 1, true)
+    view.setUint16(4, 2, true)
 
     // Entry 1: 4x4 (directory entry fields: +0 w, +1 h, +4 planes, +6 bpp, +8 size, +12 offset)
-    const entry1Off = 6;
-    buf[entry1Off] = 4;
-    buf[entry1Off + 1] = 4;
-    view.setUint16(entry1Off + 4, 1, true);
-    view.setUint16(entry1Off + 6, bpp, true);
-    view.setUint32(entry1Off + 8, small.length, true);
-    const data1Off = 6 + 16 * 2;
-    view.setUint32(entry1Off + 12, data1Off, true);
+    const entry1Off = 6
+    buf[entry1Off] = 4
+    buf[entry1Off + 1] = 4
+    view.setUint16(entry1Off + 4, 1, true)
+    view.setUint16(entry1Off + 6, bpp, true)
+    view.setUint32(entry1Off + 8, small.length, true)
+    const data1Off = 6 + 16 * 2
+    view.setUint32(entry1Off + 12, data1Off, true)
 
     // Entry 2: 8x8
-    const entry2Off = 6 + 16;
-    buf[entry2Off] = 8;
-    buf[entry2Off + 1] = 8;
-    view.setUint16(entry2Off + 4, 1, true);
-    view.setUint16(entry2Off + 6, bpp, true);
-    view.setUint32(entry2Off + 8, large.length, true);
-    const data2Off = data1Off + small.length;
-    view.setUint32(entry2Off + 12, data2Off, true);
+    const entry2Off = 6 + 16
+    buf[entry2Off] = 8
+    buf[entry2Off + 1] = 8
+    view.setUint16(entry2Off + 4, 1, true)
+    view.setUint16(entry2Off + 6, bpp, true)
+    view.setUint32(entry2Off + 8, large.length, true)
+    const data2Off = data1Off + small.length
+    view.setUint32(entry2Off + 12, data2Off, true)
 
-    buf.set(small, data1Off);
-    buf.set(large, data2Off);
+    buf.set(small, data1Off)
+    buf.set(large, data2Off)
 
-    const result = icoToPngDataURI(buf);
+    const result = icoToPngDataURI(buf)
     // Should select 8x8 (larger) and produce PNG with width=8
-    const b64 = result.replace("data:image/png;base64,", "");
-    const png = base64ToUint8(b64);
+    const b64 = result.replace("data:image/png;base64,", "")
+    const png = base64ToUint8(b64)
     // PNG IHDR starts after signature (8 bytes) + length (4) + type (4) = offset 16
-    const pngView = new DataView(png.buffer);
-    const pngWidth = pngView.getUint32(16);
-    expect(pngWidth).toBe(8);
-  });
+    const pngView = new DataView(png.buffer)
+    const pngWidth = pngView.getUint32(16)
+    expect(pngWidth).toBe(8)
+  })
 
   it("throws on invalid ICO data", () => {
-    expect(() => icoToPngDataURI(new Uint8Array([1, 2, 3, 4, 5, 6]))).toThrow("Invalid ICO");
-  });
+    expect(() => icoToPngDataURI(new Uint8Array([1, 2, 3, 4, 5, 6]))).toThrow("Invalid ICO")
+  })
 
   it("preserves alpha channel from 32bpp ICO", () => {
     // Create a 1x1 ICO with semi-transparent pixel
-    const ico = createBmpICO(1, 1, 255, 0, 0, 128);
-    const result = icoToPngDataURI(ico);
-    expect(result).toMatch(/^data:image\/png;base64,/);
-  });
-});
+    const ico = createBmpICO(1, 1, 255, 0, 0, 128)
+    const result = icoToPngDataURI(ico)
+    expect(result).toMatch(/^data:image\/png;base64,/)
+  })
+})
 
 /** Create BMP DIB data (BITMAPINFOHEADER + pixels + AND mask) for a solid color */
 function createImageData(
@@ -187,31 +187,31 @@ function createImageData(
   g: number,
   b: number,
 ): Uint8Array {
-  const headerSize = 40;
-  const pixelDataSize = width * height * 4;
-  const andMaskRowStride = Math.ceil(width / 32) * 4;
-  const andMaskSize = andMaskRowStride * height;
-  const totalSize = headerSize + pixelDataSize + andMaskSize;
+  const headerSize = 40
+  const pixelDataSize = width * height * 4
+  const andMaskRowStride = Math.ceil(width / 32) * 4
+  const andMaskSize = andMaskRowStride * height
+  const totalSize = headerSize + pixelDataSize + andMaskSize
 
-  const buf = new Uint8Array(totalSize);
-  const view = new DataView(buf.buffer);
+  const buf = new Uint8Array(totalSize)
+  const view = new DataView(buf.buffer)
 
-  view.setUint32(0, headerSize, true);
-  view.setInt32(4, width, true);
-  view.setInt32(8, height * 2, true);
-  view.setUint16(12, 1, true);
-  view.setUint16(14, 32, true);
+  view.setUint32(0, headerSize, true)
+  view.setInt32(4, width, true)
+  view.setInt32(8, height * 2, true)
+  view.setUint16(12, 1, true)
+  view.setUint16(14, 32, true)
 
-  const pixelOff = headerSize;
+  const pixelOff = headerSize
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const i = pixelOff + (y * width + x) * 4;
-      buf[i] = b;
-      buf[i + 1] = g;
-      buf[i + 2] = r;
-      buf[i + 3] = 255;
+      const i = pixelOff + (y * width + x) * 4
+      buf[i] = b
+      buf[i + 1] = g
+      buf[i + 2] = r
+      buf[i + 3] = 255
     }
   }
 
-  return buf;
+  return buf
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,134 +1,134 @@
-import { describe, expect, it } from "vitest";
-import { barcode, qrcode, encodeCode128, encodeEAN13, encodeEAN8, encodeQR } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { barcode, qrcode, encodeCode128, encodeEAN13, encodeEAN8, encodeQR } from "../src/index"
 
 describe("barcode", () => {
   it("generates Code 128 SVG", () => {
-    const svg = barcode("Hello");
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-    expect(svg).toContain("<rect");
-  });
+    const svg = barcode("Hello")
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+    expect(svg).toContain("<rect")
+  })
 
   it("generates Code 128 with text", () => {
-    const svg = barcode("ABC-123", { showText: true });
-    expect(svg).toContain("ABC-123");
-    expect(svg).toContain("<text");
-  });
+    const svg = barcode("ABC-123", { showText: true })
+    expect(svg).toContain("ABC-123")
+    expect(svg).toContain("<text")
+  })
 
   it("generates EAN-13 SVG", () => {
-    const svg = barcode("4006381333931", { type: "ean13" });
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("<rect");
-  });
+    const svg = barcode("4006381333931", { type: "ean13" })
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("<rect")
+  })
 
   it("generates EAN-8 SVG", () => {
-    const svg = barcode("96385074", { type: "ean8" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("96385074", { type: "ean8" })
+    expect(svg).toContain("<svg")
+  })
 
   it("respects custom colors", () => {
-    const svg = barcode("Test", { color: "#ff0000", background: "#eee" });
-    expect(svg).toContain("#ff0000");
-    expect(svg).toContain("#eee");
-  });
+    const svg = barcode("Test", { color: "#ff0000", background: "#eee" })
+    expect(svg).toContain("#ff0000")
+    expect(svg).toContain("#eee")
+  })
 
   it("throws on unsupported type", () => {
-    expect(() => barcode("test", { type: "invalid" as any })).toThrow("Unsupported");
-  });
-});
+    expect(() => barcode("test", { type: "invalid" as any })).toThrow("Unsupported")
+  })
+})
 
 describe("qrcode", () => {
   it("generates QR code SVG", () => {
-    const svg = qrcode("Hello");
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-    expect(svg).toContain("<path");
-  });
+    const svg = qrcode("Hello")
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+    expect(svg).toContain("<path")
+  })
 
   it("respects size option", () => {
-    const svg = qrcode("Test", { size: 300 });
-    expect(svg).toContain('width="300"');
-    expect(svg).toContain('height="300"');
-  });
+    const svg = qrcode("Test", { size: 300 })
+    expect(svg).toContain('width="300"')
+    expect(svg).toContain('height="300"')
+  })
 
   it("respects custom colors", () => {
-    const svg = qrcode("Test", { color: "#333", background: "#fff" });
-    expect(svg).toContain("#333");
-  });
+    const svg = qrcode("Test", { color: "#333", background: "#fff" })
+    expect(svg).toContain("#333")
+  })
 
   it("handles URLs", () => {
-    const svg = qrcode("https://example.com");
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = qrcode("https://example.com")
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("encodeCode128", () => {
   it("encodes numeric data", () => {
-    const bars = encodeCode128("12345678");
-    expect(bars.length).toBeGreaterThan(0);
+    const bars = encodeCode128("12345678")
+    expect(bars.length).toBeGreaterThan(0)
     // All values should be 1-4
     for (const b of bars) {
-      expect(b).toBeGreaterThanOrEqual(1);
-      expect(b).toBeLessThanOrEqual(4);
+      expect(b).toBeGreaterThanOrEqual(1)
+      expect(b).toBeLessThanOrEqual(4)
     }
-  });
+  })
 
   it("encodes alphanumeric data", () => {
-    const bars = encodeCode128("ABC123");
-    expect(bars.length).toBeGreaterThan(0);
-  });
+    const bars = encodeCode128("ABC123")
+    expect(bars.length).toBeGreaterThan(0)
+  })
 
   it("optimizes with Code C for long numeric runs", () => {
-    const short = encodeCode128("AB");
-    const numeric = encodeCode128("12345678");
+    const short = encodeCode128("AB")
+    const numeric = encodeCode128("12345678")
     // Code C encoding should be more compact for pure numbers
-    expect(numeric.length).toBeLessThan(short.length * 4);
-  });
-});
+    expect(numeric.length).toBeLessThan(short.length * 4)
+  })
+})
 
 describe("encodeEAN13", () => {
   it("encodes 13 digits", () => {
-    const result = encodeEAN13("4006381333931");
-    expect(result.bars.length).toBeGreaterThan(0);
-  });
+    const result = encodeEAN13("4006381333931")
+    expect(result.bars.length).toBeGreaterThan(0)
+  })
 
   it("auto-calculates check digit from 12 digits", () => {
-    const result = encodeEAN13("400638133393");
-    expect(result.bars.length).toBeGreaterThan(0);
-  });
+    const result = encodeEAN13("400638133393")
+    expect(result.bars.length).toBeGreaterThan(0)
+  })
 
   it("throws on invalid length", () => {
-    expect(() => encodeEAN13("123")).toThrow();
-  });
-});
+    expect(() => encodeEAN13("123")).toThrow()
+  })
+})
 
 describe("encodeEAN8", () => {
   it("encodes 8 digits", () => {
-    const result = encodeEAN8("96385074");
-    expect(result.bars.length).toBeGreaterThan(0);
-  });
+    const result = encodeEAN8("96385074")
+    expect(result.bars.length).toBeGreaterThan(0)
+  })
 
   it("auto-calculates check digit from 7 digits", () => {
-    const result = encodeEAN8("9638507");
-    expect(result.bars.length).toBeGreaterThan(0);
-  });
-});
+    const result = encodeEAN8("9638507")
+    expect(result.bars.length).toBeGreaterThan(0)
+  })
+})
 
 describe("encodeQR", () => {
   it("encodes short text", () => {
-    const matrix = encodeQR("Hello");
-    expect(matrix.length).toBeGreaterThan(0);
-    expect(matrix[0]!.length).toBe(matrix.length); // Square
-  });
+    const matrix = encodeQR("Hello")
+    expect(matrix.length).toBeGreaterThan(0)
+    expect(matrix[0]!.length).toBe(matrix.length) // Square
+  })
 
   it("encodes URL", () => {
-    const matrix = encodeQR("https://example.com");
-    expect(matrix.length).toBeGreaterThan(0);
-  });
+    const matrix = encodeQR("https://example.com")
+    expect(matrix.length).toBeGreaterThan(0)
+  })
 
   it("version scales with data length", () => {
-    const short = encodeQR("Hi");
-    const long = encodeQR("This is a longer text that needs more space");
-    expect(long.length).toBeGreaterThan(short.length);
-  });
-});
+    const short = encodeQR("Hi")
+    const long = encodeQR("This is a longer text that needs more space")
+    expect(long.length).toBeGreaterThan(short.length)
+  })
+})

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   barcode,
   qrcode,
@@ -13,10 +13,10 @@ import {
   sms,
   geo,
   url,
-} from "../src/index";
-import { renderBarcodeSVG } from "../src/renderers/svg/barcode";
-import { renderQRCodeSVG } from "../src/renderers/svg/qr";
-import { renderMatrixSVG } from "../src/renderers/svg/matrix";
+} from "../src/index"
+import { renderBarcodeSVG } from "../src/renderers/svg/barcode"
+import { renderQRCodeSVG } from "../src/renderers/svg/qr"
+import { renderMatrixSVG } from "../src/renderers/svg/matrix"
 
 describe("barcode integration", () => {
   const types = [
@@ -31,7 +31,7 @@ describe("barcode integration", () => {
     "msi",
     "pharmacode",
     "code11",
-  ] as const;
+  ] as const
 
   const testData: Record<string, string> = {
     code128: "Hello",
@@ -45,111 +45,111 @@ describe("barcode integration", () => {
     msi: "12345",
     pharmacode: "1234",
     code11: "12345-6",
-  };
+  }
 
   for (const type of types) {
     it(`generates valid SVG for ${type}`, () => {
-      const svg = barcode(testData[type]!, { type });
-      expect(svg).toContain("<svg");
-      expect(svg).toContain("</svg>");
-      expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"');
-      expect(svg).toContain("<rect"); // At least background + bars
-    });
+      const svg = barcode(testData[type]!, { type })
+      expect(svg).toContain("<svg")
+      expect(svg).toContain("</svg>")
+      expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"')
+      expect(svg).toContain("<rect") // At least background + bars
+    })
   }
 
   it("generates valid SVG for code39ext", () => {
-    const svg = barcode("hello", { type: "code39ext" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("hello", { type: "code39ext" })
+    expect(svg).toContain("<svg")
+  })
 
   it("generates valid SVG for code93ext", () => {
-    const svg = barcode("hello", { type: "code93ext" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("hello", { type: "code93ext" })
+    expect(svg).toContain("<svg")
+  })
 
   it("generates valid SVG for itf14", () => {
-    const svg = barcode("00012345678905", { type: "itf14" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("00012345678905", { type: "itf14" })
+    expect(svg).toContain("<svg")
+  })
 
   it("generates valid SVG for upce", () => {
-    const svg = barcode("01234565", { type: "upce" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("01234565", { type: "upce" })
+    expect(svg).toContain("<svg")
+  })
 
   it("generates valid SVG for ean2", () => {
-    const svg = barcode("53", { type: "ean2" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("53", { type: "ean2" })
+    expect(svg).toContain("<svg")
+  })
 
   it("generates valid SVG for ean5", () => {
-    const svg = barcode("52495", { type: "ean5" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("52495", { type: "ean5" })
+    expect(svg).toContain("<svg")
+  })
 
   it("generates valid SVG for gs1-128", () => {
-    const svg = barcode("(01)12345678901234", { type: "gs1-128" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = barcode("(01)12345678901234", { type: "gs1-128" })
+    expect(svg).toContain("<svg")
+  })
 
   it("supports text display for all types", () => {
-    const svg = barcode("Hello", { type: "code128", showText: true });
-    expect(svg).toContain("<text");
-    expect(svg).toContain("Hello");
-  });
+    const svg = barcode("Hello", { type: "code128", showText: true })
+    expect(svg).toContain("<text")
+    expect(svg).toContain("Hello")
+  })
 
   it("supports custom colors", () => {
-    const svg = barcode("Test", { color: "#ff0000", background: "#eee" });
-    expect(svg).toContain("#ff0000");
-    expect(svg).toContain("#eee");
-  });
+    const svg = barcode("Test", { color: "#ff0000", background: "#eee" })
+    expect(svg).toContain("#ff0000")
+    expect(svg).toContain("#eee")
+  })
 
   it("supports transparent background", () => {
-    const svg = barcode("Test", { background: "transparent" });
-    expect(svg).not.toContain('fill="transparent"');
-  });
+    const svg = barcode("Test", { background: "transparent" })
+    expect(svg).not.toContain('fill="transparent"')
+  })
 
   it("supports bearer bars for ITF-14", () => {
-    const svg = barcode("00012345678905", { type: "itf14", bearerBars: true });
-    expect(svg).toContain("<svg");
+    const svg = barcode("00012345678905", { type: "itf14", bearerBars: true })
+    expect(svg).toContain("<svg")
     // Bearer bars add extra rects
-    const rectCount = (svg.match(/<rect/g) || []).length;
-    expect(rectCount).toBeGreaterThan(5); // background + bars + bearer
-  });
+    const rectCount = (svg.match(/<rect/g) || []).length
+    expect(rectCount).toBeGreaterThan(5) // background + bars + bearer
+  })
 
   it("throws on unsupported type", () => {
-    expect(() => barcode("test", { type: "invalid" as any })).toThrow("Unsupported");
-  });
-});
+    expect(() => barcode("test", { type: "invalid" as any })).toThrow("Unsupported")
+  })
+})
 
 describe("qrcode integration", () => {
   it("generates valid SVG", () => {
-    const svg = qrcode("Hello");
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-    expect(svg).toContain("<path");
-  });
+    const svg = qrcode("Hello")
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+    expect(svg).toContain("<path")
+  })
 
   it("respects size option", () => {
-    const svg = qrcode("Test", { size: 300 });
-    expect(svg).toContain('width="300"');
-    expect(svg).toContain('height="300"');
-  });
+    const svg = qrcode("Test", { size: 300 })
+    expect(svg).toContain('width="300"')
+    expect(svg).toContain('height="300"')
+  })
 
   it("supports EC levels", () => {
     for (const ecLevel of ["L", "M", "Q", "H"] as const) {
-      const svg = qrcode("Test", { ecLevel });
-      expect(svg).toContain("<svg");
+      const svg = qrcode("Test", { ecLevel })
+      expect(svg).toContain("<svg")
     }
-  });
+  })
 
   it("supports dot types", () => {
-    const types = ["square", "rounded", "dots", "diamond"] as const;
+    const types = ["square", "rounded", "dots", "diamond"] as const
     for (const dotType of types) {
-      const svg = qrcode("Test", { dotType });
-      expect(svg).toContain("<svg");
+      const svg = qrcode("Test", { dotType })
+      expect(svg).toContain("<svg")
     }
-  });
+  })
 
   it("supports gradients", () => {
     const svg = qrcode("Test", {
@@ -161,11 +161,11 @@ describe("qrcode integration", () => {
           { offset: 1, color: "#0000ff" },
         ],
       },
-    });
-    expect(svg).toContain("<defs>");
-    expect(svg).toContain("<linearGradient");
-    expect(svg).toContain("url(#");
-  });
+    })
+    expect(svg).toContain("<defs>")
+    expect(svg).toContain("<linearGradient")
+    expect(svg).toContain("url(#")
+  })
 
   it("supports corner styling", () => {
     const svg = qrcode("Test", {
@@ -173,195 +173,195 @@ describe("qrcode integration", () => {
         topLeft: { outerShape: "rounded", innerShape: "dots" },
         topRight: { outerColor: "#ff0000" },
       },
-    });
-    expect(svg).toContain("<svg");
-    expect(svg).toContain('fill="#ff0000"');
-  });
+    })
+    expect(svg).toContain("<svg")
+    expect(svg).toContain('fill="#ff0000"')
+  })
 
   it("supports XML declaration", () => {
-    const svg = qrcode("Test", { xmlDeclaration: true });
-    expect(svg).toMatch(/^<\?xml/);
-  });
-});
+    const svg = qrcode("Test", { xmlDeclaration: true })
+    expect(svg).toMatch(/^<\?xml/)
+  })
+})
 
 describe("terminal output", () => {
   it("generates terminal-printable string", () => {
-    const text = qrcodeTerminal("Hello");
-    expect(text.length).toBeGreaterThan(0);
-    expect(text).toContain("\n");
-  });
-});
+    const text = qrcodeTerminal("Hello")
+    expect(text.length).toBeGreaterThan(0)
+    expect(text).toContain("\n")
+  })
+})
 
 describe("data URI output", () => {
   it("generates barcode data URI", () => {
-    const uri = barcodeDataURI("Hello");
-    expect(uri).toMatch(/^data:image\/svg\+xml,/);
-  });
+    const uri = barcodeDataURI("Hello")
+    expect(uri).toMatch(/^data:image\/svg\+xml,/)
+  })
 
   it("generates QR code data URI", () => {
-    const uri = qrcodeDataURI("Hello");
-    expect(uri).toMatch(/^data:image\/svg\+xml,/);
-  });
-});
+    const uri = qrcodeDataURI("Hello")
+    expect(uri).toMatch(/^data:image\/svg\+xml,/)
+  })
+})
 
 describe("convenience functions", () => {
   it("wifi generates QR SVG", () => {
-    const svg = wifi("MyNetwork", "password123");
-    expect(svg).toContain("<svg");
+    const svg = wifi("MyNetwork", "password123")
+    expect(svg).toContain("<svg")
     // WiFi string should be encoded
-  });
+  })
 
   it("email generates QR SVG", () => {
-    const svg = email("test@example.com");
-    expect(svg).toContain("<svg");
-  });
+    const svg = email("test@example.com")
+    expect(svg).toContain("<svg")
+  })
 
   it("sms generates QR SVG", () => {
-    const svg = sms("+1234567890", "Hello");
-    expect(svg).toContain("<svg");
-  });
+    const svg = sms("+1234567890", "Hello")
+    expect(svg).toContain("<svg")
+  })
 
   it("geo generates QR SVG", () => {
-    const svg = geo(37.7749, -122.4194);
-    expect(svg).toContain("<svg");
-  });
+    const svg = geo(37.7749, -122.4194)
+    expect(svg).toContain("<svg")
+  })
 
   it("url generates QR SVG", () => {
-    const svg = url("https://example.com");
-    expect(svg).toContain("<svg");
-  });
-});
+    const svg = url("https://example.com")
+    expect(svg).toContain("<svg")
+  })
+})
 
 describe("SVG accessibility", () => {
   // Simple test data
-  const testBars = [2, 1, 1, 1, 2];
+  const testBars = [2, 1, 1, 1, 2]
   const testMatrix: boolean[][] = [
     [true, false, true],
     [false, true, false],
     [true, false, true],
-  ];
+  ]
 
   describe("default role attribute", () => {
     it("barcode SVG has role=img by default", () => {
-      const svg = renderBarcodeSVG(testBars);
-      expect(svg).toContain('role="img"');
-    });
+      const svg = renderBarcodeSVG(testBars)
+      expect(svg).toContain('role="img"')
+    })
 
     it("QR code SVG has role=img by default", () => {
-      const svg = renderQRCodeSVG(testMatrix);
-      expect(svg).toContain('role="img"');
-    });
+      const svg = renderQRCodeSVG(testMatrix)
+      expect(svg).toContain('role="img"')
+    })
 
     it("matrix SVG has role=img by default", () => {
-      const svg = renderMatrixSVG(testMatrix);
-      expect(svg).toContain('role="img"');
-    });
-  });
+      const svg = renderMatrixSVG(testMatrix)
+      expect(svg).toContain('role="img"')
+    })
+  })
 
   describe("custom role attribute", () => {
     it("barcode SVG supports custom role", () => {
-      const svg = renderBarcodeSVG(testBars, { role: "presentation" });
-      expect(svg).toContain('role="presentation"');
-      expect(svg).not.toContain('role="img"');
-    });
+      const svg = renderBarcodeSVG(testBars, { role: "presentation" })
+      expect(svg).toContain('role="presentation"')
+      expect(svg).not.toContain('role="img"')
+    })
 
     it("QR code SVG supports custom role", () => {
-      const svg = renderQRCodeSVG(testMatrix, { role: "presentation" });
-      expect(svg).toContain('role="presentation"');
-    });
+      const svg = renderQRCodeSVG(testMatrix, { role: "presentation" })
+      expect(svg).toContain('role="presentation"')
+    })
 
     it("matrix SVG supports custom role", () => {
-      const svg = renderMatrixSVG(testMatrix, { role: "presentation" });
-      expect(svg).toContain('role="presentation"');
-    });
-  });
+      const svg = renderMatrixSVG(testMatrix, { role: "presentation" })
+      expect(svg).toContain('role="presentation"')
+    })
+  })
 
   describe("aria-label attribute", () => {
     it("barcode SVG includes aria-label when provided", () => {
-      const svg = renderBarcodeSVG(testBars, { ariaLabel: "Barcode for product 12345" });
-      expect(svg).toContain('aria-label="Barcode for product 12345"');
-    });
+      const svg = renderBarcodeSVG(testBars, { ariaLabel: "Barcode for product 12345" })
+      expect(svg).toContain('aria-label="Barcode for product 12345"')
+    })
 
     it("QR code SVG includes aria-label when provided", () => {
-      const svg = renderQRCodeSVG(testMatrix, { ariaLabel: "QR code linking to example.com" });
-      expect(svg).toContain('aria-label="QR code linking to example.com"');
-    });
+      const svg = renderQRCodeSVG(testMatrix, { ariaLabel: "QR code linking to example.com" })
+      expect(svg).toContain('aria-label="QR code linking to example.com"')
+    })
 
     it("matrix SVG includes aria-label when provided", () => {
-      const svg = renderMatrixSVG(testMatrix, { ariaLabel: "Data Matrix code" });
-      expect(svg).toContain('aria-label="Data Matrix code"');
-    });
+      const svg = renderMatrixSVG(testMatrix, { ariaLabel: "Data Matrix code" })
+      expect(svg).toContain('aria-label="Data Matrix code"')
+    })
 
     it("barcode SVG omits aria-label when not provided", () => {
-      const svg = renderBarcodeSVG(testBars);
-      expect(svg).not.toContain("aria-label");
-    });
+      const svg = renderBarcodeSVG(testBars)
+      expect(svg).not.toContain("aria-label")
+    })
 
     it("QR code SVG omits aria-label when not provided", () => {
-      const svg = renderQRCodeSVG(testMatrix);
-      expect(svg).not.toContain("aria-label");
-    });
-  });
+      const svg = renderQRCodeSVG(testMatrix)
+      expect(svg).not.toContain("aria-label")
+    })
+  })
 
   describe("title element", () => {
     it("barcode SVG includes title element when provided", () => {
-      const svg = renderBarcodeSVG(testBars, { title: "Product barcode" });
-      expect(svg).toContain("<title>Product barcode</title>");
-    });
+      const svg = renderBarcodeSVG(testBars, { title: "Product barcode" })
+      expect(svg).toContain("<title>Product barcode</title>")
+    })
 
     it("QR code SVG includes title element when provided", () => {
-      const svg = renderQRCodeSVG(testMatrix, { title: "QR code" });
-      expect(svg).toContain("<title>QR code</title>");
-    });
+      const svg = renderQRCodeSVG(testMatrix, { title: "QR code" })
+      expect(svg).toContain("<title>QR code</title>")
+    })
 
     it("matrix SVG includes title element when provided", () => {
-      const svg = renderMatrixSVG(testMatrix, { title: "Data Matrix" });
-      expect(svg).toContain("<title>Data Matrix</title>");
-    });
+      const svg = renderMatrixSVG(testMatrix, { title: "Data Matrix" })
+      expect(svg).toContain("<title>Data Matrix</title>")
+    })
 
     it("title element appears before other content", () => {
-      const svg = renderBarcodeSVG(testBars, { title: "Test title" });
-      const titleIndex = svg.indexOf("<title>");
-      const rectIndex = svg.indexOf("<rect");
-      expect(titleIndex).toBeLessThan(rectIndex);
-    });
+      const svg = renderBarcodeSVG(testBars, { title: "Test title" })
+      const titleIndex = svg.indexOf("<title>")
+      const rectIndex = svg.indexOf("<rect")
+      expect(titleIndex).toBeLessThan(rectIndex)
+    })
 
     it("barcode SVG omits title when not provided", () => {
-      const svg = renderBarcodeSVG(testBars);
-      expect(svg).not.toContain("<title>");
-    });
-  });
+      const svg = renderBarcodeSVG(testBars)
+      expect(svg).not.toContain("<title>")
+    })
+  })
 
   describe("desc element", () => {
     it("barcode SVG includes desc element when provided", () => {
       const svg = renderBarcodeSVG(testBars, {
         desc: "A barcode representing product information",
-      });
-      expect(svg).toContain("<desc>A barcode representing product information</desc>");
-    });
+      })
+      expect(svg).toContain("<desc>A barcode representing product information</desc>")
+    })
 
     it("QR code SVG includes desc element when provided", () => {
-      const svg = renderQRCodeSVG(testMatrix, { desc: "QR code for URL" });
-      expect(svg).toContain("<desc>QR code for URL</desc>");
-    });
+      const svg = renderQRCodeSVG(testMatrix, { desc: "QR code for URL" })
+      expect(svg).toContain("<desc>QR code for URL</desc>")
+    })
 
     it("matrix SVG includes desc element when provided", () => {
-      const svg = renderMatrixSVG(testMatrix, { desc: "Matrix code description" });
-      expect(svg).toContain("<desc>Matrix code description</desc>");
-    });
+      const svg = renderMatrixSVG(testMatrix, { desc: "Matrix code description" })
+      expect(svg).toContain("<desc>Matrix code description</desc>")
+    })
 
     it("desc appears after title when both provided", () => {
-      const svg = renderBarcodeSVG(testBars, { title: "My title", desc: "My description" });
-      const titleIndex = svg.indexOf("<title>");
-      const descIndex = svg.indexOf("<desc>");
-      expect(titleIndex).toBeLessThan(descIndex);
-    });
+      const svg = renderBarcodeSVG(testBars, { title: "My title", desc: "My description" })
+      const titleIndex = svg.indexOf("<title>")
+      const descIndex = svg.indexOf("<desc>")
+      expect(titleIndex).toBeLessThan(descIndex)
+    })
 
     it("barcode SVG omits desc when not provided", () => {
-      const svg = renderBarcodeSVG(testBars);
-      expect(svg).not.toContain("<desc>");
-    });
-  });
+      const svg = renderBarcodeSVG(testBars)
+      expect(svg).not.toContain("<desc>")
+    })
+  })
 
   describe("all accessibility options combined", () => {
     it("barcode SVG supports all accessibility options together", () => {
@@ -370,12 +370,12 @@ describe("SVG accessibility", () => {
         role: "img",
         title: "Barcode title",
         desc: "Barcode description",
-      });
-      expect(svg).toContain('role="img"');
-      expect(svg).toContain('aria-label="Barcode label"');
-      expect(svg).toContain("<title>Barcode title</title>");
-      expect(svg).toContain("<desc>Barcode description</desc>");
-    });
+      })
+      expect(svg).toContain('role="img"')
+      expect(svg).toContain('aria-label="Barcode label"')
+      expect(svg).toContain("<title>Barcode title</title>")
+      expect(svg).toContain("<desc>Barcode description</desc>")
+    })
 
     it("QR code SVG supports all accessibility options together", () => {
       const svg = renderQRCodeSVG(testMatrix, {
@@ -383,12 +383,12 @@ describe("SVG accessibility", () => {
         role: "img",
         title: "QR title",
         desc: "QR description",
-      });
-      expect(svg).toContain('role="img"');
-      expect(svg).toContain('aria-label="QR label"');
-      expect(svg).toContain("<title>QR title</title>");
-      expect(svg).toContain("<desc>QR description</desc>");
-    });
+      })
+      expect(svg).toContain('role="img"')
+      expect(svg).toContain('aria-label="QR label"')
+      expect(svg).toContain("<title>QR title</title>")
+      expect(svg).toContain("<desc>QR description</desc>")
+    })
 
     it("matrix SVG supports all accessibility options together", () => {
       const svg = renderMatrixSVG(testMatrix, {
@@ -396,33 +396,33 @@ describe("SVG accessibility", () => {
         role: "img",
         title: "Matrix title",
         desc: "Matrix description",
-      });
-      expect(svg).toContain('role="img"');
-      expect(svg).toContain('aria-label="Matrix label"');
-      expect(svg).toContain("<title>Matrix title</title>");
-      expect(svg).toContain("<desc>Matrix description</desc>");
-    });
-  });
+      })
+      expect(svg).toContain('role="img"')
+      expect(svg).toContain('aria-label="Matrix label"')
+      expect(svg).toContain("<title>Matrix title</title>")
+      expect(svg).toContain("<desc>Matrix description</desc>")
+    })
+  })
 
   describe("XSS prevention in accessibility options", () => {
     it("escapes HTML in ariaLabel", () => {
-      const svg = renderBarcodeSVG(testBars, { ariaLabel: 'test" onclick="alert(1)' });
-      expect(svg).not.toContain('onclick="alert(1)"');
-      expect(svg).toContain("&quot;");
-    });
+      const svg = renderBarcodeSVG(testBars, { ariaLabel: 'test" onclick="alert(1)' })
+      expect(svg).not.toContain('onclick="alert(1)"')
+      expect(svg).toContain("&quot;")
+    })
 
     it("escapes HTML in title", () => {
-      const svg = renderBarcodeSVG(testBars, { title: "<script>alert(1)</script>" });
-      expect(svg).not.toContain("<script>");
-      expect(svg).toContain("&lt;script&gt;");
-    });
+      const svg = renderBarcodeSVG(testBars, { title: "<script>alert(1)</script>" })
+      expect(svg).not.toContain("<script>")
+      expect(svg).toContain("&lt;script&gt;")
+    })
 
     it("escapes HTML in desc", () => {
-      const svg = renderBarcodeSVG(testBars, { desc: "<img onerror=alert(1)>" });
-      expect(svg).not.toContain("<img");
-      expect(svg).toContain("&lt;img");
-    });
-  });
+      const svg = renderBarcodeSVG(testBars, { desc: "<img onerror=alert(1)>" })
+      expect(svg).not.toContain("<img")
+      expect(svg).toContain("&lt;img")
+    })
+  })
 
   describe("high-level API passthrough", () => {
     it("barcode() passes accessibility options through", () => {
@@ -431,55 +431,55 @@ describe("SVG accessibility", () => {
         ariaLabel: "Code 128 barcode",
         title: "Product barcode",
         desc: "Barcode for product Hello",
-      });
-      expect(svg).toContain('role="img"');
-      expect(svg).toContain('aria-label="Code 128 barcode"');
-      expect(svg).toContain("<title>Product barcode</title>");
-      expect(svg).toContain("<desc>Barcode for product Hello</desc>");
-    });
+      })
+      expect(svg).toContain('role="img"')
+      expect(svg).toContain('aria-label="Code 128 barcode"')
+      expect(svg).toContain("<title>Product barcode</title>")
+      expect(svg).toContain("<desc>Barcode for product Hello</desc>")
+    })
 
     it("qrcode() passes accessibility options through", () => {
       const svg = qrcode("https://example.com", {
         ariaLabel: "QR code for example.com",
         title: "Website QR code",
         desc: "Scan to visit example.com",
-      });
-      expect(svg).toContain('role="img"');
-      expect(svg).toContain('aria-label="QR code for example.com"');
-      expect(svg).toContain("<title>Website QR code</title>");
-      expect(svg).toContain("<desc>Scan to visit example.com</desc>");
-    });
+      })
+      expect(svg).toContain('role="img"')
+      expect(svg).toContain('aria-label="QR code for example.com"')
+      expect(svg).toContain("<title>Website QR code</title>")
+      expect(svg).toContain("<desc>Scan to visit example.com</desc>")
+    })
 
     it("datamatrix() passes accessibility options through", () => {
       const svg = datamatrix("Hello", {
         ariaLabel: "Data Matrix",
         title: "DM title",
-      });
-      expect(svg).toContain('role="img"');
-      expect(svg).toContain('aria-label="Data Matrix"');
-      expect(svg).toContain("<title>DM title</title>");
-    });
+      })
+      expect(svg).toContain('role="img"')
+      expect(svg).toContain('aria-label="Data Matrix"')
+      expect(svg).toContain("<title>DM title</title>")
+    })
 
     it("pdf417() passes accessibility options through", () => {
       const svg = pdf417("Hello", {
         ariaLabel: "PDF417 barcode",
         title: "PDF417 title",
-      });
-      expect(svg).toContain('role="img"');
-      expect(svg).toContain('aria-label="PDF417 barcode"');
-      expect(svg).toContain("<title>PDF417 title</title>");
-    });
+      })
+      expect(svg).toContain('role="img"')
+      expect(svg).toContain('aria-label="PDF417 barcode"')
+      expect(svg).toContain("<title>PDF417 title</title>")
+    })
 
     it("aztec() passes accessibility options through", () => {
       const svg = aztec("Hello", {
         ariaLabel: "Aztec code",
         title: "Aztec title",
-      });
-      expect(svg).toContain('role="img"');
-      expect(svg).toContain('aria-label="Aztec code"');
-      expect(svg).toContain("<title>Aztec title</title>");
-    });
-  });
+      })
+      expect(svg).toContain('role="img"')
+      expect(svg).toContain('aria-label="Aztec code"')
+      expect(svg).toContain("<title>Aztec title</title>")
+    })
+  })
 
   describe("QR circle shape with accessibility", () => {
     it("circle shape works correctly with title and desc", () => {
@@ -487,13 +487,13 @@ describe("SVG accessibility", () => {
         shape: "circle",
         title: "QR circle",
         desc: "Circle-shaped QR code",
-      });
-      expect(svg).toContain("<clipPath");
-      expect(svg).toContain("etiket-circle-clip");
-      expect(svg).toContain("<title>QR circle</title>");
-      expect(svg).toContain("<desc>Circle-shaped QR code</desc>");
-      expect(svg).toContain('role="img"');
-    });
+      })
+      expect(svg).toContain("<clipPath")
+      expect(svg).toContain("etiket-circle-clip")
+      expect(svg).toContain("<title>QR circle</title>")
+      expect(svg).toContain("<desc>Circle-shaped QR code</desc>")
+      expect(svg).toContain('role="img"')
+    })
 
     it("circle shape with XML declaration and accessibility", () => {
       const svg = qrcode("Hello", {
@@ -501,11 +501,11 @@ describe("SVG accessibility", () => {
         xmlDeclaration: true,
         title: "QR code",
         ariaLabel: "QR code for Hello",
-      });
-      expect(svg).toMatch(/^<\?xml/);
-      expect(svg).toContain("<clipPath");
-      expect(svg).toContain("<title>QR code</title>");
-      expect(svg).toContain('aria-label="QR code for Hello"');
-    });
-  });
-});
+      })
+      expect(svg).toMatch(/^<\?xml/)
+      expect(svg).toContain("<clipPath")
+      expect(svg).toContain("<title>QR code</title>")
+      expect(svg).toContain('aria-label="QR code for Hello"')
+    })
+  })
+})

--- a/test/png-api.test.ts
+++ b/test/png-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
   barcodePNG,
   barcodePNGDataURI,
@@ -12,186 +12,186 @@ import {
   pdf417PNGDataURI,
   aztecPNG,
   aztecPNGDataURI,
-} from "../src/_png";
-import { renderBarcodePNG, renderMatrixPNG } from "../src/renderers/png/rasterize";
+} from "../src/_png"
+import { renderBarcodePNG, renderMatrixPNG } from "../src/renderers/png/rasterize"
 
-const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10];
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10]
 
 function isPNG(data: Uint8Array): boolean {
-  return PNG_SIG.every((b, i) => data[i] === b);
+  return PNG_SIG.every((b, i) => data[i] === b)
 }
 
 function getIHDRDimensions(png: Uint8Array): { width: number; height: number } {
-  const view = new DataView(png.buffer, png.byteOffset);
-  return { width: view.getUint32(16), height: view.getUint32(20) };
+  const view = new DataView(png.buffer, png.byteOffset)
+  return { width: view.getUint32(16), height: view.getUint32(20) }
 }
 
 describe("renderBarcodePNG", () => {
   it("renders simple bar pattern", () => {
-    const bars = [2, 1, 3, 1, 2];
-    const png = renderBarcodePNG(bars, { scale: 1, height: 10, margin: 0 });
-    expect(isPNG(png)).toBe(true);
-    const { width, height } = getIHDRDimensions(png);
-    expect(width).toBe(9); // 2+1+3+1+2
-    expect(height).toBe(10);
-  });
+    const bars = [2, 1, 3, 1, 2]
+    const png = renderBarcodePNG(bars, { scale: 1, height: 10, margin: 0 })
+    expect(isPNG(png)).toBe(true)
+    const { width, height } = getIHDRDimensions(png)
+    expect(width).toBe(9) // 2+1+3+1+2
+    expect(height).toBe(10)
+  })
 
   it("applies margin", () => {
-    const bars = [1, 1, 1];
-    const png = renderBarcodePNG(bars, { scale: 1, height: 10, margin: 5 });
-    const { width, height } = getIHDRDimensions(png);
-    expect(width).toBe(3 + 10); // bars + margin*2
-    expect(height).toBe(10 + 10); // height + margin*2
-  });
+    const bars = [1, 1, 1]
+    const png = renderBarcodePNG(bars, { scale: 1, height: 10, margin: 5 })
+    const { width, height } = getIHDRDimensions(png)
+    expect(width).toBe(3 + 10) // bars + margin*2
+    expect(height).toBe(10 + 10) // height + margin*2
+  })
 
   it("applies scale", () => {
-    const bars = [2, 1];
-    const png = renderBarcodePNG(bars, { scale: 3, height: 10, margin: 0 });
-    const { width } = getIHDRDimensions(png);
-    expect(width).toBe(9); // (2+1)*3
-  });
-});
+    const bars = [2, 1]
+    const png = renderBarcodePNG(bars, { scale: 3, height: 10, margin: 0 })
+    const { width } = getIHDRDimensions(png)
+    expect(width).toBe(9) // (2+1)*3
+  })
+})
 
 describe("renderMatrixPNG", () => {
   it("renders simple matrix", () => {
     const matrix = [
       [true, false],
       [false, true],
-    ];
-    const png = renderMatrixPNG(matrix, { moduleSize: 5, margin: 0 });
-    expect(isPNG(png)).toBe(true);
-    const { width, height } = getIHDRDimensions(png);
-    expect(width).toBe(10);
-    expect(height).toBe(10);
-  });
+    ]
+    const png = renderMatrixPNG(matrix, { moduleSize: 5, margin: 0 })
+    expect(isPNG(png)).toBe(true)
+    const { width, height } = getIHDRDimensions(png)
+    expect(width).toBe(10)
+    expect(height).toBe(10)
+  })
 
   it("applies margin in modules", () => {
-    const matrix = [[true]];
-    const png = renderMatrixPNG(matrix, { moduleSize: 4, margin: 2 });
-    const { width, height } = getIHDRDimensions(png);
-    expect(width).toBe(20); // (1 + 2*2) * 4
-    expect(height).toBe(20);
-  });
-});
+    const matrix = [[true]]
+    const png = renderMatrixPNG(matrix, { moduleSize: 4, margin: 2 })
+    const { width, height } = getIHDRDimensions(png)
+    expect(width).toBe(20) // (1 + 2*2) * 4
+    expect(height).toBe(20)
+  })
+})
 
 describe("barcodePNG", () => {
   it("generates PNG for code128", () => {
-    const png = barcodePNG("ABC123");
-    expect(isPNG(png)).toBe(true);
-  });
+    const png = barcodePNG("ABC123")
+    expect(isPNG(png)).toBe(true)
+  })
 
   it("generates PNG for ean13", () => {
-    const png = barcodePNG("5901234123457", { type: "ean13" });
-    expect(isPNG(png)).toBe(true);
-  });
+    const png = barcodePNG("5901234123457", { type: "ean13" })
+    expect(isPNG(png)).toBe(true)
+  })
 
   it("generates PNG for code39", () => {
-    const png = barcodePNG("HELLO", { type: "code39" });
-    expect(isPNG(png)).toBe(true);
-  });
+    const png = barcodePNG("HELLO", { type: "code39" })
+    expect(isPNG(png)).toBe(true)
+  })
 
   it("generates PNG with custom colors", () => {
-    const png = barcodePNG("TEST", { color: "#ff0000", background: "#00ff00" });
-    expect(isPNG(png)).toBe(true);
-  });
-});
+    const png = barcodePNG("TEST", { color: "#ff0000", background: "#00ff00" })
+    expect(isPNG(png)).toBe(true)
+  })
+})
 
 describe("barcodePNGDataURI", () => {
   it("returns data URI string", () => {
-    const uri = barcodePNGDataURI("ABC");
-    expect(uri).toMatch(/^data:image\/png;base64,/);
-  });
-});
+    const uri = barcodePNGDataURI("ABC")
+    expect(uri).toMatch(/^data:image\/png;base64,/)
+  })
+})
 
 describe("qrcodePNG", () => {
   it("generates PNG for QR code", () => {
-    const png = qrcodePNG("Hello World");
-    expect(isPNG(png)).toBe(true);
-  });
+    const png = qrcodePNG("Hello World")
+    expect(isPNG(png)).toBe(true)
+  })
 
   it("respects moduleSize option", () => {
-    const small = qrcodePNG("test", { moduleSize: 2, margin: 0 });
-    const large = qrcodePNG("test", { moduleSize: 10, margin: 0 });
-    const smallDim = getIHDRDimensions(small);
-    const largeDim = getIHDRDimensions(large);
-    expect(largeDim.width).toBe(smallDim.width * 5);
-  });
+    const small = qrcodePNG("test", { moduleSize: 2, margin: 0 })
+    const large = qrcodePNG("test", { moduleSize: 10, margin: 0 })
+    const smallDim = getIHDRDimensions(small)
+    const largeDim = getIHDRDimensions(large)
+    expect(largeDim.width).toBe(smallDim.width * 5)
+  })
 
   it("supports EC level option", () => {
-    const png = qrcodePNG("test", { ecLevel: "H" });
-    expect(isPNG(png)).toBe(true);
-  });
-});
+    const png = qrcodePNG("test", { ecLevel: "H" })
+    expect(isPNG(png)).toBe(true)
+  })
+})
 
 describe("qrcodePNGDataURI", () => {
   it("returns data URI string", () => {
-    const uri = qrcodePNGDataURI("test");
-    expect(uri).toMatch(/^data:image\/png;base64,/);
-  });
-});
+    const uri = qrcodePNGDataURI("test")
+    expect(uri).toMatch(/^data:image\/png;base64,/)
+  })
+})
 
 describe("datamatrixPNG", () => {
   it("generates PNG for Data Matrix", () => {
-    const png = datamatrixPNG("Hello");
-    expect(isPNG(png)).toBe(true);
-  });
-});
+    const png = datamatrixPNG("Hello")
+    expect(isPNG(png)).toBe(true)
+  })
+})
 
 describe("datamatrixPNGDataURI", () => {
   it("returns data URI string", () => {
-    const uri = datamatrixPNGDataURI("test");
-    expect(uri).toMatch(/^data:image\/png;base64,/);
-  });
-});
+    const uri = datamatrixPNGDataURI("test")
+    expect(uri).toMatch(/^data:image\/png;base64,/)
+  })
+})
 
 describe("gs1datamatrixPNG", () => {
   it("generates PNG for GS1 Data Matrix", () => {
-    const png = gs1datamatrixPNG("(01)09521234543213");
-    expect(isPNG(png)).toBe(true);
-  });
-});
+    const png = gs1datamatrixPNG("(01)09521234543213")
+    expect(isPNG(png)).toBe(true)
+  })
+})
 
 describe("gs1datamatrixPNGDataURI", () => {
   it("returns data URI string", () => {
-    const uri = gs1datamatrixPNGDataURI("(01)09521234543213");
-    expect(uri).toMatch(/^data:image\/png;base64,/);
-  });
-});
+    const uri = gs1datamatrixPNGDataURI("(01)09521234543213")
+    expect(uri).toMatch(/^data:image\/png;base64,/)
+  })
+})
 
 describe("pdf417PNG", () => {
   it("generates PNG for PDF417", () => {
-    const png = pdf417PNG("Hello World");
-    expect(isPNG(png)).toBe(true);
-  });
+    const png = pdf417PNG("Hello World")
+    expect(isPNG(png)).toBe(true)
+  })
 
   it("supports ecLevel option", () => {
-    const png = pdf417PNG("test", { ecLevel: 3 });
-    expect(isPNG(png)).toBe(true);
-  });
-});
+    const png = pdf417PNG("test", { ecLevel: 3 })
+    expect(isPNG(png)).toBe(true)
+  })
+})
 
 describe("pdf417PNGDataURI", () => {
   it("returns data URI string", () => {
-    const uri = pdf417PNGDataURI("test");
-    expect(uri).toMatch(/^data:image\/png;base64,/);
-  });
-});
+    const uri = pdf417PNGDataURI("test")
+    expect(uri).toMatch(/^data:image\/png;base64,/)
+  })
+})
 
 describe("aztecPNG", () => {
   it("generates PNG for Aztec", () => {
-    const png = aztecPNG("Hello");
-    expect(isPNG(png)).toBe(true);
-  });
+    const png = aztecPNG("Hello")
+    expect(isPNG(png)).toBe(true)
+  })
 
   it("supports layers option", () => {
-    const png = aztecPNG("test", { layers: 4 });
-    expect(isPNG(png)).toBe(true);
-  });
-});
+    const png = aztecPNG("test", { layers: 4 })
+    expect(isPNG(png)).toBe(true)
+  })
+})
 
 describe("aztecPNGDataURI", () => {
   it("returns data URI string", () => {
-    const uri = aztecPNGDataURI("test");
-    expect(uri).toMatch(/^data:image\/png;base64,/);
-  });
-});
+    const uri = aztecPNGDataURI("test")
+    expect(uri).toMatch(/^data:image\/png;base64,/)
+  })
+})

--- a/test/png-encoder.test.ts
+++ b/test/png-encoder.test.ts
@@ -1,188 +1,188 @@
-import { describe, expect, it } from "vitest";
-import { crc32 } from "../src/renderers/png/crc32";
-import { adler32 } from "../src/renderers/png/adler32";
-import { deflateRaw, zlibCompress } from "../src/renderers/png/deflate";
-import { encodePNG } from "../src/renderers/png/png-encoder";
+import { describe, expect, it } from "vitest"
+import { crc32 } from "../src/renderers/png/crc32"
+import { adler32 } from "../src/renderers/png/adler32"
+import { deflateRaw, zlibCompress } from "../src/renderers/png/deflate"
+import { encodePNG } from "../src/renderers/png/png-encoder"
 
 describe("CRC32", () => {
   it("computes correct CRC32 for empty input", () => {
-    expect(crc32(new Uint8Array(0))).toBe(0x00000000);
-  });
+    expect(crc32(new Uint8Array(0))).toBe(0x00000000)
+  })
 
   it("computes correct CRC32 for known string", () => {
-    const data = new TextEncoder().encode("123456789");
-    expect(crc32(data)).toBe(0xcbf43926);
-  });
-});
+    const data = new TextEncoder().encode("123456789")
+    expect(crc32(data)).toBe(0xcbf43926)
+  })
+})
 
 describe("Adler32", () => {
   it("returns 1 for empty input", () => {
-    expect(adler32(new Uint8Array(0))).toBe(1);
-  });
+    expect(adler32(new Uint8Array(0))).toBe(1)
+  })
 
   it("computes correct checksum for known string", () => {
-    const data = new TextEncoder().encode("Wikipedia");
-    expect(adler32(data)).toBe(0x11e60398);
-  });
-});
+    const data = new TextEncoder().encode("Wikipedia")
+    expect(adler32(data)).toBe(0x11e60398)
+  })
+})
 
 describe("DEFLATE stored blocks", () => {
   it("produces valid stored block structure", () => {
-    const input = new Uint8Array([1, 2, 3, 4, 5]);
-    const result = deflateRaw(input);
+    const input = new Uint8Array([1, 2, 3, 4, 5])
+    const result = deflateRaw(input)
 
     // First byte: BFINAL=1, BTYPE=00 → 0x01
-    expect(result[0]).toBe(0x01);
+    expect(result[0]).toBe(0x01)
     // LEN = 5
-    expect(result[1]).toBe(5);
-    expect(result[2]).toBe(0);
+    expect(result[1]).toBe(5)
+    expect(result[2]).toBe(0)
     // NLEN = ~5 & 0xFFFF = 0xFFFA
-    expect(result[3]).toBe(0xfa);
-    expect(result[4]).toBe(0xff);
+    expect(result[3]).toBe(0xfa)
+    expect(result[4]).toBe(0xff)
     // Data bytes
-    expect(result.slice(5, 10)).toEqual(input);
-  });
+    expect(result.slice(5, 10)).toEqual(input)
+  })
 
   it("handles empty input", () => {
-    const result = deflateRaw(new Uint8Array(0));
-    expect(result[0]).toBe(0x01); // BFINAL
-    expect(result[1]).toBe(0); // LEN = 0
-    expect(result[2]).toBe(0);
-  });
+    const result = deflateRaw(new Uint8Array(0))
+    expect(result[0]).toBe(0x01) // BFINAL
+    expect(result[1]).toBe(0) // LEN = 0
+    expect(result[2]).toBe(0)
+  })
 
   it("splits data into multiple blocks for large input", () => {
-    const input = new Uint8Array(65536);
-    input.fill(42);
-    const result = deflateRaw(input);
+    const input = new Uint8Array(65536)
+    input.fill(42)
+    const result = deflateRaw(input)
     // First block: not final (0x00), 65535 bytes
-    expect(result[0]).toBe(0x00);
+    expect(result[0]).toBe(0x00)
     // Second block: final (0x01), 1 byte
-    const secondBlockStart = 5 + 65535;
-    expect(result[secondBlockStart]).toBe(0x01);
-  });
-});
+    const secondBlockStart = 5 + 65535
+    expect(result[secondBlockStart]).toBe(0x01)
+  })
+})
 
 describe("zlib compress", () => {
   it("wraps deflate with correct header and checksum", () => {
-    const input = new Uint8Array([1, 2, 3]);
-    const result = zlibCompress(input);
+    const input = new Uint8Array([1, 2, 3])
+    const result = zlibCompress(input)
 
     // zlib header
-    expect(result[0]).toBe(0x78);
-    expect(result[1]).toBe(0x01);
+    expect(result[0]).toBe(0x78)
+    expect(result[1]).toBe(0x01)
     // (CMF*256 + FLG) % 31 === 0
-    expect((0x78 * 256 + 0x01) % 31).toBe(0);
+    expect((0x78 * 256 + 0x01) % 31).toBe(0)
 
     // Adler32 at the end (big-endian)
-    const expected = adler32(input);
-    const len = result.length;
+    const expected = adler32(input)
+    const len = result.length
     const actual =
       ((result[len - 4]! << 24) |
         (result[len - 3]! << 16) |
         (result[len - 2]! << 8) |
         result[len - 1]!) >>>
-      0;
-    expect(actual).toBe(expected);
-  });
-});
+      0
+    expect(actual).toBe(expected)
+  })
+})
 
 describe("PNG encoder", () => {
-  const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+  const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10]
 
   it("produces valid PNG signature", () => {
-    const rows = [new Uint8Array([0, 1, 0]), new Uint8Array([1, 0, 1])];
-    const png = encodePNG(3, 2, rows, [0, 0, 0], [255, 255, 255]);
-    expect(Array.from(png.slice(0, 8))).toEqual(PNG_SIGNATURE);
-  });
+    const rows = [new Uint8Array([0, 1, 0]), new Uint8Array([1, 0, 1])]
+    const png = encodePNG(3, 2, rows, [0, 0, 0], [255, 255, 255])
+    expect(Array.from(png.slice(0, 8))).toEqual(PNG_SIGNATURE)
+  })
 
   it("has correct IHDR dimensions", () => {
-    const rows = [new Uint8Array(10), new Uint8Array(10), new Uint8Array(10)];
-    const png = encodePNG(10, 3, rows, [0, 0, 0], [255, 255, 255]);
+    const rows = [new Uint8Array(10), new Uint8Array(10), new Uint8Array(10)]
+    const png = encodePNG(10, 3, rows, [0, 0, 0], [255, 255, 255])
 
     // IHDR starts at offset 8 (after signature)
     // chunk: 4 bytes length + 4 bytes type + 13 bytes data + 4 bytes CRC
-    const view = new DataView(png.buffer, png.byteOffset);
+    const view = new DataView(png.buffer, png.byteOffset)
     // Length of IHDR data
-    expect(view.getUint32(8)).toBe(13);
+    expect(view.getUint32(8)).toBe(13)
     // Type = "IHDR"
-    expect(String.fromCharCode(png[12]!, png[13]!, png[14]!, png[15]!)).toBe("IHDR");
+    expect(String.fromCharCode(png[12]!, png[13]!, png[14]!, png[15]!)).toBe("IHDR")
     // Width
-    expect(view.getUint32(16)).toBe(10);
+    expect(view.getUint32(16)).toBe(10)
     // Height
-    expect(view.getUint32(20)).toBe(3);
+    expect(view.getUint32(20)).toBe(3)
     // Bit depth = 8
-    expect(png[24]).toBe(8);
+    expect(png[24]).toBe(8)
     // Color type = 3 (indexed)
-    expect(png[25]).toBe(3);
-  });
+    expect(png[25]).toBe(3)
+  })
 
   it("contains PLTE chunk with correct colors", () => {
-    const rows = [new Uint8Array([0])];
-    const png = encodePNG(1, 1, rows, [255, 0, 0], [0, 255, 0]);
+    const rows = [new Uint8Array([0])]
+    const png = encodePNG(1, 1, rows, [255, 0, 0], [0, 255, 0])
 
     // Find PLTE chunk
-    let offset = 8;
-    let found = false;
+    let offset = 8
+    let found = false
     while (offset < png.length - 8) {
-      const view = new DataView(png.buffer, png.byteOffset);
-      const chunkLen = view.getUint32(offset);
+      const view = new DataView(png.buffer, png.byteOffset)
+      const chunkLen = view.getUint32(offset)
       const type = String.fromCharCode(
         png[offset + 4]!,
         png[offset + 5]!,
         png[offset + 6]!,
         png[offset + 7]!,
-      );
+      )
       if (type === "PLTE") {
         // bg (index 0) = [0, 255, 0], fg (index 1) = [255, 0, 0]
-        expect(png[offset + 8]).toBe(0); // bg R
-        expect(png[offset + 9]).toBe(255); // bg G
-        expect(png[offset + 10]).toBe(0); // bg B
-        expect(png[offset + 11]).toBe(255); // fg R
-        expect(png[offset + 12]).toBe(0); // fg G
-        expect(png[offset + 13]).toBe(0); // fg B
-        found = true;
-        break;
+        expect(png[offset + 8]).toBe(0) // bg R
+        expect(png[offset + 9]).toBe(255) // bg G
+        expect(png[offset + 10]).toBe(0) // bg B
+        expect(png[offset + 11]).toBe(255) // fg R
+        expect(png[offset + 12]).toBe(0) // fg G
+        expect(png[offset + 13]).toBe(0) // fg B
+        found = true
+        break
       }
-      offset += 4 + 4 + chunkLen + 4;
+      offset += 4 + 4 + chunkLen + 4
     }
-    expect(found).toBe(true);
-  });
+    expect(found).toBe(true)
+  })
 
   it("contains required chunk sequence: IHDR, PLTE, IDAT, IEND", () => {
-    const rows = [new Uint8Array([0, 1])];
-    const png = encodePNG(2, 1, rows, [0, 0, 0], [255, 255, 255]);
+    const rows = [new Uint8Array([0, 1])]
+    const png = encodePNG(2, 1, rows, [0, 0, 0], [255, 255, 255])
 
-    const chunks: string[] = [];
-    let offset = 8;
+    const chunks: string[] = []
+    let offset = 8
     while (offset < png.length) {
-      const view = new DataView(png.buffer, png.byteOffset);
-      const chunkLen = view.getUint32(offset);
+      const view = new DataView(png.buffer, png.byteOffset)
+      const chunkLen = view.getUint32(offset)
       const type = String.fromCharCode(
         png[offset + 4]!,
         png[offset + 5]!,
         png[offset + 6]!,
         png[offset + 7]!,
-      );
-      chunks.push(type);
-      offset += 4 + 4 + chunkLen + 4;
+      )
+      chunks.push(type)
+      offset += 4 + 4 + chunkLen + 4
     }
-    expect(chunks).toEqual(["IHDR", "PLTE", "IDAT", "IEND"]);
-  });
+    expect(chunks).toEqual(["IHDR", "PLTE", "IDAT", "IEND"])
+  })
 
   it("validates CRC for each chunk", () => {
-    const rows = [new Uint8Array([0, 1, 1, 0])];
-    const png = encodePNG(4, 1, rows, [0, 0, 0], [255, 255, 255]);
+    const rows = [new Uint8Array([0, 1, 1, 0])]
+    const png = encodePNG(4, 1, rows, [0, 0, 0], [255, 255, 255])
 
-    let offset = 8;
+    let offset = 8
     while (offset < png.length) {
-      const view = new DataView(png.buffer, png.byteOffset);
-      const chunkLen = view.getUint32(offset);
+      const view = new DataView(png.buffer, png.byteOffset)
+      const chunkLen = view.getUint32(offset)
       // type + data
-      const typeAndData = png.slice(offset + 4, offset + 4 + 4 + chunkLen);
-      const expectedCRC = crc32(typeAndData);
-      const actualCRC = view.getUint32(offset + 4 + 4 + chunkLen);
-      expect(actualCRC).toBe(expectedCRC);
-      offset += 4 + 4 + chunkLen + 4;
+      const typeAndData = png.slice(offset + 4, offset + 4 + 4 + chunkLen)
+      const expectedCRC = crc32(typeAndData)
+      const actualCRC = view.getUint32(offset + 4 + 4 + chunkLen)
+      expect(actualCRC).toBe(expectedCRC)
+      offset += 4 + 4 + chunkLen + 4
     }
-  });
-});
+  })
+})

--- a/test/qr-roundtrip.test.ts
+++ b/test/qr-roundtrip.test.ts
@@ -3,116 +3,116 @@
  * Verifies that generated QR codes are actually scannable
  */
 
-import { describe, expect, it } from "vitest";
-import jsQR from "jsqr";
-import { encodeQR } from "../src/encoders/qr/index";
+import { describe, expect, it } from "vitest"
+import jsQR from "jsqr"
+import { encodeQR } from "../src/encoders/qr/index"
 
 /** Convert a boolean QR matrix to RGBA image data that jsQR can decode */
 function matrixToImageData(matrix: boolean[][]): {
-  data: Uint8ClampedArray;
-  width: number;
-  height: number;
+  data: Uint8ClampedArray
+  width: number
+  height: number
 } {
-  const size = matrix.length;
-  const scale = 4;
-  const border = 4;
-  const imgSize = (size + border * 2) * scale;
-  const data = new Uint8ClampedArray(imgSize * imgSize * 4);
+  const size = matrix.length
+  const scale = 4
+  const border = 4
+  const imgSize = (size + border * 2) * scale
+  const data = new Uint8ClampedArray(imgSize * imgSize * 4)
 
   for (let y = 0; y < imgSize; y++) {
     for (let x = 0; x < imgSize; x++) {
-      const mx = Math.floor(x / scale) - border;
-      const my = Math.floor(y / scale) - border;
-      const isDark = mx >= 0 && mx < size && my >= 0 && my < size && matrix[my]![mx];
-      const idx = (y * imgSize + x) * 4;
-      const v = isDark ? 0 : 255;
-      data[idx] = v;
-      data[idx + 1] = v;
-      data[idx + 2] = v;
-      data[idx + 3] = 255;
+      const mx = Math.floor(x / scale) - border
+      const my = Math.floor(y / scale) - border
+      const isDark = mx >= 0 && mx < size && my >= 0 && my < size && matrix[my]![mx]
+      const idx = (y * imgSize + x) * 4
+      const v = isDark ? 0 : 255
+      data[idx] = v
+      data[idx + 1] = v
+      data[idx + 2] = v
+      data[idx + 3] = 255
     }
   }
 
-  return { data, width: imgSize, height: imgSize };
+  return { data, width: imgSize, height: imgSize }
 }
 
 /** Encode text as QR and decode it back, returning decoded string or null */
 function roundTrip(text: string, options?: Parameters<typeof encodeQR>[1]): string | null {
-  const matrix = encodeQR(text, options);
-  const { data, width, height } = matrixToImageData(matrix);
-  const result = jsQR(data, width, height);
-  return result?.data ?? null;
+  const matrix = encodeQR(text, options)
+  const { data, width, height } = matrixToImageData(matrix)
+  const result = jsQR(data, width, height)
+  return result?.data ?? null
 }
 
 describe("QR round-trip (encode → decode)", () => {
   it("decodes simple alphanumeric text", () => {
-    expect(roundTrip("HELLO")).toBe("HELLO");
-    expect(roundTrip("HELLO WORLD")).toBe("HELLO WORLD");
-    expect(roundTrip("TEST 123")).toBe("TEST 123");
-  });
+    expect(roundTrip("HELLO")).toBe("HELLO")
+    expect(roundTrip("HELLO WORLD")).toBe("HELLO WORLD")
+    expect(roundTrip("TEST 123")).toBe("TEST 123")
+  })
 
   it("decodes numeric data", () => {
-    expect(roundTrip("1234567890")).toBe("1234567890");
-    expect(roundTrip("0")).toBe("0");
-    expect(roundTrip("00000000")).toBe("00000000");
-  });
+    expect(roundTrip("1234567890")).toBe("1234567890")
+    expect(roundTrip("0")).toBe("0")
+    expect(roundTrip("00000000")).toBe("00000000")
+  })
 
   it("decodes byte mode (lowercase, special chars)", () => {
-    expect(roundTrip("hello world")).toBe("hello world");
-    expect(roundTrip("Hello, World!")).toBe("Hello, World!");
-    expect(roundTrip("test@example.com")).toBe("test@example.com");
-  });
+    expect(roundTrip("hello world")).toBe("hello world")
+    expect(roundTrip("Hello, World!")).toBe("Hello, World!")
+    expect(roundTrip("test@example.com")).toBe("test@example.com")
+  })
 
   it("decodes URLs", () => {
-    expect(roundTrip("https://example.com")).toBe("https://example.com");
+    expect(roundTrip("https://example.com")).toBe("https://example.com")
     expect(roundTrip("https://example.com/path?q=test&lang=en")).toBe(
       "https://example.com/path?q=test&lang=en",
-    );
-  });
+    )
+  })
 
   it("decodes WiFi strings", () => {
-    const wifi = "WIFI:T:WPA;S:MyNetwork;P:password123;;";
-    expect(roundTrip(wifi)).toBe(wifi);
-  });
+    const wifi = "WIFI:T:WPA;S:MyNetwork;P:password123;;"
+    expect(roundTrip(wifi)).toBe(wifi)
+  })
 
   it("works with all EC levels", () => {
-    const text = "EC LEVEL TEST";
-    expect(roundTrip(text, { ecLevel: "L" })).toBe(text);
-    expect(roundTrip(text, { ecLevel: "M" })).toBe(text);
-    expect(roundTrip(text, { ecLevel: "Q" })).toBe(text);
-    expect(roundTrip(text, { ecLevel: "H" })).toBe(text);
-  });
+    const text = "EC LEVEL TEST"
+    expect(roundTrip(text, { ecLevel: "L" })).toBe(text)
+    expect(roundTrip(text, { ecLevel: "M" })).toBe(text)
+    expect(roundTrip(text, { ecLevel: "Q" })).toBe(text)
+    expect(roundTrip(text, { ecLevel: "H" })).toBe(text)
+  })
 
   it("works with all 8 mask patterns", () => {
-    const text = "MASK TEST";
+    const text = "MASK TEST"
     for (let mask = 0; mask < 8; mask++) {
-      expect(roundTrip(text, { mask: mask as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 })).toBe(text);
+      expect(roundTrip(text, { mask: mask as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 })).toBe(text)
     }
-  });
+  })
 
   it("works with forced versions (1-6)", () => {
-    expect(roundTrip("AB", { version: 2 })).toBe("AB");
-    expect(roundTrip("VERSION 5 TEST", { version: 5 })).toBe("VERSION 5 TEST");
-    expect(roundTrip("VERSION 6 DATA", { version: 6 })).toBe("VERSION 6 DATA");
-  });
+    expect(roundTrip("AB", { version: 2 })).toBe("AB")
+    expect(roundTrip("VERSION 5 TEST", { version: 5 })).toBe("VERSION 5 TEST")
+    expect(roundTrip("VERSION 6 DATA", { version: 6 })).toBe("VERSION 6 DATA")
+  })
 
   it("works with version 7+ (version info encoding)", () => {
-    const text = "VERSION 7+ DATA WITH ENOUGH CONTENT TO ENCODE";
-    expect(roundTrip(text, { version: 7 })).toBe(text);
-    expect(roundTrip(text, { version: 10 })).toBe(text);
-    expect(roundTrip(text, { version: 15 })).toBe(text);
-  });
+    const text = "VERSION 7+ DATA WITH ENOUGH CONTENT TO ENCODE"
+    expect(roundTrip(text, { version: 7 })).toBe(text)
+    expect(roundTrip(text, { version: 10 })).toBe(text)
+    expect(roundTrip(text, { version: 15 })).toBe(text)
+  })
 
   it("decodes longer data (multi-version)", () => {
-    const medium = "A".repeat(100);
-    expect(roundTrip(medium)).toBe(medium);
+    const medium = "A".repeat(100)
+    expect(roundTrip(medium)).toBe(medium)
 
-    const long = "The quick brown fox jumps over the lazy dog. 1234567890";
-    expect(roundTrip(long)).toBe(long);
-  });
+    const long = "The quick brown fox jumps over the lazy dog. 1234567890"
+    expect(roundTrip(long)).toBe(long)
+  })
 
   it("decodes vCard data", () => {
-    const vcard = "BEGIN:VCARD\nVERSION:3.0\nN:Doe;John\nTEL:+1234567890\nEND:VCARD";
-    expect(roundTrip(vcard)).toBe(vcard);
-  });
-});
+    const vcard = "BEGIN:VCARD\nVERSION:3.0\nN:Doe;John\nTEL:+1234567890\nEND:VCARD"
+    expect(roundTrip(vcard)).toBe(vcard)
+  })
+})

--- a/test/raster.test.ts
+++ b/test/raster.test.ts
@@ -1,68 +1,68 @@
-import { describe, expect, it } from "vitest";
-import { renderBarcodeRaster, renderMatrixRaster } from "../src/renderers/png/rasterize";
-import type { RasterData } from "../src/renderers/png/rasterize";
+import { describe, expect, it } from "vitest"
+import { renderBarcodeRaster, renderMatrixRaster } from "../src/renderers/png/rasterize"
+import type { RasterData } from "../src/renderers/png/rasterize"
 
 describe("renderBarcodeRaster", () => {
   it("returns raw pixel rows with correct dimensions", () => {
-    const bars = [2, 1, 3, 1, 2];
-    const result: RasterData = renderBarcodeRaster(bars, { scale: 1, height: 10, margin: 0 });
-    expect(result.width).toBe(9);
-    expect(result.height).toBe(10);
-    expect(result.rows).toHaveLength(10);
-    expect(result.rows[0]).toBeInstanceOf(Uint8Array);
-    expect(result.rows[0]!.length).toBe(9);
-  });
+    const bars = [2, 1, 3, 1, 2]
+    const result: RasterData = renderBarcodeRaster(bars, { scale: 1, height: 10, margin: 0 })
+    expect(result.width).toBe(9)
+    expect(result.height).toBe(10)
+    expect(result.rows).toHaveLength(10)
+    expect(result.rows[0]).toBeInstanceOf(Uint8Array)
+    expect(result.rows[0]!.length).toBe(9)
+  })
 
   it("has foreground pixels (1) in bar positions", () => {
-    const bars = [2, 1, 2];
-    const result = renderBarcodeRaster(bars, { scale: 1, height: 5, margin: 0 });
-    const row = result.rows[0]!;
+    const bars = [2, 1, 2]
+    const result = renderBarcodeRaster(bars, { scale: 1, height: 5, margin: 0 })
+    const row = result.rows[0]!
     // bars[0]=2 (fg), bars[1]=1 (bg), bars[2]=2 (fg)
-    expect(row[0]).toBe(1);
-    expect(row[1]).toBe(1);
-    expect(row[2]).toBe(0);
-    expect(row[3]).toBe(1);
-    expect(row[4]).toBe(1);
-  });
+    expect(row[0]).toBe(1)
+    expect(row[1]).toBe(1)
+    expect(row[2]).toBe(0)
+    expect(row[3]).toBe(1)
+    expect(row[4]).toBe(1)
+  })
 
   it("applies margin", () => {
-    const bars = [1];
-    const result = renderBarcodeRaster(bars, { scale: 1, height: 1, margin: 5 });
-    expect(result.width).toBe(11); // 1 + 5*2
-    expect(result.height).toBe(11); // 1 + 5*2
-    expect(result.rows).toHaveLength(11);
-  });
-});
+    const bars = [1]
+    const result = renderBarcodeRaster(bars, { scale: 1, height: 1, margin: 5 })
+    expect(result.width).toBe(11) // 1 + 5*2
+    expect(result.height).toBe(11) // 1 + 5*2
+    expect(result.rows).toHaveLength(11)
+  })
+})
 
 describe("renderMatrixRaster", () => {
   it("returns raw pixel rows with correct dimensions", () => {
     const matrix = [
       [true, false],
       [false, true],
-    ];
-    const result: RasterData = renderMatrixRaster(matrix, { moduleSize: 1, margin: 0 });
-    expect(result.width).toBe(2);
-    expect(result.height).toBe(2);
-    expect(result.rows).toHaveLength(2);
-    expect(result.rows[0]![0]).toBe(1);
-    expect(result.rows[0]![1]).toBe(0);
-    expect(result.rows[1]![0]).toBe(0);
-    expect(result.rows[1]![1]).toBe(1);
-  });
+    ]
+    const result: RasterData = renderMatrixRaster(matrix, { moduleSize: 1, margin: 0 })
+    expect(result.width).toBe(2)
+    expect(result.height).toBe(2)
+    expect(result.rows).toHaveLength(2)
+    expect(result.rows[0]![0]).toBe(1)
+    expect(result.rows[0]![1]).toBe(0)
+    expect(result.rows[1]![0]).toBe(0)
+    expect(result.rows[1]![1]).toBe(1)
+  })
 
   it("scales with moduleSize", () => {
-    const matrix = [[true]];
-    const result = renderMatrixRaster(matrix, { moduleSize: 4, margin: 0 });
-    expect(result.width).toBe(4);
-    expect(result.height).toBe(4);
-    expect(result.rows).toHaveLength(4);
-    expect(result.rows[0]!.every((v) => v === 1)).toBe(true);
-  });
+    const matrix = [[true]]
+    const result = renderMatrixRaster(matrix, { moduleSize: 4, margin: 0 })
+    expect(result.width).toBe(4)
+    expect(result.height).toBe(4)
+    expect(result.rows).toHaveLength(4)
+    expect(result.rows[0]!.every((v) => v === 1)).toBe(true)
+  })
 
   it("applies margin", () => {
-    const matrix = [[true]];
-    const result = renderMatrixRaster(matrix, { moduleSize: 2, margin: 1 });
-    expect(result.width).toBe(6); // (1 + 1*2) * 2
-    expect(result.height).toBe(6);
-  });
-});
+    const matrix = [[true]]
+    const result = renderMatrixRaster(matrix, { moduleSize: 2, margin: 1 })
+    expect(result.width).toBe(6) // (1 + 1*2) * 2
+    expect(result.height).toBe(6)
+  })
+})

--- a/test/renderers-barcode-full.test.ts
+++ b/test/renderers-barcode-full.test.ts
@@ -3,43 +3,43 @@
  * placement and alignment, bearer bars, gaps, units and accessibility.
  */
 
-import { describe, expect, it } from "vitest";
-import { renderBarcodeSVG } from "../src/renderers/svg/barcode";
+import { describe, expect, it } from "vitest"
+import { renderBarcodeSVG } from "../src/renderers/svg/barcode"
 
-const BARS = [2, 1, 1, 2, 3, 1, 1, 2];
+const BARS = [2, 1, 1, 2, 3, 1, 1, 2]
 
 /** Extract the drawn bar rects (skipping the background rect). */
 function rects(svg: string): Array<{ x: number; y: number; w: number; h: number }> {
-  const out: Array<{ x: number; y: number; w: number; h: number }> = [];
-  const re = /<rect x="([\d.-]+)" y="([\d.-]+)" width="([\d.-]+)" height="([\d.-]+)"/g;
-  let m: RegExpExecArray | null;
+  const out: Array<{ x: number; y: number; w: number; h: number }> = []
+  const re = /<rect x="([\d.-]+)" y="([\d.-]+)" width="([\d.-]+)" height="([\d.-]+)"/g
+  let m: RegExpExecArray | null
   while ((m = re.exec(svg)) !== null) {
-    out.push({ x: Number(m[1]), y: Number(m[2]), w: Number(m[3]), h: Number(m[4]) });
+    out.push({ x: Number(m[1]), y: Number(m[2]), w: Number(m[3]), h: Number(m[4]) })
   }
-  return out;
+  return out
 }
 
 describe("renderBarcodeSVG — geometry", () => {
   it("computes width from total bar units", () => {
-    const total = BARS.reduce((a, b) => a + b, 0);
-    const svg = renderBarcodeSVG(BARS, { barWidth: 2, margin: 10, height: 80 });
-    expect(svg).toContain(`viewBox="0 0 ${total * 2 + 20} 100"`);
-  });
+    const total = BARS.reduce((a, b) => a + b, 0)
+    const svg = renderBarcodeSVG(BARS, { barWidth: 2, margin: 10, height: 80 })
+    expect(svg).toContain(`viewBox="0 0 ${total * 2 + 20} 100"`)
+  })
 
   it("draws only the bar elements, not the spaces", () => {
     // BARS alternates bar/space starting with a bar → 4 bars
-    expect(rects(renderBarcodeSVG(BARS, { background: "transparent" }))).toHaveLength(4);
-  });
+    expect(rects(renderBarcodeSVG(BARS, { background: "transparent" }))).toHaveLength(4)
+  })
 
   it("positions bars cumulatively", () => {
     const drawn = rects(
       renderBarcodeSVG([2, 1, 3], { barWidth: 2, margin: 0, background: "transparent" }),
-    );
-    expect(drawn[0]!.x).toBe(0);
-    expect(drawn[0]!.w).toBe(4);
-    expect(drawn[1]!.x).toBe(6); // after bar(2) + space(1) = 3 units * 2
-    expect(drawn[1]!.w).toBe(6);
-  });
+    )
+    expect(drawn[0]!.x).toBe(0)
+    expect(drawn[0]!.w).toBe(4)
+    expect(drawn[1]!.x).toBe(6) // after bar(2) + space(1) = 3 units * 2
+    expect(drawn[1]!.w).toBe(6)
+  })
 
   it("supports per-side margins", () => {
     const svg = renderBarcodeSVG([1], {
@@ -50,20 +50,20 @@ describe("renderBarcodeSVG — geometry", () => {
       marginTop: 3,
       marginBottom: 9,
       background: "transparent",
-    });
-    expect(svg).toContain(`viewBox="0 0 ${2 + 5 + 7} ${50 + 3 + 9}"`);
-    const [bar] = rects(svg);
-    expect(bar!.x).toBe(5);
-    expect(bar!.y).toBe(3);
-  });
+    })
+    expect(svg).toContain(`viewBox="0 0 ${2 + 5 + 7} ${50 + 3 + 9}"`)
+    const [bar] = rects(svg)
+    expect(bar!.x).toBe(5)
+    expect(bar!.y).toBe(3)
+  })
 
   it("narrows bars by barGap", () => {
     const drawn = rects(
       renderBarcodeSVG([2], { barWidth: 4, barGap: 2, margin: 0, background: "transparent" }),
-    );
-    expect(drawn[0]!.w).toBe(6); // 2*4 - 2
-    expect(drawn[0]!.x).toBe(1); // shifted by half the gap
-  });
+    )
+    expect(drawn[0]!.w).toBe(6) // 2*4 - 2
+    expect(drawn[0]!.x).toBe(1) // shifted by half the gap
+  })
 
   it("omits bars fully consumed by the gap", () => {
     const svg = renderBarcodeSVG([1, 1, 1], {
@@ -71,52 +71,52 @@ describe("renderBarcodeSVG — geometry", () => {
       barGap: 4,
       margin: 0,
       background: "transparent",
-    });
-    expect(rects(svg)).toHaveLength(0);
-  });
-});
+    })
+    expect(rects(svg)).toHaveLength(0)
+  })
+})
 
 describe("renderBarcodeSVG — rotation", () => {
   it("does not emit a transform at 0 degrees", () => {
-    expect(renderBarcodeSVG(BARS)).not.toContain("rotate(");
-  });
+    expect(renderBarcodeSVG(BARS)).not.toContain("rotate(")
+  })
 
   it("swaps dimensions at 90 and 270 degrees", () => {
-    const total = BARS.reduce((a, b) => a + b, 0);
-    const contentW = total * 2 + 20;
-    const contentH = 80 + 20;
+    const total = BARS.reduce((a, b) => a + b, 0)
+    const contentW = total * 2 + 20
+    const contentH = 80 + 20
     for (const rotation of [90, 270] as const) {
-      const svg = renderBarcodeSVG(BARS, { rotation, barWidth: 2, margin: 10, height: 80 });
-      expect(svg, String(rotation)).toContain(`viewBox="0 0 ${contentH} ${contentW}"`);
-      expect(svg, String(rotation)).toContain(`rotate(${rotation},`);
+      const svg = renderBarcodeSVG(BARS, { rotation, barWidth: 2, margin: 10, height: 80 })
+      expect(svg, String(rotation)).toContain(`viewBox="0 0 ${contentH} ${contentW}"`)
+      expect(svg, String(rotation)).toContain(`rotate(${rotation},`)
     }
-  });
+  })
 
   it("keeps dimensions at 180 degrees", () => {
-    const total = BARS.reduce((a, b) => a + b, 0);
-    const svg = renderBarcodeSVG(BARS, { rotation: 180, barWidth: 2, margin: 10, height: 80 });
-    expect(svg).toContain(`viewBox="0 0 ${total * 2 + 20} 100"`);
-    expect(svg).toContain("rotate(180,");
-  });
+    const total = BARS.reduce((a, b) => a + b, 0)
+    const svg = renderBarcodeSVG(BARS, { rotation: 180, barWidth: 2, margin: 10, height: 80 })
+    expect(svg).toContain(`viewBox="0 0 ${total * 2 + 20} 100"`)
+    expect(svg).toContain("rotate(180,")
+  })
 
   it("closes the transform group", () => {
-    const svg = renderBarcodeSVG(BARS, { rotation: 90 });
-    expect(svg).toContain("<g transform=");
-    expect(svg).toContain("</g>");
-  });
-});
+    const svg = renderBarcodeSVG(BARS, { rotation: 90 })
+    expect(svg).toContain("<g transform=")
+    expect(svg).toContain("</g>")
+  })
+})
 
 describe("renderBarcodeSVG — human-readable text", () => {
   it("omits text unless showText is set", () => {
-    expect(renderBarcodeSVG(BARS, { text: "12345" })).not.toContain("<text");
-  });
+    expect(renderBarcodeSVG(BARS, { text: "12345" })).not.toContain("<text")
+  })
 
   it("renders text below by default", () => {
-    const svg = renderBarcodeSVG(BARS, { showText: true, text: "12345", height: 80, margin: 10 });
-    const y = Number(/<text x="[\d.]+" y="([\d.]+)"/.exec(svg)![1]);
-    expect(y).toBeGreaterThan(80);
-    expect(svg).toContain(">12345</text>");
-  });
+    const svg = renderBarcodeSVG(BARS, { showText: true, text: "12345", height: 80, margin: 10 })
+    const y = Number(/<text x="[\d.]+" y="([\d.]+)"/.exec(svg)![1])
+    expect(y).toBeGreaterThan(80)
+    expect(svg).toContain(">12345</text>")
+  })
 
   it("renders text above when textPosition is top", () => {
     const svg = renderBarcodeSVG(BARS, {
@@ -127,37 +127,37 @@ describe("renderBarcodeSVG — human-readable text", () => {
       margin: 10,
       fontSize: 14,
       background: "transparent",
-    });
-    const textY = Number(/<text x="[\d.]+" y="([\d.]+)"/.exec(svg)![1]);
-    const [firstBar] = rects(svg);
-    expect(textY).toBeLessThan(firstBar!.y);
-  });
+    })
+    const textY = Number(/<text x="[\d.]+" y="([\d.]+)"/.exec(svg)![1])
+    const [firstBar] = rects(svg)
+    expect(textY).toBeLessThan(firstBar!.y)
+  })
 
   it("aligns text center, left and right", () => {
-    const center = renderBarcodeSVG(BARS, { showText: true, text: "X" });
-    expect(center).toContain('text-anchor="middle"');
+    const center = renderBarcodeSVG(BARS, { showText: true, text: "X" })
+    expect(center).toContain('text-anchor="middle"')
 
-    const left = renderBarcodeSVG(BARS, { showText: true, text: "X", textAlign: "left" });
-    expect(left).toContain('text-anchor="start"');
-    expect(left).toContain('<text x="10"');
+    const left = renderBarcodeSVG(BARS, { showText: true, text: "X", textAlign: "left" })
+    expect(left).toContain('text-anchor="start"')
+    expect(left).toContain('<text x="10"')
 
-    const right = renderBarcodeSVG(BARS, { showText: true, text: "X", textAlign: "right" });
-    expect(right).toContain('text-anchor="end"');
-  });
+    const right = renderBarcodeSVG(BARS, { showText: true, text: "X", textAlign: "right" })
+    expect(right).toContain('text-anchor="end"')
+  })
 
   it("reserves vertical space for the text", () => {
-    const without = renderBarcodeSVG(BARS, { height: 80, margin: 10 });
+    const without = renderBarcodeSVG(BARS, { height: 80, margin: 10 })
     const withText = renderBarcodeSVG(BARS, {
       height: 80,
       margin: 10,
       showText: true,
       text: "X",
       fontSize: 14,
-    });
-    const width = BARS.reduce((a, b) => a + b, 0) * 2 + 20;
-    expect(without).toContain(`viewBox="0 0 ${width} 100"`);
-    expect(withText).toContain(`viewBox="0 0 ${width} ${100 + 14 + 8}"`);
-  });
+    })
+    const width = BARS.reduce((a, b) => a + b, 0) * 2 + 20
+    expect(without).toContain(`viewBox="0 0 ${width} 100"`)
+    expect(withText).toContain(`viewBox="0 0 ${width} ${100 + 14 + 8}"`)
+  })
 
   it("applies font family and size", () => {
     const svg = renderBarcodeSVG(BARS, {
@@ -165,26 +165,26 @@ describe("renderBarcodeSVG — human-readable text", () => {
       text: "X",
       fontFamily: "Helvetica",
       fontSize: 20,
-    });
-    expect(svg).toContain('font-family="Helvetica"');
-    expect(svg).toContain('font-size="20"');
-  });
+    })
+    expect(svg).toContain('font-family="Helvetica"')
+    expect(svg).toContain('font-size="20"')
+  })
 
   it("escapes text content", () => {
     expect(renderBarcodeSVG(BARS, { showText: true, text: '<a & "b">' })).toContain(
       "&lt;a &amp; &quot;b&quot;&gt;",
-    );
-  });
-});
+    )
+  })
+})
 
 describe("renderBarcodeSVG — bearer bars", () => {
   it("draws four bearer rects around the symbol", () => {
-    const plain = rects(renderBarcodeSVG(BARS, { background: "transparent" })).length;
+    const plain = rects(renderBarcodeSVG(BARS, { background: "transparent" })).length
     const bearer = rects(
       renderBarcodeSVG(BARS, { bearerBars: true, background: "transparent" }),
-    ).length;
-    expect(bearer).toBe(plain + 4);
-  });
+    ).length
+    expect(bearer).toBe(plain + 4)
+  })
 
   it("adds vertical space for the bearer bars", () => {
     const svg = renderBarcodeSVG(BARS, {
@@ -192,49 +192,49 @@ describe("renderBarcodeSVG — bearer bars", () => {
       bearerBarWidth: 5,
       height: 80,
       margin: 10,
-    });
-    const width = BARS.reduce((a, b) => a + b, 0) * 2 + 20;
-    expect(svg).toContain(`viewBox="0 0 ${width} ${80 + 20 + 10}"`);
-  });
+    })
+    const width = BARS.reduce((a, b) => a + b, 0) * 2 + 20
+    expect(svg).toContain(`viewBox="0 0 ${width} ${80 + 20 + 10}"`)
+  })
 
   it("honours bearerBarWidth", () => {
-    const thin = renderBarcodeSVG(BARS, { bearerBars: true, bearerBarWidth: 2 });
-    const thick = renderBarcodeSVG(BARS, { bearerBars: true, bearerBarWidth: 8 });
-    expect(thin).not.toBe(thick);
-  });
+    const thin = renderBarcodeSVG(BARS, { bearerBars: true, bearerBarWidth: 2 })
+    const thick = renderBarcodeSVG(BARS, { bearerBars: true, bearerBarWidth: 8 })
+    expect(thin).not.toBe(thick)
+  })
 
   it("combines bearer bars with text", () => {
-    const svg = renderBarcodeSVG(BARS, { bearerBars: true, showText: true, text: "1234" });
-    expect(svg).toContain("<text");
-    expect(rects(svg).length).toBeGreaterThan(4);
-  });
-});
+    const svg = renderBarcodeSVG(BARS, { bearerBars: true, showText: true, text: "1234" })
+    expect(svg).toContain("<text")
+    expect(rects(svg).length).toBeGreaterThan(4)
+  })
+})
 
 describe("renderBarcodeSVG — presentation", () => {
   it("applies colors", () => {
-    const svg = renderBarcodeSVG(BARS, { color: "#123456", background: "#abcdef" });
-    expect(svg).toContain('fill="#123456"');
-    expect(svg).toContain('fill="#abcdef"');
-  });
+    const svg = renderBarcodeSVG(BARS, { color: "#123456", background: "#abcdef" })
+    expect(svg).toContain('fill="#123456"')
+    expect(svg).toContain('fill="#abcdef"')
+  })
 
   it("omits the background rect when transparent", () => {
-    expect(renderBarcodeSVG(BARS, { background: "transparent" })).not.toContain('width="100%"');
-  });
+    expect(renderBarcodeSVG(BARS, { background: "transparent" })).not.toContain('width="100%"')
+  })
 
   it("applies measurement units to width and height only", () => {
-    const svg = renderBarcodeSVG(BARS, { unit: "mm" });
-    expect(svg).toMatch(/width="[\d.]+mm"/);
-    expect(svg).toMatch(/height="[\d.]+mm"/);
-    expect(svg).toMatch(/viewBox="0 0 [\d.]+ [\d.]+"/);
-  });
+    const svg = renderBarcodeSVG(BARS, { unit: "mm" })
+    expect(svg).toMatch(/width="[\d.]+mm"/)
+    expect(svg).toMatch(/height="[\d.]+mm"/)
+    expect(svg).toMatch(/viewBox="0 0 [\d.]+ [\d.]+"/)
+  })
 
   it("supports every measurement unit", () => {
     for (const unit of ["px", "mm", "cm", "in", "pt"] as const) {
-      const svg = renderBarcodeSVG(BARS, { unit });
-      const suffix = unit === "px" ? "" : unit;
-      expect(svg, unit).toMatch(new RegExp(`width="[\\d.]+${suffix}"`));
+      const svg = renderBarcodeSVG(BARS, { unit })
+      const suffix = unit === "px" ? "" : unit
+      expect(svg, unit).toMatch(new RegExp(`width="[\\d.]+${suffix}"`))
     }
-  });
+  })
 
   it("supports accessibility metadata", () => {
     const svg = renderBarcodeSVG(BARS, {
@@ -242,29 +242,29 @@ describe("renderBarcodeSVG — presentation", () => {
       role: "graphics-symbol",
       title: "Barcode",
       desc: "A Code 128 barcode",
-    });
-    expect(svg).toContain('aria-label="product code"');
-    expect(svg).toContain('role="graphics-symbol"');
-    expect(svg).toContain("<title>Barcode</title>");
-    expect(svg).toContain("<desc>A Code 128 barcode</desc>");
-  });
+    })
+    expect(svg).toContain('aria-label="product code"')
+    expect(svg).toContain('role="graphics-symbol"')
+    expect(svg).toContain("<title>Barcode</title>")
+    expect(svg).toContain("<desc>A Code 128 barcode</desc>")
+  })
 
   it("defaults to role=img with no aria-label", () => {
-    const svg = renderBarcodeSVG(BARS);
-    expect(svg).toContain('role="img"');
-    expect(svg).not.toContain("aria-label");
-  });
+    const svg = renderBarcodeSVG(BARS)
+    expect(svg).toContain('role="img"')
+    expect(svg).not.toContain("aria-label")
+  })
 
   it("escapes accessibility text", () => {
-    const svg = renderBarcodeSVG(BARS, { title: "<t>", desc: "a & b", ariaLabel: '"q"' });
-    expect(svg).toContain("<title>&lt;t&gt;</title>");
-    expect(svg).toContain("<desc>a &amp; b</desc>");
-    expect(svg).toContain('aria-label="&quot;q&quot;"');
-  });
+    const svg = renderBarcodeSVG(BARS, { title: "<t>", desc: "a & b", ariaLabel: '"q"' })
+    expect(svg).toContain("<title>&lt;t&gt;</title>")
+    expect(svg).toContain("<desc>a &amp; b</desc>")
+    expect(svg).toContain('aria-label="&quot;q&quot;"')
+  })
 
   it("handles an empty bar list", () => {
-    const svg = renderBarcodeSVG([], { margin: 10, height: 80 });
-    expect(svg).toContain('viewBox="0 0 20 100"');
-    expect(rects(svg)).toHaveLength(0);
-  });
-});
+    const svg = renderBarcodeSVG([], { margin: 10, height: 80 })
+    expect(svg).toContain('viewBox="0 0 20 100"')
+    expect(rects(svg)).toHaveLength(0)
+  })
+})

--- a/test/renderers-barcode-options.test.ts
+++ b/test/renderers-barcode-options.test.ts
@@ -1,33 +1,33 @@
-import { describe, expect, it } from "vitest";
-import { renderBarcodeSVG } from "../src/renderers/svg/barcode";
+import { describe, expect, it } from "vitest"
+import { renderBarcodeSVG } from "../src/renderers/svg/barcode"
 
 // Simple bar pattern: bar(2), space(1), bar(1), space(1), bar(2)
-const testBars = [2, 1, 1, 1, 2];
+const testBars = [2, 1, 1, 1, 2]
 
 describe("barGap option", () => {
   it("barGap 0 (default) renders normally", () => {
-    const svg = renderBarcodeSVG(testBars, { barGap: 0 });
-    const svgDefault = renderBarcodeSVG(testBars);
-    expect(svg).toBe(svgDefault);
-  });
+    const svg = renderBarcodeSVG(testBars, { barGap: 0 })
+    const svgDefault = renderBarcodeSVG(testBars)
+    expect(svg).toBe(svgDefault)
+  })
 
   it("barGap > 0 produces different SVG than barGap 0", () => {
-    const svgNoGap = renderBarcodeSVG(testBars, { barGap: 0 });
-    const svgWithGap = renderBarcodeSVG(testBars, { barGap: 1 });
-    expect(svgWithGap).not.toBe(svgNoGap);
+    const svgNoGap = renderBarcodeSVG(testBars, { barGap: 0 })
+    const svgWithGap = renderBarcodeSVG(testBars, { barGap: 1 })
+    expect(svgWithGap).not.toBe(svgNoGap)
     // The gapped version should have narrower bars
-    expect(svgWithGap).toContain("<rect");
-  });
+    expect(svgWithGap).toContain("<rect")
+  })
 
   it("barGap does not change total SVG width", () => {
-    const svgNoGap = renderBarcodeSVG(testBars, { barGap: 0 });
-    const svgWithGap = renderBarcodeSVG(testBars, { barGap: 1 });
+    const svgNoGap = renderBarcodeSVG(testBars, { barGap: 0 })
+    const svgWithGap = renderBarcodeSVG(testBars, { barGap: 1 })
 
     const widthOf = (svg: string) => {
-      const match = svg.match(/viewBox="0 0 (\d+(?:\.\d+)?)/);
-      return match ? parseFloat(match[1]) : NaN;
-    };
+      const match = svg.match(/viewBox="0 0 (\d+(?:\.\d+)?)/)
+      return match ? parseFloat(match[1]) : NaN
+    }
 
-    expect(widthOf(svgWithGap)).toBe(widthOf(svgNoGap));
-  });
-});
+    expect(widthOf(svgWithGap)).toBe(widthOf(svgNoGap))
+  })
+})

--- a/test/renderers-corners.test.ts
+++ b/test/renderers-corners.test.ts
@@ -1,21 +1,21 @@
-import { describe, expect, it } from "vitest";
-import { getFinderOuterPath, getFinderInnerPath } from "../src/renderers/svg/shapes";
+import { describe, expect, it } from "vitest"
+import { getFinderOuterPath, getFinderInnerPath } from "../src/renderers/svg/shapes"
 
 /**
  * Parse an SVG path string into a list of {command, args} segments.
  * Handles M, m, h, v, a, l, z and their uppercase variants.
  */
 function parsePath(d: string): Array<{ cmd: string; args: number[] }> {
-  const segments: Array<{ cmd: string; args: number[] }> = [];
-  const re = /([MmHhVvAaLlZz])([^MmHhVvAaLlZz]*)/g;
-  let match: RegExpExecArray | null;
+  const segments: Array<{ cmd: string; args: number[] }> = []
+  const re = /([MmHhVvAaLlZz])([^MmHhVvAaLlZz]*)/g
+  let match: RegExpExecArray | null
   while ((match = re.exec(d)) !== null) {
-    const cmd = match[1]!;
-    const raw = match[2]!.trim();
-    const args = raw.length > 0 ? raw.split(/[\s,]+/).map(Number) : [];
-    segments.push({ cmd, args });
+    const cmd = match[1]!
+    const raw = match[2]!.trim()
+    const args = raw.length > 0 ? raw.split(/[\s,]+/).map(Number) : []
+    segments.push({ cmd, args })
   }
-  return segments;
+  return segments
 }
 
 /**
@@ -23,185 +23,185 @@ function parsePath(d: string): Array<{ cmd: string; args: number[] }> {
  * (start of each segment + arc/line endpoints).
  */
 function tracePoints(d: string): Array<[number, number]> {
-  const segs = parsePath(d);
-  const points: Array<[number, number]> = [];
-  let cx = 0;
-  let cy = 0;
+  const segs = parsePath(d)
+  const points: Array<[number, number]> = []
+  let cx = 0
+  let cy = 0
   for (const { cmd, args } of segs) {
     switch (cmd) {
       case "M":
-        cx = args[0]!;
-        cy = args[1]!;
-        points.push([cx, cy]);
-        break;
+        cx = args[0]!
+        cy = args[1]!
+        points.push([cx, cy])
+        break
       case "h":
-        cx += args[0]!;
-        points.push([cx, cy]);
-        break;
+        cx += args[0]!
+        points.push([cx, cy])
+        break
       case "H":
-        cx = args[0]!;
-        points.push([cx, cy]);
-        break;
+        cx = args[0]!
+        points.push([cx, cy])
+        break
       case "v":
-        cy += args[0]!;
-        points.push([cx, cy]);
-        break;
+        cy += args[0]!
+        points.push([cx, cy])
+        break
       case "V":
-        cy = args[0]!;
-        points.push([cx, cy]);
-        break;
+        cy = args[0]!
+        points.push([cx, cy])
+        break
       case "a": {
         // relative arc: last two args are dx, dy
         for (let i = 0; i < args.length; i += 7) {
-          cx += args[i + 5]!;
-          cy += args[i + 6]!;
-          points.push([cx, cy]);
+          cx += args[i + 5]!
+          cy += args[i + 6]!
+          points.push([cx, cy])
         }
-        break;
+        break
       }
       case "l":
-        cx += args[0]!;
-        cy += args[1]!;
-        points.push([cx, cy]);
-        break;
+        cx += args[0]!
+        cy += args[1]!
+        points.push([cx, cy])
+        break
       case "z":
       case "Z":
-        break;
+        break
     }
   }
-  return points;
+  return points
 }
 
 /**
  * Extract bounding box from traced path points.
  */
 function pathBounds(d: string): { minX: number; minY: number; maxX: number; maxY: number } {
-  const pts = tracePoints(d);
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
+  const pts = tracePoints(d)
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
   for (const [x, y] of pts) {
-    if (x < minX) minX = x;
-    if (y < minY) minY = y;
-    if (x > maxX) maxX = x;
-    if (y > maxY) maxY = y;
+    if (x < minX) minX = x
+    if (y < minY) minY = y
+    if (x > maxX) maxX = x
+    if (y > maxY) maxY = y
   }
-  return { minX, minY, maxX, maxY };
+  return { minX, minY, maxX, maxY }
 }
 
 describe("finder pattern corner shapes", () => {
-  const moduleSize = 10;
-  const x = 0;
-  const y = 0;
-  const finderSize = moduleSize * 7; // 70
+  const moduleSize = 10
+  const x = 0
+  const y = 0
+  const finderSize = moduleSize * 7 // 70
 
   describe.each(["square", "rounded", "extra-rounded", "classy", "dots"] as const)(
     "outer shape: %s",
     (shape) => {
-      const d = getFinderOuterPath(x, y, moduleSize, shape);
+      const d = getFinderOuterPath(x, y, moduleSize, shape)
 
       it("produces non-empty path data", () => {
-        expect(d.length).toBeGreaterThan(0);
-      });
+        expect(d.length).toBeGreaterThan(0)
+      })
 
       if (shape !== "dots") {
         it("outer path stays within the 7×7 module bounding box", () => {
-          const bounds = pathBounds(d);
-          expect(bounds.minX).toBeGreaterThanOrEqual(x - 0.01);
-          expect(bounds.minY).toBeGreaterThanOrEqual(y - 0.01);
-          expect(bounds.maxX).toBeLessThanOrEqual(x + finderSize + 0.01);
-          expect(bounds.maxY).toBeLessThanOrEqual(y + finderSize + 0.01);
-        });
+          const bounds = pathBounds(d)
+          expect(bounds.minX).toBeGreaterThanOrEqual(x - 0.01)
+          expect(bounds.minY).toBeGreaterThanOrEqual(y - 0.01)
+          expect(bounds.maxX).toBeLessThanOrEqual(x + finderSize + 0.01)
+          expect(bounds.maxY).toBeLessThanOrEqual(y + finderSize + 0.01)
+        })
       }
 
       it("contains exactly 2 sub-paths (outer boundary + inner hole)", () => {
-        const mCount = (d.match(/M/g) || []).length;
-        expect(mCount).toBe(2);
-      });
+        const mCount = (d.match(/M/g) || []).length
+        expect(mCount).toBe(2)
+      })
 
       it("inner hole stays within outer boundary", () => {
         // Split at second M to get outer and inner paths
-        const secondM = d.indexOf("M", 1);
-        const outerD = d.substring(0, secondM);
-        const innerD = d.substring(secondM);
+        const secondM = d.indexOf("M", 1)
+        const outerD = d.substring(0, secondM)
+        const innerD = d.substring(secondM)
 
-        const outerBounds = pathBounds(outerD);
-        const innerBounds = pathBounds(innerD);
+        const outerBounds = pathBounds(outerD)
+        const innerBounds = pathBounds(innerD)
 
         // Inner must be strictly inside outer
-        expect(innerBounds.minX).toBeGreaterThan(outerBounds.minX - 0.01);
-        expect(innerBounds.minY).toBeGreaterThan(outerBounds.minY - 0.01);
-        expect(innerBounds.maxX).toBeLessThan(outerBounds.maxX + 0.01);
-        expect(innerBounds.maxY).toBeLessThan(outerBounds.maxY + 0.01);
-      });
+        expect(innerBounds.minX).toBeGreaterThan(outerBounds.minX - 0.01)
+        expect(innerBounds.minY).toBeGreaterThan(outerBounds.minY - 0.01)
+        expect(innerBounds.maxX).toBeLessThan(outerBounds.maxX + 0.01)
+        expect(innerBounds.maxY).toBeLessThan(outerBounds.maxY + 0.01)
+      })
     },
-  );
+  )
 
   describe.each(["square", "rounded", "dots"] as const)("inner shape: %s", (shape) => {
-    const d = getFinderInnerPath(x, y, moduleSize, shape);
+    const d = getFinderInnerPath(x, y, moduleSize, shape)
 
     it("produces non-empty path data", () => {
-      expect(d.length).toBeGreaterThan(0);
-    });
+      expect(d.length).toBeGreaterThan(0)
+    })
 
     it("inner dot is centered at 3.5 modules", () => {
-      const bounds = pathBounds(d);
-      const centerX = (bounds.minX + bounds.maxX) / 2;
-      const centerY = (bounds.minY + bounds.maxY) / 2;
-      const expectedCenter = moduleSize * 3.5;
-      expect(centerX).toBeCloseTo(expectedCenter, 1);
-      expect(centerY).toBeCloseTo(expectedCenter, 1);
-    });
+      const bounds = pathBounds(d)
+      const centerX = (bounds.minX + bounds.maxX) / 2
+      const centerY = (bounds.minY + bounds.maxY) / 2
+      const expectedCenter = moduleSize * 3.5
+      expect(centerX).toBeCloseTo(expectedCenter, 1)
+      expect(centerY).toBeCloseTo(expectedCenter, 1)
+    })
 
     it("inner dot size is 3 modules", () => {
-      const bounds = pathBounds(d);
-      const width = bounds.maxX - bounds.minX;
+      const bounds = pathBounds(d)
+      const width = bounds.maxX - bounds.minX
       // For circles, traced endpoints only capture horizontal extent (arcs go above/below),
       // but width = diameter is sufficient to verify size since circles are symmetric
-      expect(width).toBeCloseTo(moduleSize * 3, 1);
-    });
-  });
+      expect(width).toBeCloseTo(moduleSize * 3, 1)
+    })
+  })
 
   describe("rounded corner geometry regression", () => {
     it("inner hole of rounded shape matches expected dimensions", () => {
-      const d = getFinderOuterPath(0, 0, 10, "rounded");
+      const d = getFinderOuterPath(0, 0, 10, "rounded")
       // Inner hole: starts at (moduleSize, moduleSize) = (10,10), size = 5*moduleSize = 50
-      const secondM = d.indexOf("M", 1);
-      const innerD = d.substring(secondM);
-      const bounds = pathBounds(innerD);
+      const secondM = d.indexOf("M", 1)
+      const innerD = d.substring(secondM)
+      const bounds = pathBounds(innerD)
 
       // Inner rect should be at (10,10) with size 50x50
-      expect(bounds.minX).toBeCloseTo(10, 0);
-      expect(bounds.minY).toBeCloseTo(10, 0);
-      expect(bounds.maxX).toBeCloseTo(60, 0);
-      expect(bounds.maxY).toBeCloseTo(60, 0);
-    });
+      expect(bounds.minX).toBeCloseTo(10, 0)
+      expect(bounds.minY).toBeCloseTo(10, 0)
+      expect(bounds.maxX).toBeCloseTo(60, 0)
+      expect(bounds.maxY).toBeCloseTo(60, 0)
+    })
 
     it("inner hole of extra-rounded shape matches expected dimensions", () => {
-      const d = getFinderOuterPath(0, 0, 10, "extra-rounded");
-      const secondM = d.indexOf("M", 1);
-      const innerD = d.substring(secondM);
-      const bounds = pathBounds(innerD);
+      const d = getFinderOuterPath(0, 0, 10, "extra-rounded")
+      const secondM = d.indexOf("M", 1)
+      const innerD = d.substring(secondM)
+      const bounds = pathBounds(innerD)
 
-      expect(bounds.minX).toBeCloseTo(10, 0);
-      expect(bounds.minY).toBeCloseTo(10, 0);
-      expect(bounds.maxX).toBeCloseTo(60, 0);
-      expect(bounds.maxY).toBeCloseTo(60, 0);
-    });
+      expect(bounds.minX).toBeCloseTo(10, 0)
+      expect(bounds.minY).toBeCloseTo(10, 0)
+      expect(bounds.maxX).toBeCloseTo(60, 0)
+      expect(bounds.maxY).toBeCloseTo(60, 0)
+    })
 
     it("offset finder patterns stay within bounds", () => {
       // Test with non-zero origin to catch offset bugs
-      const ox = 50;
-      const oy = 80;
+      const ox = 50
+      const oy = 80
       for (const shape of ["rounded", "extra-rounded", "classy"] as const) {
-        const d = getFinderOuterPath(ox, oy, moduleSize, shape);
-        const bounds = pathBounds(d);
-        expect(bounds.minX).toBeGreaterThanOrEqual(ox - 0.01);
-        expect(bounds.minY).toBeGreaterThanOrEqual(oy - 0.01);
-        expect(bounds.maxX).toBeLessThanOrEqual(ox + finderSize + 0.01);
-        expect(bounds.maxY).toBeLessThanOrEqual(oy + finderSize + 0.01);
+        const d = getFinderOuterPath(ox, oy, moduleSize, shape)
+        const bounds = pathBounds(d)
+        expect(bounds.minX).toBeGreaterThanOrEqual(ox - 0.01)
+        expect(bounds.minY).toBeGreaterThanOrEqual(oy - 0.01)
+        expect(bounds.maxX).toBeLessThanOrEqual(ox + finderSize + 0.01)
+        expect(bounds.maxY).toBeLessThanOrEqual(oy + finderSize + 0.01)
       }
-    });
-  });
-});
+    })
+  })
+})

--- a/test/renderers-data-uri.test.ts
+++ b/test/renderers-data-uri.test.ts
@@ -1,73 +1,73 @@
-import { describe, expect, it } from "vitest";
-import { svgToDataURI, svgToBase64, svgToBase64Raw } from "../src/renderers/data-uri";
+import { describe, expect, it } from "vitest"
+import { svgToDataURI, svgToBase64, svgToBase64Raw } from "../src/renderers/data-uri"
 
 describe("data URI encoding", () => {
   const svg =
-    '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect fill="#000"/></svg>';
+    '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect fill="#000"/></svg>'
 
   it("creates valid data URI", () => {
-    const uri = svgToDataURI(svg);
-    expect(uri).toMatch(/^data:image\/svg\+xml,/);
-    expect(uri.length).toBeGreaterThan(svg.length);
-  });
+    const uri = svgToDataURI(svg)
+    expect(uri).toMatch(/^data:image\/svg\+xml,/)
+    expect(uri.length).toBeGreaterThan(svg.length)
+  })
 
   it("creates base64 data URI", () => {
-    const uri = svgToBase64(svg);
-    expect(uri).toMatch(/^data:image\/svg\+xml;base64,/);
-  });
+    const uri = svgToBase64(svg)
+    expect(uri).toMatch(/^data:image\/svg\+xml;base64,/)
+  })
 
   it("creates raw base64 string", () => {
-    const b64 = svgToBase64Raw(svg);
-    expect(b64).not.toContain("data:");
+    const b64 = svgToBase64Raw(svg)
+    expect(b64).not.toContain("data:")
     // Should be valid base64 characters
-    expect(b64).toMatch(/^[A-Za-z0-9+/=]+$/);
-  });
+    expect(b64).toMatch(/^[A-Za-z0-9+/=]+$/)
+  })
 
   it("percent-encodes special characters", () => {
-    const uri = svgToDataURI(svg);
-    expect(uri).not.toContain("<svg");
-    expect(uri).toContain("%3C");
-  });
+    const uri = svgToDataURI(svg)
+    expect(uri).not.toContain("<svg")
+    expect(uri).toContain("%3C")
+  })
 
   it("handles UTF-8 content in base64 encoding", () => {
-    const utf8Svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>café über naïve</text></svg>';
-    const uri = svgToBase64(utf8Svg);
-    expect(uri).toMatch(/^data:image\/svg\+xml;base64,/);
+    const utf8Svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>café über naïve</text></svg>'
+    const uri = svgToBase64(utf8Svg)
+    expect(uri).toMatch(/^data:image\/svg\+xml;base64,/)
     // Round-trip: decode and verify the original string is preserved
-    const base64Part = uri.replace("data:image/svg+xml;base64,", "");
+    const base64Part = uri.replace("data:image/svg+xml;base64,", "")
     const decoded = new TextDecoder().decode(
       Uint8Array.from(atob(base64Part), (c) => c.charCodeAt(0)),
-    );
-    expect(decoded).toBe(utf8Svg);
-  });
+    )
+    expect(decoded).toBe(utf8Svg)
+  })
 
   it("handles UTF-8 content in raw base64 encoding", () => {
-    const utf8Svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>résumé</text></svg>';
-    const b64 = svgToBase64Raw(utf8Svg);
-    expect(b64).toMatch(/^[A-Za-z0-9+/=]+$/);
-    const decoded = new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
-    expect(decoded).toBe(utf8Svg);
-  });
+    const utf8Svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>résumé</text></svg>'
+    const b64 = svgToBase64Raw(utf8Svg)
+    expect(b64).toMatch(/^[A-Za-z0-9+/=]+$/)
+    const decoded = new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)))
+    expect(decoded).toBe(utf8Svg)
+  })
 
   it("encodes literal % in SVG content (e.g. width='100%')", () => {
     const svgWithPercent =
-      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#000"/></svg>';
-    const uri = svgToDataURI(svgWithPercent);
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#000"/></svg>'
+    const uri = svgToDataURI(svgWithPercent)
     // Must produce valid percent-encoding — decodeURIComponent must not throw
-    const content = uri.replace("data:image/svg+xml,", "");
-    expect(() => decodeURIComponent(content)).not.toThrow();
-    const decoded = decodeURIComponent(content);
-    expect(decoded).toContain("100%");
-    expect(decoded).toContain("fill='#000'");
-  });
+    const content = uri.replace("data:image/svg+xml,", "")
+    expect(() => decodeURIComponent(content)).not.toThrow()
+    const decoded = decodeURIComponent(content)
+    expect(decoded).toContain("100%")
+    expect(decoded).toContain("fill='#000'")
+  })
 
   it("preserves nested data URIs (e.g. embedded base64 image)", () => {
     const svgWithImage =
-      '<svg xmlns="http://www.w3.org/2000/svg"><image href="data:image/png;base64,iVBORw0KGgo="/></svg>';
-    const uri = svgToDataURI(svgWithImage);
-    const content = uri.replace("data:image/svg+xml,", "");
-    expect(() => decodeURIComponent(content)).not.toThrow();
-    const decoded = decodeURIComponent(content);
-    expect(decoded).toContain("data:image/png;base64,iVBORw0KGgo=");
-  });
-});
+      '<svg xmlns="http://www.w3.org/2000/svg"><image href="data:image/png;base64,iVBORw0KGgo="/></svg>'
+    const uri = svgToDataURI(svgWithImage)
+    const content = uri.replace("data:image/svg+xml,", "")
+    expect(() => decodeURIComponent(content)).not.toThrow()
+    const decoded = decodeURIComponent(content)
+    expect(decoded).toContain("data:image/png;base64,iVBORw0KGgo=")
+  })
+})

--- a/test/renderers-gradient.test.ts
+++ b/test/renderers-gradient.test.ts
@@ -1,20 +1,20 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest"
 import {
   isGradient,
   generateGradientDef,
   resetGradientCounter,
-} from "../src/renderers/svg/gradient";
+} from "../src/renderers/svg/gradient"
 
 describe("gradient utilities", () => {
   beforeEach(() => {
-    resetGradientCounter();
-  });
+    resetGradientCounter()
+  })
 
   it("isGradient returns false for strings", () => {
-    expect(isGradient("#000")).toBe(false);
-    expect(isGradient("red")).toBe(false);
-    expect(isGradient(undefined)).toBe(false);
-  });
+    expect(isGradient("#000")).toBe(false)
+    expect(isGradient("red")).toBe(false)
+    expect(isGradient(undefined)).toBe(false)
+  })
 
   it("isGradient returns true for gradient objects", () => {
     expect(
@@ -25,7 +25,7 @@ describe("gradient utilities", () => {
           { offset: 1, color: "#fff" },
         ],
       }),
-    ).toBe(true);
+    ).toBe(true)
     expect(
       isGradient({
         type: "radial",
@@ -34,8 +34,8 @@ describe("gradient utilities", () => {
           { offset: 1, color: "#fff" },
         ],
       }),
-    ).toBe(true);
-  });
+    ).toBe(true)
+  })
 
   it("generates linear gradient SVG", () => {
     const { id, svg } = generateGradientDef({
@@ -45,16 +45,16 @@ describe("gradient utilities", () => {
         { offset: 0, color: "#ff0000" },
         { offset: 1, color: "#0000ff" },
       ],
-    });
+    })
 
-    expect(id).toBe("etiket-grad-0");
-    expect(svg).toContain("<linearGradient");
-    expect(svg).toContain('id="etiket-grad-0"');
-    expect(svg).toContain("<stop");
-    expect(svg).toContain("#ff0000");
-    expect(svg).toContain("#0000ff");
-    expect(svg).toContain("</linearGradient>");
-  });
+    expect(id).toBe("etiket-grad-0")
+    expect(svg).toContain("<linearGradient")
+    expect(svg).toContain('id="etiket-grad-0"')
+    expect(svg).toContain("<stop")
+    expect(svg).toContain("#ff0000")
+    expect(svg).toContain("#0000ff")
+    expect(svg).toContain("</linearGradient>")
+  })
 
   it("generates radial gradient SVG", () => {
     const { id, svg } = generateGradientDef({
@@ -63,18 +63,18 @@ describe("gradient utilities", () => {
         { offset: 0, color: "#000" },
         { offset: 1, color: "#fff" },
       ],
-    });
+    })
 
-    expect(id).toBe("etiket-grad-0");
-    expect(svg).toContain("<radialGradient");
-    expect(svg).toContain('cx="50%"');
-    expect(svg).toContain("</radialGradient>");
-  });
+    expect(id).toBe("etiket-grad-0")
+    expect(svg).toContain("<radialGradient")
+    expect(svg).toContain('cx="50%"')
+    expect(svg).toContain("</radialGradient>")
+  })
 
   it("increments gradient IDs", () => {
-    const g1 = generateGradientDef({ type: "linear", stops: [{ offset: 0, color: "#000" }] });
-    const g2 = generateGradientDef({ type: "linear", stops: [{ offset: 0, color: "#000" }] });
-    expect(g1.id).toBe("etiket-grad-0");
-    expect(g2.id).toBe("etiket-grad-1");
-  });
-});
+    const g1 = generateGradientDef({ type: "linear", stops: [{ offset: 0, color: "#000" }] })
+    const g2 = generateGradientDef({ type: "linear", stops: [{ offset: 0, color: "#000" }] })
+    expect(g1.id).toBe("etiket-grad-0")
+    expect(g2.id).toBe("etiket-grad-1")
+  })
+})

--- a/test/renderers-logo.test.ts
+++ b/test/renderers-logo.test.ts
@@ -1,55 +1,55 @@
-import { describe, expect, it } from "vitest";
-import { renderQRCodeSVG } from "../src/renderers/svg/qr";
+import { describe, expect, it } from "vitest"
+import { renderQRCodeSVG } from "../src/renderers/svg/qr"
 
 function uint8ToBase64(data: Uint8Array): string {
-  let binary = "";
-  for (let i = 0; i < data.length; i++) binary += String.fromCharCode(data[i]!);
-  return btoa(binary);
+  let binary = ""
+  for (let i = 0; i < data.length; i++) binary += String.fromCharCode(data[i]!)
+  return btoa(binary)
 }
 
 /** Create a minimal valid ICO file with a single 32bpp entry */
 function createTestICO(width: number, height: number, r: number, g: number, b: number): Uint8Array {
-  const bpp = 32;
-  const pixelDataSize = width * height * 4;
-  const andMaskRowStride = Math.ceil(width / 32) * 4;
-  const andMaskSize = andMaskRowStride * height;
-  const headerSize = 40;
-  const imageSize = headerSize + pixelDataSize + andMaskSize;
-  const totalSize = 6 + 16 + imageSize;
+  const bpp = 32
+  const pixelDataSize = width * height * 4
+  const andMaskRowStride = Math.ceil(width / 32) * 4
+  const andMaskSize = andMaskRowStride * height
+  const headerSize = 40
+  const imageSize = headerSize + pixelDataSize + andMaskSize
+  const totalSize = 6 + 16 + imageSize
 
-  const buf = new Uint8Array(totalSize);
-  const view = new DataView(buf.buffer);
+  const buf = new Uint8Array(totalSize)
+  const view = new DataView(buf.buffer)
 
-  view.setUint16(0, 0, true);
-  view.setUint16(2, 1, true);
-  view.setUint16(4, 1, true);
+  view.setUint16(0, 0, true)
+  view.setUint16(2, 1, true)
+  view.setUint16(4, 1, true)
 
-  buf[6] = width < 256 ? width : 0;
-  buf[7] = height < 256 ? height : 0;
-  view.setUint16(10, 1, true);
-  view.setUint16(12, bpp, true);
-  view.setUint32(14, imageSize, true);
-  view.setUint32(18, 22, true);
+  buf[6] = width < 256 ? width : 0
+  buf[7] = height < 256 ? height : 0
+  view.setUint16(10, 1, true)
+  view.setUint16(12, bpp, true)
+  view.setUint32(14, imageSize, true)
+  view.setUint32(18, 22, true)
 
-  const imgOff = 22;
-  view.setUint32(imgOff, headerSize, true);
-  view.setInt32(imgOff + 4, width, true);
-  view.setInt32(imgOff + 8, height * 2, true);
-  view.setUint16(imgOff + 12, 1, true);
-  view.setUint16(imgOff + 14, bpp, true);
+  const imgOff = 22
+  view.setUint32(imgOff, headerSize, true)
+  view.setInt32(imgOff + 4, width, true)
+  view.setInt32(imgOff + 8, height * 2, true)
+  view.setUint16(imgOff + 12, 1, true)
+  view.setUint16(imgOff + 14, bpp, true)
 
-  const pixelOff = imgOff + headerSize;
+  const pixelOff = imgOff + headerSize
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const i = pixelOff + (y * width + x) * 4;
-      buf[i] = b;
-      buf[i + 1] = g;
-      buf[i + 2] = r;
-      buf[i + 3] = 255;
+      const i = pixelOff + (y * width + x) * 4
+      buf[i] = b
+      buf[i + 1] = g
+      buf[i + 2] = r
+      buf[i + 3] = 255
     }
   }
 
-  return buf;
+  return buf
 }
 
 const matrix: boolean[][] = [
@@ -58,112 +58,112 @@ const matrix: boolean[][] = [
   [true, false, true, false, true],
   [false, true, false, true, false],
   [true, false, true, false, true],
-];
+]
 
 describe("QR logo embedding", () => {
   it("embeds inline SVG logo", () => {
     const svg = renderQRCodeSVG(matrix, {
       logo: { svg: '<circle r="0.5" fill="red"/>' },
-    });
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("circle");
-  });
+    })
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("circle")
+  })
 
   it("embeds SVG path logo", () => {
     const svg = renderQRCodeSVG(matrix, {
       logo: { path: "M10 10 L90 10 L90 90 L10 90 Z" },
-    });
-    expect(svg).toContain("M10 10");
-  });
+    })
+    expect(svg).toContain("M10 10")
+  })
 
   it("embeds image via data URI", () => {
-    const dataUri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==";
+    const dataUri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="
     const svg = renderQRCodeSVG(matrix, {
       logo: { imageUrl: dataUri },
-    });
-    expect(svg).toContain("<image");
-    expect(svg).toContain('href="data:image/png;base64,');
-  });
+    })
+    expect(svg).toContain("<image")
+    expect(svg).toContain('href="data:image/png;base64,')
+  })
 
   it("embeds image via URL", () => {
     const svg = renderQRCodeSVG(matrix, {
       logo: { imageUrl: "https://example.com/logo.png", imageWidth: 40, imageHeight: 40 },
-    });
-    expect(svg).toContain("<image");
-    expect(svg).toContain("https://example.com/logo.png");
-    expect(svg).toContain('width="40"');
-    expect(svg).toContain('height="40"');
-  });
+    })
+    expect(svg).toContain("<image")
+    expect(svg).toContain("https://example.com/logo.png")
+    expect(svg).toContain('width="40"')
+    expect(svg).toContain('height="40"')
+  })
 
   it("rejects imageUrl with dangerous scheme", () => {
     expect(() =>
       renderQRCodeSVG(matrix, {
         logo: { imageUrl: "javascript:alert(1)" },
       }),
-    ).toThrow("imageUrl must use https:, http:, or data:image/ scheme");
-  });
+    ).toThrow("imageUrl must use https:, http:, or data:image/ scheme")
+  })
 
   it("escapes imageUrl to prevent injection", () => {
     const svg = renderQRCodeSVG(matrix, {
       logo: { imageUrl: 'https://example.com/logo.png" onload="alert(1)' },
-    });
+    })
     // The quote should be escaped so the attribute boundary is preserved
-    expect(svg).not.toContain('href="https://example.com/logo.png"');
-    expect(svg).toContain("&quot;");
-  });
+    expect(svg).not.toContain('href="https://example.com/logo.png"')
+    expect(svg).toContain("&quot;")
+  })
 
   it("rejects inline SVG with script tags", () => {
     expect(() =>
       renderQRCodeSVG(matrix, {
         logo: { svg: "<script>alert(1)</script>" },
       }),
-    ).toThrow("potentially dangerous content");
-  });
+    ).toThrow("potentially dangerous content")
+  })
 
   it("rejects inline SVG with event handlers", () => {
     expect(() =>
       renderQRCodeSVG(matrix, {
         logo: { svg: '<circle r="1" onload="alert(1)"/>' },
       }),
-    ).toThrow("potentially dangerous content");
-  });
+    ).toThrow("potentially dangerous content")
+  })
 
   it("auto-converts ICO logo to PNG", () => {
     // Create minimal valid 1x1 32bpp ICO
-    const ico = createTestICO(1, 1, 255, 0, 0);
-    const icoUri = `data:image/x-icon;base64,${uint8ToBase64(ico)}`;
+    const ico = createTestICO(1, 1, 255, 0, 0)
+    const icoUri = `data:image/x-icon;base64,${uint8ToBase64(ico)}`
     const svg = renderQRCodeSVG(matrix, {
       logo: { imageUrl: icoUri },
-    });
-    expect(svg).toContain("<image");
-    expect(svg).toContain("data:image/png;base64,");
-    expect(svg).not.toContain("x-icon");
-  });
+    })
+    expect(svg).toContain("<image")
+    expect(svg).toContain("data:image/png;base64,")
+    expect(svg).not.toContain("x-icon")
+  })
 
   it("auto-converts vnd.microsoft.icon logo to PNG", () => {
-    const ico = createTestICO(1, 1, 0, 0, 255);
-    const icoUri = `data:image/vnd.microsoft.icon;base64,${uint8ToBase64(ico)}`;
+    const ico = createTestICO(1, 1, 0, 0, 255)
+    const icoUri = `data:image/vnd.microsoft.icon;base64,${uint8ToBase64(ico)}`
     const svg = renderQRCodeSVG(matrix, {
       logo: { imageUrl: icoUri },
-    });
-    expect(svg).toContain("data:image/png;base64,");
-  });
+    })
+    expect(svg).toContain("data:image/png;base64,")
+  })
 
   it("adds background behind logo", () => {
     const svg = renderQRCodeSVG(matrix, {
       logo: { imageUrl: "data:image/png;base64,abc", backgroundColor: "#fff" },
-    });
-    expect(svg).toContain('fill="#fff"');
-  });
+    })
+    expect(svg).toContain('fill="#fff"')
+  })
 
   it("hides background dots by default", () => {
     const withLogo = renderQRCodeSVG(matrix, {
       logo: { imageUrl: "data:image/png;base64,abc", size: 0.5 },
-    });
-    const withoutLogo = renderQRCodeSVG(matrix);
+    })
+    const withoutLogo = renderQRCodeSVG(matrix)
     // With logo should have fewer path segments (dots hidden)
-    const withCount = (withLogo.match(/M/g) || []).length;
-    const withoutCount = (withoutLogo.match(/M/g) || []).length;
-    expect(withCount).toBeLessThanOrEqual(withoutCount);
-  });
-});
+    const withCount = (withLogo.match(/M/g) || []).length
+    const withoutCount = (withoutLogo.match(/M/g) || []).length
+    expect(withCount).toBeLessThanOrEqual(withoutCount)
+  })
+})

--- a/test/renderers-optimize.test.ts
+++ b/test/renderers-optimize.test.ts
@@ -1,49 +1,49 @@
-import { describe, expect, it } from "vitest";
-import { optimizeSVG } from "../src/renderers/svg/optimize";
+import { describe, expect, it } from "vitest"
+import { optimizeSVG } from "../src/renderers/svg/optimize"
 
 describe("SVG optimization", () => {
   it("rounds decimals to specified precision", () => {
-    const input = '<path d="M1.123456,2.654321h3.999999"/>';
-    const result = optimizeSVG(input, { precision: 2 });
-    expect(result).toContain("1.12");
-    expect(result).toContain("2.65");
-    expect(result).not.toContain("1.123456");
-  });
+    const input = '<path d="M1.123456,2.654321h3.999999"/>'
+    const result = optimizeSVG(input, { precision: 2 })
+    expect(result).toContain("1.12")
+    expect(result).toContain("2.65")
+    expect(result).not.toContain("1.123456")
+  })
 
   it("removes trailing zeros", () => {
-    const input = '<rect x="4.000000" y="8.100000"/>';
-    const result = optimizeSVG(input, { precision: 2 });
-    expect(result).toContain('"4"');
-    expect(result).toContain('"8.1"');
-  });
+    const input = '<rect x="4.000000" y="8.100000"/>'
+    const result = optimizeSVG(input, { precision: 2 })
+    expect(result).toContain('"4"')
+    expect(result).toContain('"8.1"')
+  })
 
   it("responsive mode removes width/height", () => {
-    const input = '<svg viewBox="0 0 200 100" width="200" height="100">';
-    const result = optimizeSVG(input, { responsive: true });
-    expect(result).toContain("viewBox");
-    expect(result).not.toMatch(/ width="/);
-    expect(result).not.toMatch(/ height="/);
-  });
+    const input = '<svg viewBox="0 0 200 100" width="200" height="100">'
+    const result = optimizeSVG(input, { responsive: true })
+    expect(result).toContain("viewBox")
+    expect(result).not.toMatch(/ width="/)
+    expect(result).not.toMatch(/ height="/)
+  })
 
   it("keeps width/height by default", () => {
-    const input = '<svg viewBox="0 0 200 100" width="200" height="100">';
-    const result = optimizeSVG(input);
-    expect(result).toContain('width="200"');
-    expect(result).toContain('height="100"');
-  });
+    const input = '<svg viewBox="0 0 200 100" width="200" height="100">'
+    const result = optimizeSVG(input)
+    expect(result).toContain('width="200"')
+    expect(result).toContain('height="100"')
+  })
 
   it("default precision is 2", () => {
-    const input = "M1.23456789";
-    const result = optimizeSVG(input);
-    expect(result).toBe("M1.23");
-  });
+    const input = "M1.23456789"
+    const result = optimizeSVG(input)
+    expect(result).toBe("M1.23")
+  })
 
   it("works with real QR SVG output", () => {
     const input =
-      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200"><path d="M6.896551724137931,6.896551724137931h6.896551724137931v6.896551724137931h-6.896551724137931z"/></svg>';
-    const result = optimizeSVG(input, { precision: 1, responsive: true });
-    expect(result).not.toContain("6.896551724137931");
-    expect(result).toContain("6.9");
-    expect(result).not.toMatch(/ width="/);
-  });
-});
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200"><path d="M6.896551724137931,6.896551724137931h6.896551724137931v6.896551724137931h-6.896551724137931z"/></svg>'
+    const result = optimizeSVG(input, { precision: 1, responsive: true })
+    expect(result).not.toContain("6.896551724137931")
+    expect(result).toContain("6.9")
+    expect(result).not.toMatch(/ width="/)
+  })
+})

--- a/test/renderers-postal.test.ts
+++ b/test/renderers-postal.test.ts
@@ -1,129 +1,129 @@
-import { describe, expect, it } from "vitest";
-import { renderPostalSVG } from "../src/renderers/svg/postal";
-import { renderPostalRaster, renderPostalPNG } from "../src/renderers/png/rasterize";
-import { encodePostal, postal, postalDataURI, postalBase64 } from "../src/_postal";
-import { postalPNG, postalPNGDataURI } from "../src/_png";
-import { barcode, encodeBars } from "../src/_barcode";
-import { encodePOSTNET, encodePLANET } from "../src/encoders/postnet";
-import { encodeRM4SCC } from "../src/encoders/fourstate";
-import type { FourState } from "../src/encoders/fourstate";
+import { describe, expect, it } from "vitest"
+import { renderPostalSVG } from "../src/renderers/svg/postal"
+import { renderPostalRaster, renderPostalPNG } from "../src/renderers/png/rasterize"
+import { encodePostal, postal, postalDataURI, postalBase64 } from "../src/_postal"
+import { postalPNG, postalPNGDataURI } from "../src/_png"
+import { barcode, encodeBars } from "../src/_barcode"
+import { encodePOSTNET, encodePLANET } from "../src/encoders/postnet"
+import { encodeRM4SCC } from "../src/encoders/fourstate"
+import type { FourState } from "../src/encoders/fourstate"
 
 /** Extract every <path d="..."> rect as {x, y, w, h} from a postal SVG. */
 function parseBars(svg: string): Array<{ x: number; y: number; w: number; h: number }> {
-  const match = /<path d="([^"]+)"/.exec(svg);
-  if (!match) return [];
-  const bars: Array<{ x: number; y: number; w: number; h: number }> = [];
-  const re = /M([\d.-]+),([\d.-]+)h([\d.-]+)v([\d.-]+)h-[\d.-]+z/g;
-  let m: RegExpExecArray | null;
+  const match = /<path d="([^"]+)"/.exec(svg)
+  if (!match) return []
+  const bars: Array<{ x: number; y: number; w: number; h: number }> = []
+  const re = /M([\d.-]+),([\d.-]+)h([\d.-]+)v([\d.-]+)h-[\d.-]+z/g
+  let m: RegExpExecArray | null
   while ((m = re.exec(match[1]!)) !== null) {
-    bars.push({ x: Number(m[1]), y: Number(m[2]), w: Number(m[3]), h: Number(m[4]) });
+    bars.push({ x: Number(m[1]), y: Number(m[2]), w: Number(m[3]), h: Number(m[4]) })
   }
-  return bars;
+  return bars
 }
 
 describe("renderPostalSVG — 2-state (POSTNET/PLANET)", () => {
   it("renders one bar per encoded height", () => {
-    const bars = encodePOSTNET("12345");
-    const svg = renderPostalSVG(bars);
-    expect(parseBars(svg)).toHaveLength(bars.length);
-  });
+    const bars = encodePOSTNET("12345")
+    const svg = renderPostalSVG(bars)
+    expect(parseBars(svg)).toHaveLength(bars.length)
+  })
 
   it("gives tall bars full height and short bars the short fraction", () => {
-    const heights = encodePOSTNET("12345");
-    const svg = renderPostalSVG(heights, { height: 100, shortRatio: 0.4 });
-    const drawn = parseBars(svg);
+    const heights = encodePOSTNET("12345")
+    const svg = renderPostalSVG(heights, { height: 100, shortRatio: 0.4 })
+    const drawn = parseBars(svg)
 
     for (const [i, h] of heights.entries()) {
-      expect(drawn[i]!.h).toBeCloseTo(h === 1 ? 100 : 40, 3);
+      expect(drawn[i]!.h).toBeCloseTo(h === 1 ? 100 : 40, 3)
     }
-  });
+  })
 
   it("aligns tall and short bars on a common baseline", () => {
-    const heights = encodePOSTNET("12345");
-    const svg = renderPostalSVG(heights, { height: 100, margin: 10 });
-    const drawn = parseBars(svg);
+    const heights = encodePOSTNET("12345")
+    const svg = renderPostalSVG(heights, { height: 100, margin: 10 })
+    const drawn = parseBars(svg)
     for (const bar of drawn) {
-      expect(bar.y + bar.h).toBeCloseTo(110, 3);
+      expect(bar.y + bar.h).toBeCloseTo(110, 3)
     }
-  });
+  })
 
   it("recovers the original heights from the rendered geometry", () => {
-    const heights = encodePOSTNET("123456789");
-    const svg = renderPostalSVG(heights, { height: 100 });
-    const recovered = parseBars(svg).map((b) => (b.h > 50 ? 1 : 0));
-    expect(recovered).toEqual(heights);
-  });
+    const heights = encodePOSTNET("123456789")
+    const svg = renderPostalSVG(heights, { height: 100 })
+    const recovered = parseBars(svg).map((b) => (b.h > 50 ? 1 : 0))
+    expect(recovered).toEqual(heights)
+  })
 
   it("distinguishes POSTNET from PLANET (inverted heights)", () => {
-    const zip = "12345678901";
-    const postnet = renderPostalSVG(encodePOSTNET(zip), { height: 100 });
-    const planet = renderPostalSVG(encodePLANET(zip), { height: 100 });
-    expect(postnet).not.toBe(planet);
-  });
+    const zip = "12345678901"
+    const postnet = renderPostalSVG(encodePOSTNET(zip), { height: 100 })
+    const planet = renderPostalSVG(encodePLANET(zip), { height: 100 })
+    expect(postnet).not.toBe(planet)
+  })
 
   it("spaces bars on the configured pitch", () => {
-    const svg = renderPostalSVG(encodePOSTNET("12345"), { barWidth: 2, pitch: 5, margin: 10 });
-    const drawn = parseBars(svg);
-    expect(drawn[0]!.x).toBe(10);
-    expect(drawn[1]!.x).toBe(15);
-    expect(drawn[2]!.x).toBe(20);
-    expect(drawn[0]!.w).toBe(2);
-  });
+    const svg = renderPostalSVG(encodePOSTNET("12345"), { barWidth: 2, pitch: 5, margin: 10 })
+    const drawn = parseBars(svg)
+    expect(drawn[0]!.x).toBe(10)
+    expect(drawn[1]!.x).toBe(15)
+    expect(drawn[2]!.x).toBe(20)
+    expect(drawn[0]!.w).toBe(2)
+  })
 
   it("defaults pitch to twice the bar width", () => {
-    const drawn = parseBars(renderPostalSVG(encodePOSTNET("12345"), { barWidth: 3, margin: 0 }));
-    expect(drawn[1]!.x - drawn[0]!.x).toBe(6);
-  });
-});
+    const drawn = parseBars(renderPostalSVG(encodePOSTNET("12345"), { barWidth: 3, margin: 0 }))
+    expect(drawn[1]!.x - drawn[0]!.x).toBe(6)
+  })
+})
 
 describe("renderPostalSVG — 4-state", () => {
-  const ALL: FourState[] = ["T", "A", "D", "F"];
+  const ALL: FourState[] = ["T", "A", "D", "F"]
 
   it("renders the four bar states at distinct vertical extents", () => {
-    const svg = renderPostalSVG(ALL, { height: 90, margin: 0, trackerRatio: 1 / 3 });
-    const [t, a, d, f] = parseBars(svg);
+    const svg = renderPostalSVG(ALL, { height: 90, margin: 0, trackerRatio: 1 / 3 })
+    const [t, a, d, f] = parseBars(svg)
 
     // Tracker: centre band only
-    expect(t!.y).toBeCloseTo(30, 3);
-    expect(t!.h).toBeCloseTo(30, 3);
+    expect(t!.y).toBeCloseTo(30, 3)
+    expect(t!.h).toBeCloseTo(30, 3)
     // Ascender: top through centre
-    expect(a!.y).toBeCloseTo(0, 3);
-    expect(a!.h).toBeCloseTo(60, 3);
+    expect(a!.y).toBeCloseTo(0, 3)
+    expect(a!.h).toBeCloseTo(60, 3)
     // Descender: centre through bottom
-    expect(d!.y).toBeCloseTo(30, 3);
-    expect(d!.h).toBeCloseTo(60, 3);
+    expect(d!.y).toBeCloseTo(30, 3)
+    expect(d!.h).toBeCloseTo(60, 3)
     // Full: entire height
-    expect(f!.y).toBeCloseTo(0, 3);
-    expect(f!.h).toBeCloseTo(90, 3);
-  });
+    expect(f!.y).toBeCloseTo(0, 3)
+    expect(f!.h).toBeCloseTo(90, 3)
+  })
 
   it("recovers bar states from the rendered geometry", () => {
-    const bars = encodeRM4SCC("SN34RD1A");
-    const svg = renderPostalSVG(bars, { height: 90, margin: 0 });
+    const bars = encodeRM4SCC("SN34RD1A")
+    const svg = renderPostalSVG(bars, { height: 90, margin: 0 })
     const recovered = parseBars(svg).map((b): FourState => {
-      const top = b.y < 15;
-      const bottom = b.y + b.h > 75;
-      if (top && bottom) return "F";
-      if (top) return "A";
-      if (bottom) return "D";
-      return "T";
-    });
-    expect(recovered).toEqual(bars);
-  });
+      const top = b.y < 15
+      const bottom = b.y + b.h > 75
+      if (top && bottom) return "F"
+      if (top) return "A"
+      if (bottom) return "D"
+      return "T"
+    })
+    expect(recovered).toEqual(bars)
+  })
 
   it("honours trackerRatio", () => {
-    const svg = renderPostalSVG(["T"], { height: 100, margin: 0, trackerRatio: 0.5 });
-    const [t] = parseBars(svg);
-    expect(t!.h).toBeCloseTo(50, 3);
-    expect(t!.y).toBeCloseTo(25, 3);
-  });
+    const svg = renderPostalSVG(["T"], { height: 100, margin: 0, trackerRatio: 0.5 })
+    const [t] = parseBars(svg)
+    expect(t!.h).toBeCloseTo(50, 3)
+    expect(t!.y).toBeCloseTo(25, 3)
+  })
 
   it("detects the 4-state family even when the first bar is a tracker", () => {
-    const svg = renderPostalSVG(["T", "T", "A"], { height: 90, margin: 0 });
-    const [first] = parseBars(svg);
-    expect(first!.h).toBeCloseTo(30, 3);
-  });
-});
+    const svg = renderPostalSVG(["T", "T", "A"], { height: 90, margin: 0 })
+    const [first] = parseBars(svg)
+    expect(first!.h).toBeCloseTo(30, 3)
+  })
+})
 
 describe("renderPostalSVG — output shape", () => {
   it("produces a well-formed SVG with computed dimensions", () => {
@@ -132,26 +132,26 @@ describe("renderPostalSVG — output shape", () => {
       pitch: 4,
       height: 40,
       margin: 10,
-    });
-    const bars = encodePOSTNET("12345").length;
-    const width = (bars - 1) * 4 + 2 + 20;
-    expect(svg).toContain(`viewBox="0 0 ${width} 60"`);
-    expect(svg).toContain(`width="${width}"`);
-    expect(svg.startsWith("<svg")).toBe(true);
-    expect(svg.endsWith("</svg>")).toBe(true);
-  });
+    })
+    const bars = encodePOSTNET("12345").length
+    const width = (bars - 1) * 4 + 2 + 20
+    expect(svg).toContain(`viewBox="0 0 ${width} 60"`)
+    expect(svg).toContain(`width="${width}"`)
+    expect(svg.startsWith("<svg")).toBe(true)
+    expect(svg.endsWith("</svg>")).toBe(true)
+  })
 
   it("omits the background rect when transparent", () => {
-    const svg = renderPostalSVG(["A", "F"], { background: "transparent" });
-    expect(svg).not.toContain("<rect");
-  });
+    const svg = renderPostalSVG(["A", "F"], { background: "transparent" })
+    expect(svg).not.toContain("<rect")
+  })
 
   it("applies colors and measurement units", () => {
-    const svg = renderPostalSVG(["A", "F"], { color: "#f00", background: "#eee", unit: "mm" });
-    expect(svg).toContain('fill="#f00"');
-    expect(svg).toContain('fill="#eee"');
-    expect(svg).toContain('mm"');
-  });
+    const svg = renderPostalSVG(["A", "F"], { color: "#f00", background: "#eee", unit: "mm" })
+    expect(svg).toContain('fill="#f00"')
+    expect(svg).toContain('fill="#eee"')
+    expect(svg).toContain('mm"')
+  })
 
   it("supports accessibility metadata", () => {
     const svg = renderPostalSVG(["A", "F"], {
@@ -159,28 +159,28 @@ describe("renderPostalSVG — output shape", () => {
       title: "Title",
       desc: "Desc",
       role: "graphics-symbol",
-    });
-    expect(svg).toContain('aria-label="postal code"');
-    expect(svg).toContain("<title>Title</title>");
-    expect(svg).toContain("<desc>Desc</desc>");
-    expect(svg).toContain('role="graphics-symbol"');
-  });
+    })
+    expect(svg).toContain('aria-label="postal code"')
+    expect(svg).toContain("<title>Title</title>")
+    expect(svg).toContain("<desc>Desc</desc>")
+    expect(svg).toContain('role="graphics-symbol"')
+  })
 
   it("escapes text content", () => {
-    const svg = renderPostalSVG(["A"], { showText: true, text: "<a & b>" });
-    expect(svg).toContain("&lt;a &amp; b&gt;");
-  });
+    const svg = renderPostalSVG(["A"], { showText: true, text: "<a & b>" })
+    expect(svg).toContain("&lt;a &amp; b&gt;")
+  })
 
   it("renders human-readable text when requested", () => {
-    const svg = renderPostalSVG(encodePOSTNET("12345"), { showText: true, text: "12345" });
-    expect(svg).toContain(">12345</text>");
-  });
+    const svg = renderPostalSVG(encodePOSTNET("12345"), { showText: true, text: "12345" })
+    expect(svg).toContain(">12345</text>")
+  })
 
   it("handles an empty bar list", () => {
-    const svg = renderPostalSVG([]);
-    expect(svg).toContain("<svg");
-    expect(svg).not.toContain("<path");
-  });
+    const svg = renderPostalSVG([])
+    expect(svg).toContain("<svg")
+    expect(svg).not.toContain("<path")
+  })
 
   it("supports per-side margins", () => {
     const svg = renderPostalSVG(["A"], {
@@ -190,61 +190,61 @@ describe("renderPostalSVG — output shape", () => {
       marginBottom: 13,
       barWidth: 2,
       height: 40,
-    });
-    const [bar] = parseBars(svg);
-    expect(bar!.x).toBe(5);
-    expect(bar!.y).toBe(7);
-    expect(svg).toContain(`viewBox="0 0 ${5 + 2 + 11} ${40 + 7 + 13}"`);
-  });
-});
+    })
+    const [bar] = parseBars(svg)
+    expect(bar!.x).toBe(5)
+    expect(bar!.y).toBe(7)
+    expect(svg).toContain(`viewBox="0 0 ${5 + 2 + 11} ${40 + 7 + 13}"`)
+  })
+})
 
 describe("encodePostal", () => {
   it("encodes each supported symbology", () => {
-    expect(encodePostal("12345", { type: "postnet" }).length).toBeGreaterThan(0);
-    expect(encodePostal("12345678901", { type: "planet" }).length).toBeGreaterThan(0);
-    expect(encodePostal("SN34RD1A", { type: "rm4scc" })).toContain("F");
-    expect(encodePostal("2500GG", { type: "kix" }).length).toBe(24);
-    expect(encodePostal("12345678", { type: "auspost", fcc: "11" }).length).toBeGreaterThan(0);
-    expect(encodePostal("1234567", { type: "jppost" }).length).toBeGreaterThan(0);
-    expect(encodePostal("01234567094987654321", { type: "imb" }).length).toBe(65);
-  });
+    expect(encodePostal("12345", { type: "postnet" }).length).toBeGreaterThan(0)
+    expect(encodePostal("12345678901", { type: "planet" }).length).toBeGreaterThan(0)
+    expect(encodePostal("SN34RD1A", { type: "rm4scc" })).toContain("F")
+    expect(encodePostal("2500GG", { type: "kix" }).length).toBe(24)
+    expect(encodePostal("12345678", { type: "auspost", fcc: "11" }).length).toBeGreaterThan(0)
+    expect(encodePostal("1234567", { type: "jppost" }).length).toBeGreaterThan(0)
+    expect(encodePostal("01234567094987654321", { type: "imb" }).length).toBe(65)
+  })
 
   it("defaults to postnet", () => {
-    expect(encodePostal("12345")).toEqual(encodePOSTNET("12345"));
-  });
+    expect(encodePostal("12345")).toEqual(encodePOSTNET("12345"))
+  })
 
   it("passes the routing code through to IMb", () => {
     const withRouting = encodePostal("01234567094987654321", {
       type: "imb",
       routingCode: "01234567891",
-    });
-    const without = encodePostal("01234567094987654321", { type: "imb" });
-    expect(withRouting).not.toEqual(without);
-  });
+    })
+    const without = encodePostal("01234567094987654321", { type: "imb" })
+    expect(withRouting).not.toEqual(without)
+  })
 
   it("passes the address through to Japan Post", () => {
-    const withAddr = encodePostal("1234567", { type: "jppost", routingCode: "1-2-3" });
-    const without = encodePostal("1234567", { type: "jppost" });
-    expect(withAddr).not.toEqual(without);
-  });
+    const withAddr = encodePostal("1234567", { type: "jppost", routingCode: "1-2-3" })
+    const without = encodePostal("1234567", { type: "jppost" })
+    expect(withAddr).not.toEqual(without)
+  })
 
   it("uses the Australia Post format control code", () => {
-    const fcc11 = encodePostal("12345678", { type: "auspost", fcc: "11" });
-    const fcc59 = encodePostal("12345678", { type: "auspost", fcc: "59" });
-    expect(fcc11).not.toEqual(fcc59);
-  });
+    const fcc11 = encodePostal("12345678", { type: "auspost", fcc: "11" })
+    const fcc59 = encodePostal("12345678", { type: "auspost", fcc: "59" })
+    expect(fcc11).not.toEqual(fcc59)
+  })
 
   it("rejects an unknown type", () => {
     expect(() => encodePostal("12345", { type: "nope" as "postnet" })).toThrow(
       /Unsupported postal type/,
-    );
-  });
+    )
+  })
 
   it("propagates encoder validation errors", () => {
-    expect(() => encodePostal("ABC", { type: "postnet" })).toThrow();
-    expect(() => encodePostal("123", { type: "auspost" })).toThrow();
-  });
-});
+    expect(() => encodePostal("ABC", { type: "postnet" })).toThrow()
+    expect(() => encodePostal("123", { type: "auspost" })).toThrow()
+  })
+})
 
 describe("postal()", () => {
   it("renders SVG for each symbology", () => {
@@ -257,72 +257,72 @@ describe("postal()", () => {
       ["jppost", "1234567"],
       ["imb", "01234567094987654321"],
     ] as const) {
-      const svg = postal(text, { type });
-      expect(svg, type).toContain("<svg");
-      expect(svg, type).toContain("<path");
+      const svg = postal(text, { type })
+      expect(svg, type).toContain("<svg")
+      expect(svg, type).toContain("<path")
     }
-  });
+  })
 
   it("does not leak encoding options into SVG attributes", () => {
-    const svg = postal("01234567094987654321", { type: "imb", routingCode: "01234567891" });
-    expect(svg).not.toContain("routingCode");
-    expect(svg).not.toContain("type=");
-  });
+    const svg = postal("01234567094987654321", { type: "imb", routingCode: "01234567891" })
+    expect(svg).not.toContain("routingCode")
+    expect(svg).not.toContain("type=")
+  })
 
   it("produces data URI and base64 variants", () => {
-    expect(postalDataURI("12345", { type: "postnet" })).toMatch(/^data:image\/svg\+xml/);
-    expect(postalBase64("12345", { type: "postnet" })).toMatch(/^data:image\/svg\+xml;base64,/);
-  });
-});
+    expect(postalDataURI("12345", { type: "postnet" })).toMatch(/^data:image\/svg\+xml/)
+    expect(postalBase64("12345", { type: "postnet" })).toMatch(/^data:image\/svg\+xml;base64,/)
+  })
+})
 
 describe("barcode() postal integration", () => {
   it("renders POSTNET with height modulation rather than flat bars", () => {
-    const svg = barcode("12345", { type: "postnet", height: 100 });
-    const heights = new Set(parseBars(svg).map((b) => b.h));
+    const svg = barcode("12345", { type: "postnet", height: 100 })
+    const heights = new Set(parseBars(svg).map((b) => b.h))
     // A meaningful POSTNET has both tall and short bars
-    expect(heights.size).toBe(2);
-  });
+    expect(heights.size).toBe(2)
+  })
 
   it("matches the dedicated postal() renderer", () => {
-    expect(barcode("12345", { type: "postnet" })).toBe(postal("12345", { type: "postnet" }));
-  });
+    expect(barcode("12345", { type: "postnet" })).toBe(postal("12345", { type: "postnet" }))
+  })
 
   it("renders PLANET too", () => {
-    const svg = barcode("12345678901", { type: "planet", height: 100 });
-    expect(new Set(parseBars(svg).map((b) => b.h)).size).toBe(2);
-  });
+    const svg = barcode("12345678901", { type: "planet", height: 100 })
+    expect(new Set(parseBars(svg).map((b) => b.h)).size).toBe(2)
+  })
 
   it("directs encodeBars() callers to the postal API", () => {
-    expect(() => encodeBars("12345", { type: "postnet" })).toThrow(/encodePostal/);
-    expect(() => encodeBars("12345678901", { type: "planet" })).toThrow(/encodePostal/);
-  });
-});
+    expect(() => encodeBars("12345", { type: "postnet" })).toThrow(/encodePostal/)
+    expect(() => encodeBars("12345678901", { type: "planet" })).toThrow(/encodePostal/)
+  })
+})
 
 describe("postal PNG", () => {
   it("rasterizes 2-state bars with the correct dimensions", () => {
-    const bars = encodePOSTNET("12345");
-    const raster = renderPostalRaster(bars, { scale: 2, pitch: 4, height: 40, margin: 10 });
-    expect(raster.width).toBe((bars.length - 1) * 4 + 2 + 20);
-    expect(raster.height).toBe(60);
-    expect(raster.rows).toHaveLength(60);
-  });
+    const bars = encodePOSTNET("12345")
+    const raster = renderPostalRaster(bars, { scale: 2, pitch: 4, height: 40, margin: 10 })
+    expect(raster.width).toBe((bars.length - 1) * 4 + 2 + 20)
+    expect(raster.height).toBe(60)
+    expect(raster.rows).toHaveLength(60)
+  })
 
   it("rasterizes tall bars taller than short bars", () => {
-    const heights = encodePOSTNET("12345");
-    const raster = renderPostalRaster(heights, { scale: 2, pitch: 4, height: 40, margin: 0 });
+    const heights = encodePOSTNET("12345")
+    const raster = renderPostalRaster(heights, { scale: 2, pitch: 4, height: 40, margin: 0 })
 
     const columnHeight = (barIndex: number): number => {
-      let count = 0;
+      let count = 0
       for (const row of raster.rows) {
-        if (row[barIndex * 4]) count++;
+        if (row[barIndex * 4]) count++
       }
-      return count;
-    };
+      return count
+    }
 
     for (const [i, h] of heights.entries()) {
-      expect(columnHeight(i)).toBe(h === 1 ? 40 : 16);
+      expect(columnHeight(i)).toBe(h === 1 ? 40 : 16)
     }
-  });
+  })
 
   it("rasterizes the four bar states distinctly", () => {
     const raster = renderPostalRaster(["T", "A", "D", "F"], {
@@ -330,37 +330,37 @@ describe("postal PNG", () => {
       pitch: 4,
       height: 90,
       margin: 0,
-    });
+    })
     const extent = (i: number): { first: number; last: number } => {
-      let first = -1;
-      let last = -1;
+      let first = -1
+      let last = -1
       for (const [y, row] of raster.rows.entries()) {
         if (row[i * 4]) {
-          if (first === -1) first = y;
-          last = y;
+          if (first === -1) first = y
+          last = y
         }
       }
-      return { first, last };
-    };
-    expect(extent(0)).toEqual({ first: 30, last: 59 });
-    expect(extent(1)).toEqual({ first: 0, last: 59 });
-    expect(extent(2)).toEqual({ first: 30, last: 89 });
-    expect(extent(3)).toEqual({ first: 0, last: 89 });
-  });
+      return { first, last }
+    }
+    expect(extent(0)).toEqual({ first: 30, last: 59 })
+    expect(extent(1)).toEqual({ first: 0, last: 59 })
+    expect(extent(2)).toEqual({ first: 30, last: 89 })
+    expect(extent(3)).toEqual({ first: 0, last: 89 })
+  })
 
   it("emits a valid PNG signature", () => {
-    const png = renderPostalPNG(encodePOSTNET("12345"));
-    expect(Array.from(png.slice(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
-  });
+    const png = renderPostalPNG(encodePOSTNET("12345"))
+    expect(Array.from(png.slice(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10])
+  })
 
   it("exposes postalPNG and postalPNGDataURI", () => {
-    const png = postalPNG("SN34RD1A", { type: "rm4scc" });
-    expect(Array.from(png.slice(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
-    expect(postalPNGDataURI("12345", { type: "postnet" })).toMatch(/^data:image\/png;base64,/);
-  });
+    const png = postalPNG("SN34RD1A", { type: "rm4scc" })
+    expect(Array.from(png.slice(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10])
+    expect(postalPNGDataURI("12345", { type: "postnet" })).toMatch(/^data:image\/png;base64,/)
+  })
 
   it("handles an empty bar list", () => {
-    const raster = renderPostalRaster([], { margin: 5 });
-    expect(raster.width).toBe(10);
-  });
-});
+    const raster = renderPostalRaster([], { margin: 5 })
+    expect(raster.width).toBe(10)
+  })
+})

--- a/test/renderers-qr-shape.test.ts
+++ b/test/renderers-qr-shape.test.ts
@@ -1,45 +1,45 @@
-import { describe, expect, it } from "vitest";
-import { renderQRCodeSVG } from "../src/renderers/svg/qr";
-import { qrcode } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { renderQRCodeSVG } from "../src/renderers/svg/qr"
+import { qrcode } from "../src/index"
 
 const matrix: boolean[][] = [
   [true, false, true],
   [false, true, false],
   [true, false, true],
-];
+]
 
 describe("QR shape option", () => {
   it("default square has no clipPath", () => {
-    const svg = renderQRCodeSVG(matrix);
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-    expect(svg).not.toContain("clipPath");
-    expect(svg).not.toContain("etiket-circle-clip");
-  });
+    const svg = renderQRCodeSVG(matrix)
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+    expect(svg).not.toContain("clipPath")
+    expect(svg).not.toContain("etiket-circle-clip")
+  })
 
   it("circle shape adds clipPath with circle", () => {
-    const svg = renderQRCodeSVG(matrix, { shape: "circle" });
-    expect(svg).toContain("<clipPath");
-    expect(svg).toContain("etiket-circle-clip");
-    expect(svg).toContain("<circle");
-    expect(svg).toContain('clip-path="url(#etiket-circle-clip)"');
-  });
+    const svg = renderQRCodeSVG(matrix, { shape: "circle" })
+    expect(svg).toContain("<clipPath")
+    expect(svg).toContain("etiket-circle-clip")
+    expect(svg).toContain("<circle")
+    expect(svg).toContain('clip-path="url(#etiket-circle-clip)"')
+  })
 
   it("circle shape produces valid SVG", () => {
-    const svg = renderQRCodeSVG(matrix, { shape: "circle" });
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-    expect(svg).toContain("<path");
-  });
+    const svg = renderQRCodeSVG(matrix, { shape: "circle" })
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+    expect(svg).toContain("<path")
+  })
 
   it("works via qrcode() convenience function", () => {
-    const svg = qrcode("Hello", { shape: "circle" });
-    expect(svg).toContain("<clipPath");
-    expect(svg).toContain("etiket-circle-clip");
-  });
+    const svg = qrcode("Hello", { shape: "circle" })
+    expect(svg).toContain("<clipPath")
+    expect(svg).toContain("etiket-circle-clip")
+  })
 
   it("square shape explicitly set has no clipPath", () => {
-    const svg = renderQRCodeSVG(matrix, { shape: "square" });
-    expect(svg).not.toContain("clipPath");
-  });
-});
+    const svg = renderQRCodeSVG(matrix, { shape: "square" })
+    expect(svg).not.toContain("clipPath")
+  })
+})

--- a/test/renderers-security.test.ts
+++ b/test/renderers-security.test.ts
@@ -1,113 +1,113 @@
-import { describe, expect, it } from "vitest";
-import { barcode, qrcode, datamatrix } from "../src/index";
-import { escapeAttr } from "../src/renderers/svg/utils";
+import { describe, expect, it } from "vitest"
+import { barcode, qrcode, datamatrix } from "../src/index"
+import { escapeAttr } from "../src/renderers/svg/utils"
 
 describe("SVG injection prevention", () => {
-  const maliciousColor = '#000" onload="alert(1)';
-  const maliciousBackground = '#fff" onclick="alert(2)';
-  const maliciousFont = 'monospace" onload="alert(3)';
+  const maliciousColor = '#000" onload="alert(1)'
+  const maliciousBackground = '#fff" onclick="alert(2)'
+  const maliciousFont = 'monospace" onload="alert(3)'
 
   describe("escapeAttr utility", () => {
     it("escapes double quotes", () => {
-      expect(escapeAttr('#000" onload="alert(1)')).toBe("#000&quot; onload=&quot;alert(1)");
-    });
+      expect(escapeAttr('#000" onload="alert(1)')).toBe("#000&quot; onload=&quot;alert(1)")
+    })
 
     it("escapes ampersands", () => {
-      expect(escapeAttr("a&b")).toBe("a&amp;b");
-    });
+      expect(escapeAttr("a&b")).toBe("a&amp;b")
+    })
 
     it("escapes single quotes", () => {
-      expect(escapeAttr("a'b")).toBe("a&#39;b");
-    });
+      expect(escapeAttr("a'b")).toBe("a&#39;b")
+    })
 
     it("escapes angle brackets", () => {
-      expect(escapeAttr("<script>")).toBe("&lt;script&gt;");
-    });
+      expect(escapeAttr("<script>")).toBe("&lt;script&gt;")
+    })
 
     it("escapes all dangerous characters together", () => {
-      expect(escapeAttr(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
-    });
+      expect(escapeAttr(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;")
+    })
 
     it("leaves safe strings unchanged", () => {
-      expect(escapeAttr("#ff0000")).toBe("#ff0000");
-      expect(escapeAttr("red")).toBe("red");
-      expect(escapeAttr("monospace")).toBe("monospace");
-    });
-  });
+      expect(escapeAttr("#ff0000")).toBe("#ff0000")
+      expect(escapeAttr("red")).toBe("red")
+      expect(escapeAttr("monospace")).toBe("monospace")
+    })
+  })
 
   describe("barcode", () => {
     it("does not allow attribute breakout via color", () => {
-      const svg = barcode("test", { color: maliciousColor });
+      const svg = barcode("test", { color: maliciousColor })
       // The raw double-quote should never appear unescaped in the fill attribute.
       // After escaping, the fill value contains &quot; instead of literal ",
       // so the attribute cannot be terminated early to inject onload.
-      expect(svg).not.toContain(`fill="${maliciousColor}"`);
-      expect(svg).toContain(`fill="#000&quot; onload=&quot;alert(1)"`);
-    });
+      expect(svg).not.toContain(`fill="${maliciousColor}"`)
+      expect(svg).toContain(`fill="#000&quot; onload=&quot;alert(1)"`)
+    })
 
     it("does not allow attribute breakout via background", () => {
-      const svg = barcode("test", { background: maliciousBackground });
-      expect(svg).not.toContain(`fill="${maliciousBackground}"`);
-      expect(svg).toContain(`fill="#fff&quot; onclick=&quot;alert(2)"`);
-    });
+      const svg = barcode("test", { background: maliciousBackground })
+      expect(svg).not.toContain(`fill="${maliciousBackground}"`)
+      expect(svg).toContain(`fill="#fff&quot; onclick=&quot;alert(2)"`)
+    })
 
     it("does not allow attribute breakout via fontFamily", () => {
       const svg = barcode("test", {
         showText: true,
         text: "hello",
         fontFamily: maliciousFont,
-      });
-      expect(svg).not.toContain(`font-family="${maliciousFont}"`);
-      expect(svg).toContain(`font-family="monospace&quot; onload=&quot;alert(3)"`);
-    });
+      })
+      expect(svg).not.toContain(`font-family="${maliciousFont}"`)
+      expect(svg).toContain(`font-family="monospace&quot; onload=&quot;alert(3)"`)
+    })
 
     it("works correctly with normal hex colors", () => {
-      const svg = barcode("test", { color: "#ff0000", background: "#eee" });
-      expect(svg).toContain("<svg");
-      expect(svg).toContain('fill="#ff0000"');
-      expect(svg).toContain('fill="#eee"');
-    });
+      const svg = barcode("test", { color: "#ff0000", background: "#eee" })
+      expect(svg).toContain("<svg")
+      expect(svg).toContain('fill="#ff0000"')
+      expect(svg).toContain('fill="#eee"')
+    })
 
     it("works correctly with named colors", () => {
-      const svg = barcode("test", { color: "red", background: "white" });
-      expect(svg).toContain('fill="red"');
-      expect(svg).toContain('fill="white"');
-    });
-  });
+      const svg = barcode("test", { color: "red", background: "white" })
+      expect(svg).toContain('fill="red"')
+      expect(svg).toContain('fill="white"')
+    })
+  })
 
   describe("qrcode", () => {
     it("does not allow attribute breakout via color", () => {
-      const svg = qrcode("test", { color: maliciousColor });
+      const svg = qrcode("test", { color: maliciousColor })
       // The raw unescaped malicious value must not appear in a fill attribute
-      expect(svg).not.toContain(`fill="${maliciousColor}"`);
-      expect(svg).toContain("&quot;");
-    });
+      expect(svg).not.toContain(`fill="${maliciousColor}"`)
+      expect(svg).toContain("&quot;")
+    })
 
     it("does not allow attribute breakout via background", () => {
-      const svg = qrcode("test", { background: maliciousBackground });
-      expect(svg).not.toContain(`fill="${maliciousBackground}"`);
-      expect(svg).toContain("&quot;");
-    });
+      const svg = qrcode("test", { background: maliciousBackground })
+      expect(svg).not.toContain(`fill="${maliciousBackground}"`)
+      expect(svg).toContain("&quot;")
+    })
 
     it("works correctly with normal hex colors", () => {
-      const svg = qrcode("test", { color: "#333", background: "#fff" });
-      expect(svg).toContain("<svg");
-      expect(svg).toContain("#333");
-      expect(svg).toContain("#fff");
-    });
-  });
+      const svg = qrcode("test", { color: "#333", background: "#fff" })
+      expect(svg).toContain("<svg")
+      expect(svg).toContain("#333")
+      expect(svg).toContain("#fff")
+    })
+  })
 
   describe("datamatrix", () => {
     it("does not allow attribute breakout via color", () => {
-      const svg = datamatrix("test", { color: maliciousColor });
-      expect(svg).not.toContain(`fill="${maliciousColor}"`);
-      expect(svg).toContain("&quot;");
-    });
+      const svg = datamatrix("test", { color: maliciousColor })
+      expect(svg).not.toContain(`fill="${maliciousColor}"`)
+      expect(svg).toContain("&quot;")
+    })
 
     it("does not allow attribute breakout via background", () => {
-      const svg = datamatrix("test", { background: maliciousBackground });
-      expect(svg).not.toContain(`fill="${maliciousBackground}"`);
-      expect(svg).toContain("&quot;");
-    });
-  });
-});
+      const svg = datamatrix("test", { background: maliciousBackground })
+      expect(svg).not.toContain(`fill="${maliciousBackground}"`)
+      expect(svg).toContain("&quot;")
+    })
+  })
+})

--- a/test/renderers-shapes.test.ts
+++ b/test/renderers-shapes.test.ts
@@ -1,33 +1,33 @@
-import { describe, expect, it } from "vitest";
-import { getModulePath, getFinderOuterPath, getFinderInnerPath } from "../src/renderers/svg/shapes";
+import { describe, expect, it } from "vitest"
+import { getModulePath, getFinderOuterPath, getFinderInnerPath } from "../src/renderers/svg/shapes"
 
 describe("module shapes", () => {
-  const x = 10;
-  const y = 20;
-  const size = 5;
+  const x = 10
+  const y = 20
+  const size = 5
 
   it("square generates valid path", () => {
-    const path = getModulePath(x, y, size, "square");
-    expect(path).toContain("M");
-    expect(path).toContain("h");
-    expect(path).toContain("v");
-    expect(path).toContain("z");
-  });
+    const path = getModulePath(x, y, size, "square")
+    expect(path).toContain("M")
+    expect(path).toContain("h")
+    expect(path).toContain("v")
+    expect(path).toContain("z")
+  })
 
   it("dots generates circle path", () => {
-    const path = getModulePath(x, y, size, "dots");
-    expect(path).toContain("a"); // arc commands for circle
-  });
+    const path = getModulePath(x, y, size, "dots")
+    expect(path).toContain("a") // arc commands for circle
+  })
 
   it("rounded generates path with arcs", () => {
-    const path = getModulePath(x, y, size, "rounded");
-    expect(path).toContain("a"); // arc commands
-  });
+    const path = getModulePath(x, y, size, "rounded")
+    expect(path).toContain("a") // arc commands
+  })
 
   it("diamond generates path", () => {
-    const path = getModulePath(x, y, size, "diamond");
-    expect(path).toContain("l"); // line commands
-  });
+    const path = getModulePath(x, y, size, "diamond")
+    expect(path).toContain("l") // line commands
+  })
 
   it("all dot types produce non-empty paths", () => {
     const types = [
@@ -42,41 +42,41 @@ describe("module shapes", () => {
       "horizontal-line",
       "small-square",
       "tiny-square",
-    ] as const;
+    ] as const
 
     for (const type of types) {
-      const path = getModulePath(x, y, size, type);
-      expect(path.length).toBeGreaterThan(0);
-      expect(path).toContain("M"); // All paths start with moveto
+      const path = getModulePath(x, y, size, type)
+      expect(path.length).toBeGreaterThan(0)
+      expect(path).toContain("M") // All paths start with moveto
     }
-  });
+  })
 
   it("dotSize scales the module", () => {
-    const full = getModulePath(x, y, size, "square", 1);
-    const half = getModulePath(x, y, size, "square", 0.5);
-    expect(full).not.toBe(half);
-  });
-});
+    const full = getModulePath(x, y, size, "square", 1)
+    const half = getModulePath(x, y, size, "square", 0.5)
+    expect(full).not.toBe(half)
+  })
+})
 
 describe("finder pattern paths", () => {
   it("outer path generates valid SVG", () => {
-    const path = getFinderOuterPath(0, 0, 5, "square");
-    expect(path).toContain("M");
-    expect(path.length).toBeGreaterThan(10);
-  });
+    const path = getFinderOuterPath(0, 0, 5, "square")
+    expect(path).toContain("M")
+    expect(path.length).toBeGreaterThan(10)
+  })
 
   it("inner path generates valid SVG", () => {
-    const path = getFinderInnerPath(0, 0, 5, "square");
-    expect(path).toContain("M");
-  });
+    const path = getFinderInnerPath(0, 0, 5, "square")
+    expect(path).toContain("M")
+  })
 
   it("rounded outer path has arcs", () => {
-    const path = getFinderOuterPath(0, 0, 5, "rounded");
-    expect(path).toContain("a");
-  });
+    const path = getFinderOuterPath(0, 0, 5, "rounded")
+    expect(path).toContain("a")
+  })
 
   it("dots outer path has circles", () => {
-    const path = getFinderOuterPath(0, 0, 5, "dots");
-    expect(path).toContain("a");
-  });
-});
+    const path = getFinderOuterPath(0, 0, 5, "dots")
+    expect(path).toContain("a")
+  })
+})

--- a/test/renderers-text.test.ts
+++ b/test/renderers-text.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { renderText } from "../src/renderers/text";
+import { describe, expect, it } from "vitest"
+import { renderText } from "../src/renderers/text"
 
 describe("text renderer", () => {
   // Small test matrix
@@ -7,36 +7,36 @@ describe("text renderer", () => {
     [true, false, true],
     [false, true, false],
     [true, false, true],
-  ];
+  ]
 
   it("renders compact mode by default", () => {
-    const text = renderText(matrix);
-    expect(text.length).toBeGreaterThan(0);
+    const text = renderText(matrix)
+    expect(text.length).toBeGreaterThan(0)
     // Compact mode uses half-block characters
-    expect(text).toMatch(/[█▀▄ ]/);
-  });
+    expect(text).toMatch(/[█▀▄ ]/)
+  })
 
   it("renders non-compact mode", () => {
-    const text = renderText(matrix, { compact: false });
-    expect(text.length).toBeGreaterThan(0);
-    expect(text).toContain("██"); // Dark module
-  });
+    const text = renderText(matrix, { compact: false })
+    expect(text.length).toBeGreaterThan(0)
+    expect(text).toContain("██") // Dark module
+  })
 
   it("includes margin", () => {
-    const withMargin = renderText(matrix, { margin: 2 });
-    const noMargin = renderText(matrix, { margin: 0 });
-    expect(withMargin.length).toBeGreaterThan(noMargin.length);
-  });
+    const withMargin = renderText(matrix, { margin: 2 })
+    const noMargin = renderText(matrix, { margin: 0 })
+    expect(withMargin.length).toBeGreaterThan(noMargin.length)
+  })
 
   it("invert option swaps dark/light", () => {
-    const normal = renderText(matrix, { compact: false, margin: 0 });
-    const inverted = renderText(matrix, { compact: false, margin: 0, invert: true });
-    expect(normal).not.toBe(inverted);
-  });
+    const normal = renderText(matrix, { compact: false, margin: 0 })
+    const inverted = renderText(matrix, { compact: false, margin: 0, invert: true })
+    expect(normal).not.toBe(inverted)
+  })
 
   it("produces multiple lines", () => {
-    const text = renderText(matrix);
-    const lines = text.split("\n");
-    expect(lines.length).toBeGreaterThan(1);
-  });
-});
+    const text = renderText(matrix)
+    const lines = text.split("\n")
+    expect(lines.length).toBeGreaterThan(1)
+  })
+})

--- a/test/renderers-units.test.ts
+++ b/test/renderers-units.test.ts
@@ -1,39 +1,39 @@
-import { describe, expect, it } from "vitest";
-import { renderBarcodeSVG } from "../src/renderers/svg/barcode";
+import { describe, expect, it } from "vitest"
+import { renderBarcodeSVG } from "../src/renderers/svg/barcode"
 
-const bars = [2, 1, 2, 2, 2, 2]; // simple pattern
+const bars = [2, 1, 2, 2, 2, 2] // simple pattern
 
 describe("measurement units", () => {
   it("default px has no unit suffix", () => {
-    const svg = renderBarcodeSVG(bars);
-    expect(svg).toMatch(/width="\d+"/);
-    expect(svg).not.toMatch(/width="\d+mm"/);
-  });
+    const svg = renderBarcodeSVG(bars)
+    expect(svg).toMatch(/width="\d+"/)
+    expect(svg).not.toMatch(/width="\d+mm"/)
+  })
 
   it("mm unit adds mm suffix", () => {
-    const svg = renderBarcodeSVG(bars, { unit: "mm" });
-    expect(svg).toMatch(/width="\d+mm"/);
-    expect(svg).toMatch(/height="\d+mm"/);
-  });
+    const svg = renderBarcodeSVG(bars, { unit: "mm" })
+    expect(svg).toMatch(/width="\d+mm"/)
+    expect(svg).toMatch(/height="\d+mm"/)
+  })
 
   it("in unit adds in suffix", () => {
-    const svg = renderBarcodeSVG(bars, { unit: "in" });
-    expect(svg).toMatch(/width="[\d.]+in"/);
-  });
+    const svg = renderBarcodeSVG(bars, { unit: "in" })
+    expect(svg).toMatch(/width="[\d.]+in"/)
+  })
 
   it("cm unit adds cm suffix", () => {
-    const svg = renderBarcodeSVG(bars, { unit: "cm" });
-    expect(svg).toMatch(/width="[\d.]+cm"/);
-  });
+    const svg = renderBarcodeSVG(bars, { unit: "cm" })
+    expect(svg).toMatch(/width="[\d.]+cm"/)
+  })
 
   it("pt unit adds pt suffix", () => {
-    const svg = renderBarcodeSVG(bars, { unit: "pt" });
-    expect(svg).toMatch(/width="[\d.]+pt"/);
-  });
+    const svg = renderBarcodeSVG(bars, { unit: "pt" })
+    expect(svg).toMatch(/width="[\d.]+pt"/)
+  })
 
   it("viewBox remains unitless", () => {
-    const svg = renderBarcodeSVG(bars, { unit: "mm" });
-    expect(svg).toMatch(/viewBox="0 0 \d+ \d+"/);
-    expect(svg).not.toMatch(/viewBox="0 0 \d+mm/);
-  });
-});
+    const svg = renderBarcodeSVG(bars, { unit: "mm" })
+    expect(svg).toMatch(/viewBox="0 0 \d+ \d+"/)
+    expect(svg).not.toMatch(/viewBox="0 0 \d+mm/)
+  })
+})

--- a/test/swiss-qr.test.ts
+++ b/test/swiss-qr.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { swissQR } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { swissQR } from "../src/index"
 
 describe("Swiss QR Code", () => {
   const baseData = {
@@ -16,28 +16,28 @@ describe("Swiss QR Code", () => {
     currency: "CHF" as const,
     reference: "210000000003139471430009017",
     referenceType: "QRR" as const,
-  };
+  }
 
   it("generates valid SVG", () => {
-    const svg = swissQR(baseData);
-    expect(svg).toContain("<svg");
-    expect(svg).toContain("</svg>");
-  });
+    const svg = swissQR(baseData)
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("</svg>")
+  })
 
   it("uses EC level M by default", () => {
-    const svg = swissQR(baseData);
-    expect(svg).toContain("<path");
-  });
+    const svg = swissQR(baseData)
+    expect(svg).toContain("<path")
+  })
 
   it("works without amount", () => {
-    const svg = swissQR({ ...baseData, amount: undefined });
-    expect(svg).toContain("<svg");
-  });
+    const svg = swissQR({ ...baseData, amount: undefined })
+    expect(svg).toContain("<svg")
+  })
 
   it("works without debtor", () => {
-    const svg = swissQR(baseData);
-    expect(svg).toContain("<svg");
-  });
+    const svg = swissQR(baseData)
+    expect(svg).toContain("<svg")
+  })
 
   it("works with debtor", () => {
     const svg = swissQR({
@@ -49,23 +49,23 @@ describe("Swiss QR Code", () => {
         city: "Lugano",
         country: "CH",
       },
-    });
-    expect(svg).toContain("<svg");
-  });
+    })
+    expect(svg).toContain("<svg")
+  })
 
   it("supports EUR currency", () => {
-    const svg = swissQR({ ...baseData, currency: "EUR" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = swissQR({ ...baseData, currency: "EUR" })
+    expect(svg).toContain("<svg")
+  })
 
   it("strips IBAN spaces", () => {
     // Should not throw — spaces in IBAN are stripped
-    const svg = swissQR({ ...baseData, iban: "CH44 3199 9123 0008 8901 2" });
-    expect(svg).toContain("<svg");
-  });
+    const svg = swissQR({ ...baseData, iban: "CH44 3199 9123 0008 8901 2" })
+    expect(svg).toContain("<svg")
+  })
 
   it("accepts custom QR options", () => {
-    const svg = swissQR(baseData, { size: 300 });
-    expect(svg).toContain('width="300"');
-  });
-});
+    const svg = swissQR(baseData, { size: 300 })
+    expect(svg).toContain('width="300"')
+  })
+})

--- a/test/validators-barcode-full.test.ts
+++ b/test/validators-barcode-full.test.ts
@@ -3,13 +3,13 @@
  * between the validator's verdict and what the encoders actually accept.
  */
 
-import { describe, expect, it } from "vitest";
-import { validateBarcode, isValidInput, validateBarcodeInput } from "../src/validators/barcode";
-import { calculateEANCheckDigit, verifyEANCheckDigit } from "../src/validators/barcode";
-import { encodeBars } from "../src/_barcode";
-import { encodePostal } from "../src/_postal";
-import { encodeIdentcode, encodeLeitcode } from "../src/encoders/deutsche-post";
-import { encodePOSTNET, encodePLANET } from "../src/encoders/postnet";
+import { describe, expect, it } from "vitest"
+import { validateBarcode, isValidInput, validateBarcodeInput } from "../src/validators/barcode"
+import { calculateEANCheckDigit, verifyEANCheckDigit } from "../src/validators/barcode"
+import { encodeBars } from "../src/_barcode"
+import { encodePostal } from "../src/_postal"
+import { encodeIdentcode, encodeLeitcode } from "../src/encoders/deutsche-post"
+import { encodePOSTNET, encodePLANET } from "../src/encoders/postnet"
 
 describe("validateBarcode — accepts valid input", () => {
   const valid: Array<[string, string]> = [
@@ -59,17 +59,17 @@ describe("validateBarcode — accepts valid input", () => {
     ["code16k", "HELLO"],
     ["micropdf417", "HELLO"],
     ["gs1-datamatrix", "(01)12345678901231"],
-  ];
+  ]
 
   for (const [type, text] of valid) {
     it(`${type}: "${text}"`, () => {
-      const result = validateBarcode(text, type);
-      expect(result.valid, `${type} ${text}: ${result.error ?? ""}`).toBe(true);
-      expect(result.error).toBeUndefined();
-      expect(isValidInput(text, type)).toBe(true);
-    });
+      const result = validateBarcode(text, type)
+      expect(result.valid, `${type} ${text}: ${result.error ?? ""}`).toBe(true)
+      expect(result.error).toBeUndefined()
+      expect(isValidInput(text, type)).toBe(true)
+    })
   }
-});
+})
 
 describe("validateBarcode — rejects invalid input", () => {
   const invalid: Array<[string, string, RegExp]> = [
@@ -124,23 +124,23 @@ describe("validateBarcode — rejects invalid input", () => {
     ["codablock-f", "", /must not be empty/],
     ["code16k", "", /must not be empty/],
     ["micropdf417", "", /must not be empty/],
-  ];
+  ]
 
   for (const [type, text, pattern] of invalid) {
     it(`${type}: "${text}"`, () => {
-      const result = validateBarcode(text, type);
-      expect(result.valid, `${type} "${text}" should be invalid`).toBe(false);
-      expect(result.error).toMatch(pattern);
-      expect(isValidInput(text, type)).toBe(false);
-    });
+      const result = validateBarcode(text, type)
+      expect(result.valid, `${type} "${text}" should be invalid`).toBe(false)
+      expect(result.error).toMatch(pattern)
+      expect(isValidInput(text, type)).toBe(false)
+    })
   }
-});
+})
 
 describe("validateBarcode — unknown types", () => {
   it("permits unknown types rather than blocking them", () => {
-    expect(validateBarcode("anything", "some-future-type")).toEqual({ valid: true });
-  });
-});
+    expect(validateBarcode("anything", "some-future-type")).toEqual({ valid: true })
+  })
+})
 
 describe("validator agrees with the encoders", () => {
   const cases: Array<[string, string]> = [
@@ -159,14 +159,14 @@ describe("validator agrees with the encoders", () => {
     ["identcode", "56310243031"],
     ["leitcode", "2131000006418"],
     ["plessey", "1234"],
-  ];
+  ]
 
   it("input the validator accepts, the encoder encodes", () => {
     for (const [type, text] of cases) {
-      expect(validateBarcode(text, type).valid, type).toBe(true);
-      expect(() => encodeBars(text, { type: type as "code128" }), type).not.toThrow();
+      expect(validateBarcode(text, type).valid, type).toBe(true)
+      expect(() => encodeBars(text, { type: type as "code128" }), type).not.toThrow()
     }
-  });
+  })
 
   it("postal input the validator accepts, the postal encoder encodes", () => {
     const postalCases: Array<[string, string]> = [
@@ -177,12 +177,12 @@ describe("validator agrees with the encoders", () => {
       ["auspost", "12345678"],
       ["jppost", "1234567"],
       ["imb", "01234567094987654321"],
-    ];
+    ]
     for (const [type, text] of postalCases) {
-      expect(validateBarcode(text, type).valid, type).toBe(true);
-      expect(() => encodePostal(text, { type: type as "postnet" }), type).not.toThrow();
+      expect(validateBarcode(text, type).valid, type).toBe(true)
+      expect(() => encodePostal(text, { type: type as "postnet" }), type).not.toThrow()
     }
-  });
+  })
 
   it("input the validator rejects, the encoder also rejects", () => {
     const rejected: Array<[string, string]> = [
@@ -193,90 +193,90 @@ describe("validator agrees with the encoders", () => {
       ["code11", "12A4"],
       ["ean2", "123"],
       ["ean5", "1234"],
-    ];
+    ]
     for (const [type, text] of rejected) {
-      expect(validateBarcode(text, type).valid, type).toBe(false);
-      expect(() => encodeBars(text, { type: type as "code128" }), type).toThrow();
+      expect(validateBarcode(text, type).valid, type).toBe(false)
+      expect(() => encodeBars(text, { type: type as "code128" }), type).toThrow()
     }
-  });
-});
+  })
+})
 
 describe("validateBarcodeInput — check digits", () => {
   it("computes the EAN-13 check digit", () => {
-    expect(validateBarcodeInput("400638133393", "ean13")).toEqual({ valid: true, checkDigit: 1 });
-  });
+    expect(validateBarcodeInput("400638133393", "ean13")).toEqual({ valid: true, checkDigit: 1 })
+  })
 
   it("computes the EAN-8 check digit", () => {
-    const result = validateBarcodeInput("9638507", "ean8");
-    expect(result.valid).toBe(true);
-    expect(result.checkDigit).toBe(4);
-  });
+    const result = validateBarcodeInput("9638507", "ean8")
+    expect(result.valid).toBe(true)
+    expect(result.checkDigit).toBe(4)
+  })
 
   it("computes the UPC-A check digit", () => {
-    expect(validateBarcodeInput("03600029145", "upca").checkDigit).toBe(2);
-  });
+    expect(validateBarcodeInput("03600029145", "upca").checkDigit).toBe(2)
+  })
 
   it("computes the ITF-14 check digit", () => {
-    expect(validateBarcodeInput("1540014128876", "itf14").checkDigit).toBe(3);
-  });
+    expect(validateBarcodeInput("1540014128876", "itf14").checkDigit).toBe(3)
+  })
 
   it("computes the UPC-E check digit", () => {
-    const result = validateBarcodeInput("012345", "upce");
-    expect(result.valid).toBe(true);
-    expect(typeof result.checkDigit).toBe("number");
-  });
+    const result = validateBarcodeInput("012345", "upce")
+    expect(result.valid).toBe(true)
+    expect(typeof result.checkDigit).toBe("number")
+  })
 
   it("computes Identcode/Leitcode check digits matching the encoder", () => {
-    const ident = validateBarcodeInput("56310243031", "identcode");
-    expect(ident.valid).toBe(true);
+    const ident = validateBarcodeInput("56310243031", "identcode")
+    expect(ident.valid).toBe(true)
     // The encoder accepts data + the validator's check digit as a complete code
-    expect(() => encodeIdentcode("56310243031" + String(ident.checkDigit))).not.toThrow();
+    expect(() => encodeIdentcode("56310243031" + String(ident.checkDigit))).not.toThrow()
 
-    const leit = validateBarcodeInput("2131000006418", "leitcode");
-    expect(leit.valid).toBe(true);
-    expect(() => encodeLeitcode("2131000006418" + String(leit.checkDigit))).not.toThrow();
-  });
+    const leit = validateBarcodeInput("2131000006418", "leitcode")
+    expect(leit.valid).toBe(true)
+    expect(() => encodeLeitcode("2131000006418" + String(leit.checkDigit))).not.toThrow()
+  })
 
   it("computes POSTNET/PLANET check digits", () => {
     // 1+2+3+4+5 = 15 → (10 - 15 % 10) % 10 = 5
-    expect(validateBarcodeInput("12345", "postnet").checkDigit).toBe(5);
+    expect(validateBarcodeInput("12345", "postnet").checkDigit).toBe(5)
     // 1+2+…+9+0+1 = 46 → (10 - 46 % 10) % 10 = 4
-    expect(validateBarcodeInput("12345678901", "planet").checkDigit).toBe(4);
+    expect(validateBarcodeInput("12345678901", "planet").checkDigit).toBe(4)
     // The encoders append the same digit
-    expect(encodePOSTNET("12345").length).toBe(1 + 6 * 5 + 1);
-    expect(encodePLANET("12345678901").length).toBe(1 + 12 * 5 + 1);
-  });
+    expect(encodePOSTNET("12345").length).toBe(1 + 6 * 5 + 1)
+    expect(encodePLANET("12345678901").length).toBe(1 + 12 * 5 + 1)
+  })
 
   it("returns no check digit for types that do not define one", () => {
-    expect(validateBarcodeInput("HELLO", "code128")).toEqual({ valid: true });
-    expect(validateBarcodeInput("HELLO", "code39")).toEqual({ valid: true });
-  });
+    expect(validateBarcodeInput("HELLO", "code128")).toEqual({ valid: true })
+    expect(validateBarcodeInput("HELLO", "code39")).toEqual({ valid: true })
+  })
 
   it("propagates validation failures without computing a check digit", () => {
-    const result = validateBarcodeInput("123", "ean13");
-    expect(result.valid).toBe(false);
-    expect(result.checkDigit).toBeUndefined();
-  });
-});
+    const result = validateBarcodeInput("123", "ean13")
+    expect(result.valid).toBe(false)
+    expect(result.checkDigit).toBeUndefined()
+  })
+})
 
 describe("EAN check digit helpers", () => {
   it("calculates known check digits", () => {
-    expect(calculateEANCheckDigit([4, 0, 0, 6, 3, 8, 1, 3, 3, 3, 9, 3])).toBe(1);
-    expect(calculateEANCheckDigit([9, 6, 3, 8, 5, 0, 7])).toBe(4);
-  });
+    expect(calculateEANCheckDigit([4, 0, 0, 6, 3, 8, 1, 3, 3, 3, 9, 3])).toBe(1)
+    expect(calculateEANCheckDigit([9, 6, 3, 8, 5, 0, 7])).toBe(4)
+  })
 
   it("verifies complete codes", () => {
-    expect(verifyEANCheckDigit("4006381333931")).toBe(true);
-    expect(verifyEANCheckDigit("4006381333930")).toBe(false);
-    expect(verifyEANCheckDigit("96385074")).toBe(true);
-  });
+    expect(verifyEANCheckDigit("4006381333931")).toBe(true)
+    expect(verifyEANCheckDigit("4006381333930")).toBe(false)
+    expect(verifyEANCheckDigit("96385074")).toBe(true)
+  })
 
   it("rejects input too short to carry a check digit", () => {
-    expect(verifyEANCheckDigit("")).toBe(false);
-    expect(verifyEANCheckDigit("5")).toBe(false);
-  });
+    expect(verifyEANCheckDigit("")).toBe(false)
+    expect(verifyEANCheckDigit("5")).toBe(false)
+  })
 
   it("ignores non-digit separators", () => {
-    expect(verifyEANCheckDigit("4-006381333931")).toBe(true);
-  });
-});
+    expect(verifyEANCheckDigit("4-006381333931")).toBe(true)
+  })
+})

--- a/test/validators-validation.test.ts
+++ b/test/validators-validation.test.ts
@@ -1,102 +1,102 @@
-import { describe, expect, it } from "vitest";
-import { validateQRInput, validateBarcodeInput } from "../src/index";
+import { describe, expect, it } from "vitest"
+import { validateQRInput, validateBarcodeInput } from "../src/index"
 
 describe("validateQRInput", () => {
   it("returns valid with version 1 and mode numeric for short numeric input", () => {
-    const result = validateQRInput("12345", "L");
-    expect(result.valid).toBe(true);
-    expect(result.version).toBe(1);
-    expect(result.mode).toBe("numeric");
-    expect(result.dataLength).toBe(5);
-    expect(result.maxCapacity).toBeGreaterThan(0);
-  });
+    const result = validateQRInput("12345", "L")
+    expect(result.valid).toBe(true)
+    expect(result.version).toBe(1)
+    expect(result.mode).toBe("numeric")
+    expect(result.dataLength).toBe(5)
+    expect(result.maxCapacity).toBeGreaterThan(0)
+  })
 
   it("returns valid with mode byte for mixed-case text", () => {
-    const result = validateQRInput("Hello", "H");
-    expect(result.valid).toBe(true);
-    expect(result.mode).toBe("byte");
-    expect(result.version).toBeGreaterThanOrEqual(1);
-    expect(result.dataLength).toBe(5);
-  });
+    const result = validateQRInput("Hello", "H")
+    expect(result.valid).toBe(true)
+    expect(result.mode).toBe("byte")
+    expect(result.version).toBeGreaterThanOrEqual(1)
+    expect(result.dataLength).toBe(5)
+  })
 
   it("returns invalid for data that exceeds maximum capacity", () => {
-    const result = validateQRInput("A".repeat(5000), "H");
-    expect(result.valid).toBe(false);
-    expect(result.error).toBeDefined();
-  });
+    const result = validateQRInput("A".repeat(5000), "H")
+    expect(result.valid).toBe(false)
+    expect(result.error).toBeDefined()
+  })
 
   it("returns invalid for empty string", () => {
-    const result = validateQRInput("");
-    expect(result.valid).toBe(false);
-    expect(result.error).toBe("Text cannot be empty");
-  });
+    const result = validateQRInput("")
+    expect(result.valid).toBe(false)
+    expect(result.error).toBe("Text cannot be empty")
+  })
 
   it("returns higher version for longer data", () => {
-    const short = validateQRInput("123", "L");
-    const long = validateQRInput("1".repeat(200), "L");
-    expect(short.valid).toBe(true);
-    expect(long.valid).toBe(true);
-    expect(long.version).toBeGreaterThan(short.version!);
-  });
+    const short = validateQRInput("123", "L")
+    const long = validateQRInput("1".repeat(200), "L")
+    expect(short.valid).toBe(true)
+    expect(long.valid).toBe(true)
+    expect(long.version).toBeGreaterThan(short.version!)
+  })
 
   it("detects alphanumeric mode for uppercase + digits", () => {
-    const result = validateQRInput("HELLO 123", "M");
-    expect(result.valid).toBe(true);
-    expect(result.mode).toBe("alphanumeric");
-  });
+    const result = validateQRInput("HELLO 123", "M")
+    expect(result.valid).toBe(true)
+    expect(result.mode).toBe("alphanumeric")
+  })
 
   it("uses default EC level M when not specified", () => {
-    const result = validateQRInput("test");
-    expect(result.valid).toBe(true);
-    expect(result.version).toBeGreaterThanOrEqual(1);
-  });
-});
+    const result = validateQRInput("test")
+    expect(result.valid).toBe(true)
+    expect(result.version).toBeGreaterThanOrEqual(1)
+  })
+})
 
 describe("validateBarcodeInput", () => {
   it("returns valid with checkDigit for EAN-13 (12 digits)", () => {
-    const result = validateBarcodeInput("400638133393", "ean13");
-    expect(result.valid).toBe(true);
-    expect(result.checkDigit).toBe(1);
-  });
+    const result = validateBarcodeInput("400638133393", "ean13")
+    expect(result.valid).toBe(true)
+    expect(result.checkDigit).toBe(1)
+  })
 
   it("returns invalid for non-numeric EAN-13 input", () => {
-    const result = validateBarcodeInput("ABC", "ean13");
-    expect(result.valid).toBe(false);
-    expect(result.error).toBeDefined();
-  });
+    const result = validateBarcodeInput("ABC", "ean13")
+    expect(result.valid).toBe(false)
+    expect(result.error).toBeDefined()
+  })
 
   it("returns valid with checkDigit for EAN-13 with 13 digits", () => {
-    const result = validateBarcodeInput("4006381333931", "ean13");
-    expect(result.valid).toBe(true);
-    expect(result.checkDigit).toBe(1);
-  });
+    const result = validateBarcodeInput("4006381333931", "ean13")
+    expect(result.valid).toBe(true)
+    expect(result.checkDigit).toBe(1)
+  })
 
   it("returns valid with checkDigit for EAN-8", () => {
-    const result = validateBarcodeInput("9638507", "ean8");
-    expect(result.valid).toBe(true);
-    expect(typeof result.checkDigit).toBe("number");
-  });
+    const result = validateBarcodeInput("9638507", "ean8")
+    expect(result.valid).toBe(true)
+    expect(typeof result.checkDigit).toBe("number")
+  })
 
   it("returns valid with checkDigit for UPC-A", () => {
-    const result = validateBarcodeInput("01234567890", "upca");
-    expect(result.valid).toBe(true);
-    expect(typeof result.checkDigit).toBe("number");
-  });
+    const result = validateBarcodeInput("01234567890", "upca")
+    expect(result.valid).toBe(true)
+    expect(typeof result.checkDigit).toBe("number")
+  })
 
   it("returns valid with checkDigit for ITF-14", () => {
-    const result = validateBarcodeInput("1234567890123", "itf14");
-    expect(result.valid).toBe(true);
-    expect(typeof result.checkDigit).toBe("number");
-  });
+    const result = validateBarcodeInput("1234567890123", "itf14")
+    expect(result.valid).toBe(true)
+    expect(typeof result.checkDigit).toBe("number")
+  })
 
   it("returns valid without checkDigit for code128", () => {
-    const result = validateBarcodeInput("Hello", "code128");
-    expect(result.valid).toBe(true);
-    expect(result.checkDigit).toBeUndefined();
-  });
+    const result = validateBarcodeInput("Hello", "code128")
+    expect(result.valid).toBe(true)
+    expect(result.checkDigit).toBeUndefined()
+  })
 
   it("returns invalid for wrong length ITF-14", () => {
-    const result = validateBarcodeInput("123", "itf14");
-    expect(result.valid).toBe(false);
-  });
-});
+    const result = validateBarcodeInput("123", "itf14")
+    expect(result.valid).toBe(false)
+  })
+})

--- a/web/app/app.ts
+++ b/web/app/app.ts
@@ -52,9 +52,9 @@ import {
   gs1datamatrixPNG,
   pdf417PNG,
   aztecPNG,
-} from "etiket";
+} from "etiket"
 
-import type { GradientOptions, LogoOptions } from "etiket";
+import type { GradientOptions, LogoOptions } from "etiket"
 
 // ── Constants ──
 
@@ -99,7 +99,7 @@ const BARCODE_DEFAULTS: Record<string, string> = {
   "isbt-component": "E0791",
   "isbt-expiry": "260101",
   "isbt-bloodgroup": "51",
-};
+}
 
 const FORMAT_HINTS: Record<string, string> = {
   "australia-post": "Format: FCC:DPID (e.g. 11:12345678)",
@@ -107,7 +107,7 @@ const FORMAT_HINTS: Record<string, string> = {
   "hibc-secondary": "Format: EXPIRY:LOT (e.g. 260101:LOT123)",
   "hibc-concatenated": "Format: LIC:PRODUCT:EXPIRY:LOT",
   "isbt-din": "Format: COUNTRY:FACILITY:YEAR:DONATION",
-};
+}
 
 const M2D_DEFAULTS: Record<string, string> = {
   datamatrix: "Hello World",
@@ -123,87 +123,87 @@ const M2D_DEFAULTS: Record<string, string> = {
   codablockf: "HELLO WORLD",
   code16k: "HELLO",
   "gs1-composite": "(17)260101(10)BATCH01",
-};
+}
 
 // ── Utilities ──
 
-const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
-const val = (id: string) => $<HTMLInputElement>(id).value;
-const numVal = (id: string) => Number(val(id));
+const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T
+const val = (id: string) => $<HTMLInputElement>(id).value
+const numVal = (id: string) => Number(val(id))
 const optNum = (id: string) => {
-  const v = val(id);
-  return v === "" ? undefined : Number(v);
-};
+  const v = val(id)
+  return v === "" ? undefined : Number(v)
+}
 
 function renderSafe(target: HTMLElement, fn: () => string) {
   try {
-    target.innerHTML = fn();
+    target.innerHTML = fn()
   } catch (err) {
-    target.innerHTML = `<div class="error">${(err as Error).message}</div>`;
+    target.innerHTML = `<div class="error">${(err as Error).message}</div>`
   }
 }
 
-let toastTimer: ReturnType<typeof setTimeout>;
+let toastTimer: ReturnType<typeof setTimeout>
 function toast(msg: string) {
-  const el = $("toast");
-  el.textContent = msg;
-  el.classList.add("show");
-  clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => el.classList.remove("show"), 2000);
+  const el = $("toast")
+  el.textContent = msg
+  el.classList.add("show")
+  clearTimeout(toastTimer)
+  toastTimer = setTimeout(() => el.classList.remove("show"), 2000)
 }
 
 function copySVG(svg: string) {
-  navigator.clipboard.writeText(svg).then(() => toast("Copied to clipboard"));
+  navigator.clipboard.writeText(svg).then(() => toast("Copied to clipboard"))
 }
 
 function downloadSVG(svg: string, name: string) {
-  const blob = new Blob([svg], { type: "image/svg+xml" });
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = `${name}.svg`;
-  a.click();
-  URL.revokeObjectURL(a.href);
-  toast("Downloaded");
+  const blob = new Blob([svg], { type: "image/svg+xml" })
+  const a = document.createElement("a")
+  a.href = URL.createObjectURL(blob)
+  a.download = `${name}.svg`
+  a.click()
+  URL.revokeObjectURL(a.href)
+  toast("Downloaded")
 }
 
 function downloadPNG(data: Uint8Array, name: string) {
-  const blob = new Blob([data], { type: "image/png" });
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = `${name}.png`;
-  a.click();
-  URL.revokeObjectURL(a.href);
-  toast("Downloaded PNG");
+  const blob = new Blob([data], { type: "image/png" })
+  const a = document.createElement("a")
+  a.href = URL.createObjectURL(blob)
+  a.download = `${name}.png`
+  a.click()
+  URL.revokeObjectURL(a.href)
+  toast("Downloaded PNG")
 }
 
 function svgToPNG(svgString: string): Promise<Uint8Array> {
   return new Promise((resolve, reject) => {
-    const svgBlob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
-    const url = URL.createObjectURL(svgBlob);
-    const img = new Image();
+    const svgBlob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" })
+    const url = URL.createObjectURL(svgBlob)
+    const img = new Image()
     img.onload = () => {
-      const canvas = document.createElement("canvas");
-      canvas.width = img.naturalWidth * 2;
-      canvas.height = img.naturalHeight * 2;
-      const ctx = canvas.getContext("2d")!;
-      ctx.scale(2, 2);
-      ctx.drawImage(img, 0, 0);
-      URL.revokeObjectURL(url);
+      const canvas = document.createElement("canvas")
+      canvas.width = img.naturalWidth * 2
+      canvas.height = img.naturalHeight * 2
+      const ctx = canvas.getContext("2d")!
+      ctx.scale(2, 2)
+      ctx.drawImage(img, 0, 0)
+      URL.revokeObjectURL(url)
       canvas.toBlob((blob) => {
-        if (!blob) return reject(new Error("Failed to create PNG"));
-        blob.arrayBuffer().then((buf) => resolve(new Uint8Array(buf)));
-      }, "image/png");
-    };
+        if (!blob) return reject(new Error("Failed to create PNG"))
+        blob.arrayBuffer().then((buf) => resolve(new Uint8Array(buf)))
+      }, "image/png")
+    }
     img.onerror = () => {
-      URL.revokeObjectURL(url);
-      reject(new Error("Failed to load SVG"));
-    };
-    img.src = url;
-  });
+      URL.revokeObjectURL(url)
+      reject(new Error("Failed to load SVG"))
+    }
+    img.src = url
+  })
 }
 
 function listen(ids: string[], fn: () => void) {
-  for (const id of ids) $(id).addEventListener("input", fn);
+  for (const id of ids) $(id).addEventListener("input", fn)
 }
 
 // Track active preview mode per panel
@@ -211,143 +211,143 @@ const previewMode: Record<string, "svg" | "png"> = {
   bc: "svg",
   qr: "svg",
   m2d: "svg",
-};
+}
 
 function setupPreviewToggles() {
   document.querySelectorAll<HTMLButtonElement>(".toggle-btn[data-preview]").forEach((btn) => {
     btn.addEventListener("click", () => {
-      const target = btn.dataset.target!;
-      const mode = btn.dataset.preview as "svg" | "png";
-      previewMode[target] = mode;
+      const target = btn.dataset.target!
+      const mode = btn.dataset.preview as "svg" | "png"
+      previewMode[target] = mode
 
       // Toggle active class
       btn
         .parentElement!.querySelectorAll(".toggle-btn")
-        .forEach((b) => b.classList.remove("active"));
-      btn.classList.add("active");
+        .forEach((b) => b.classList.remove("active"))
+      btn.classList.add("active")
 
       // Toggle output visibility
-      const svgOut = $(`${target}-output`);
-      const pngOut = $(`${target}-output-png`);
-      svgOut.hidden = mode === "png";
-      pngOut.hidden = mode === "svg";
+      const svgOut = $(`${target}-output`)
+      const pngOut = $(`${target}-output-png`)
+      svgOut.hidden = mode === "png"
+      pngOut.hidden = mode === "svg"
 
       // Trigger re-render for PNG if switching
       if (mode === "png") {
-        pngOut.dispatchEvent(new CustomEvent("render-png"));
+        pngOut.dispatchEvent(new CustomEvent("render-png"))
       }
-    });
-  });
+    })
+  })
 }
 
 function renderPNGPreview(target: string, pngData: Uint8Array) {
-  const el = $(`${target}-output-png`);
-  const blob = new Blob([pngData], { type: "image/png" });
-  const url = URL.createObjectURL(blob);
-  el.innerHTML = `<img src="${url}" alt="PNG preview" style="max-width:100%;image-rendering:pixelated" />`;
+  const el = $(`${target}-output-png`)
+  const blob = new Blob([pngData], { type: "image/png" })
+  const url = URL.createObjectURL(blob)
+  el.innerHTML = `<img src="${url}" alt="PNG preview" style="max-width:100%;image-rendering:pixelated" />`
 }
 
 function renderPNGPreviewFromSVG(target: string, svg: string) {
   svgToPNG(svg)
     .then((png) => {
-      const el = $(`${target}-output-png`);
-      const blob = new Blob([png], { type: "image/png" });
-      const url = URL.createObjectURL(blob);
-      el.innerHTML = `<img src="${url}" alt="PNG preview" style="max-width:100%" />`;
+      const el = $(`${target}-output-png`)
+      const blob = new Blob([png], { type: "image/png" })
+      const url = URL.createObjectURL(blob)
+      el.innerHTML = `<img src="${url}" alt="PNG preview" style="max-width:100%" />`
     })
     .catch(() => {
-      $(`${target}-output-png`).innerHTML = `<div class="error">PNG render failed</div>`;
-    });
+      $(`${target}-output-png`).innerHTML = `<div class="error">PNG render failed</div>`
+    })
 }
 
 function setupCopyDownload(prefix: string, getFn: () => string) {
   $(`${prefix}-copy`).addEventListener("click", () => {
     try {
-      copySVG(getFn());
+      copySVG(getFn())
     } catch {}
-  });
+  })
   $(`${prefix}-download`).addEventListener("click", () => {
     try {
-      downloadSVG(getFn(), prefix);
+      downloadSVG(getFn(), prefix)
     } catch {}
-  });
+  })
 }
 
 // ── Custom Renderers ──
 
 function renderFourStateSVG(states: string[], color: string): string {
-  const bw = 2;
-  const gap = 3;
-  const h = 24;
-  const m = 10;
-  const w = states.length * (bw + gap) - gap + m * 2;
+  const bw = 2
+  const gap = 3
+  const h = 24
+  const m = 10
+  const w = states.length * (bw + gap) - gap + m * 2
 
   const bars = states
     .map((s, i) => {
-      const x = m + i * (bw + gap);
-      let y: number;
-      let bh: number;
+      const x = m + i * (bw + gap)
+      let y: number
+      let bh: number
       switch (s) {
         case "F":
-          y = 0;
-          bh = h;
-          break;
+          y = 0
+          bh = h
+          break
         case "A":
-          y = 0;
-          bh = h * 0.6;
-          break;
+          y = 0
+          bh = h * 0.6
+          break
         case "D":
-          y = h * 0.4;
-          bh = h * 0.6;
-          break;
+          y = h * 0.4
+          bh = h * 0.6
+          break
         default:
-          y = h * 0.25;
-          bh = h * 0.5;
-          break; // T
+          y = h * 0.25
+          bh = h * 0.5
+          break // T
       }
-      return `<rect x="${x}" y="${y + m}" width="${bw}" height="${bh}" fill="${color}"/>`;
+      return `<rect x="${x}" y="${y + m}" width="${bw}" height="${bh}" fill="${color}"/>`
     })
-    .join("");
+    .join("")
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h + m * 2}" width="${w}" height="${h + m * 2}">${bars}</svg>`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h + m * 2}" width="${w}" height="${h + m * 2}">${bars}</svg>`
 }
 
 function renderJABCodeSVG(
   result: { matrix: number[][]; rows: number; cols: number; palette: readonly string[] },
   size: number,
 ): string {
-  const cell = Math.max(2, Math.floor(size / Math.max(result.rows, result.cols)));
-  const w = result.cols * cell;
-  const h = result.rows * cell;
-  let rects = "";
+  const cell = Math.max(2, Math.floor(size / Math.max(result.rows, result.cols)))
+  const w = result.cols * cell
+  const h = result.rows * cell
+  let rects = ""
   for (let r = 0; r < result.rows; r++) {
     for (let c = 0; c < result.cols; c++) {
-      rects += `<rect x="${c * cell}" y="${r * cell}" width="${cell}" height="${cell}" fill="${result.palette[result.matrix[r][c]]}"/>`;
+      rects += `<rect x="${c * cell}" y="${r * cell}" width="${cell}" height="${cell}" fill="${result.palette[result.matrix[r][c]]}"/>`
     }
   }
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h}" width="${w}" height="${h}">${rects}</svg>`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h}" width="${w}" height="${h}">${rects}</svg>`
 }
 
 // ── Tabs ──
 
 function setupTabs() {
-  const tabs = document.querySelectorAll<HTMLButtonElement>(".tab");
-  const panels = document.querySelectorAll<HTMLElement>(".panel");
+  const tabs = document.querySelectorAll<HTMLButtonElement>(".tab")
+  const panels = document.querySelectorAll<HTMLElement>(".panel")
   for (const tab of tabs) {
     tab.addEventListener("click", () => {
-      tabs.forEach((t) => t.classList.remove("active"));
-      panels.forEach((p) => p.classList.remove("active"));
-      tab.classList.add("active");
+      tabs.forEach((t) => t.classList.remove("active"))
+      panels.forEach((p) => p.classList.remove("active"))
+      tab.classList.add("active")
       document
         .querySelector<HTMLElement>(`[data-panel="${tab.dataset.tab}"]`)!
-        .classList.add("active");
-    });
+        .classList.add("active")
+    })
   }
 }
 
 // ── Barcode ──
 
-const FOURSTATE_TYPES = new Set(["rm4scc", "kix", "australia-post", "japan-post", "imb"]);
+const FOURSTATE_TYPES = new Set(["rm4scc", "kix", "australia-post", "japan-post", "imb"])
 const HEALTHCARE_TYPES = new Set([
   "hibc-primary",
   "hibc-secondary",
@@ -356,77 +356,77 @@ const HEALTHCARE_TYPES = new Set([
   "isbt-component",
   "isbt-expiry",
   "isbt-bloodgroup",
-]);
+])
 
 function generateBarcode(data: string, type: string, opts: any): string {
   // 4-State postal codes
   if (FOURSTATE_TYPES.has(type)) {
-    let states: string[];
+    let states: string[]
     switch (type) {
       case "rm4scc":
-        states = encodeRM4SCC(data) as string[];
-        break;
+        states = encodeRM4SCC(data) as string[]
+        break
       case "kix":
-        states = encodeKIX(data) as string[];
-        break;
+        states = encodeKIX(data) as string[]
+        break
       case "australia-post": {
-        const [fcc, dpid] = data.split(":");
-        states = encodeAustraliaPost(fcc, dpid) as string[];
-        break;
+        const [fcc, dpid] = data.split(":")
+        states = encodeAustraliaPost(fcc, dpid) as string[]
+        break
       }
       case "japan-post":
-        states = encodeJapanPost(data) as string[];
-        break;
+        states = encodeJapanPost(data) as string[]
+        break
       case "imb":
-        states = encodeIMb(data) as string[];
-        break;
+        states = encodeIMb(data) as string[]
+        break
       default:
-        states = [];
+        states = []
     }
-    return renderFourStateSVG(states, opts.color ?? "#000");
+    return renderFourStateSVG(states, opts.color ?? "#000")
   }
 
   // Healthcare — encode to string, render as Code128
   if (HEALTHCARE_TYPES.has(type)) {
-    let encoded: string;
+    let encoded: string
     switch (type) {
       case "hibc-primary": {
-        const [lic, product, uom] = data.split(":");
-        encoded = encodeHIBCPrimary(lic, product, uom ? Number(uom) : undefined);
-        break;
+        const [lic, product, uom] = data.split(":")
+        encoded = encodeHIBCPrimary(lic, product, uom ? Number(uom) : undefined)
+        break
       }
       case "hibc-secondary": {
-        const [expiry, lot] = data.split(":");
-        encoded = encodeHIBCSecondary(expiry || undefined, lot || undefined);
-        break;
+        const [expiry, lot] = data.split(":")
+        encoded = encodeHIBCSecondary(expiry || undefined, lot || undefined)
+        break
       }
       case "hibc-concatenated": {
-        const [lic, product, expiry, lot] = data.split(":");
-        encoded = encodeHIBCConcatenated(lic, product, { expiry, lot });
-        break;
+        const [lic, product, expiry, lot] = data.split(":")
+        encoded = encodeHIBCConcatenated(lic, product, { expiry, lot })
+        break
       }
       case "isbt-din": {
-        const [cc, facility, year, donation] = data.split(":");
-        encoded = encodeISBT128DIN(cc, facility, year, donation);
-        break;
+        const [cc, facility, year, donation] = data.split(":")
+        encoded = encodeISBT128DIN(cc, facility, year, donation)
+        break
       }
       case "isbt-component":
-        encoded = encodeISBT128Component(data);
-        break;
+        encoded = encodeISBT128Component(data)
+        break
       case "isbt-expiry":
-        encoded = encodeISBT128Expiry(data);
-        break;
+        encoded = encodeISBT128Expiry(data)
+        break
       case "isbt-bloodgroup":
-        encoded = encodeISBT128BloodGroup(data);
-        break;
+        encoded = encodeISBT128BloodGroup(data)
+        break
       default:
-        encoded = data;
+        encoded = data
     }
-    return barcode(encoded, { ...opts, type: "code128" });
+    return barcode(encoded, { ...opts, type: "code128" })
   }
 
   // Standard barcode types
-  return barcode(data, { ...opts, type });
+  return barcode(data, { ...opts, type })
 }
 
 function getBarcodeOpts() {
@@ -440,14 +440,14 @@ function getBarcodeOpts() {
     margin: numVal("bc-margin"),
     marginTop: optNum("bc-mt"),
     marginBottom: optNum("bc-mb"),
-  };
+  }
 }
 
 function renderBarcodePNGPreview() {
   try {
-    const type = val("bc-type");
-    const data = val("bc-data");
-    const opts = getBarcodeOpts();
+    const type = val("bc-type")
+    const data = val("bc-data")
+    const opts = getBarcodeOpts()
     if (!FOURSTATE_TYPES.has(type) && !HEALTHCARE_TYPES.has(type)) {
       const png = barcodePNG(data, {
         type: type as any,
@@ -456,13 +456,13 @@ function renderBarcodePNGPreview() {
         margin: opts.margin,
         color: opts.color,
         background: opts.background,
-      });
-      renderPNGPreview("bc", png);
+      })
+      renderPNGPreview("bc", png)
     } else {
-      renderPNGPreviewFromSVG("bc", generateBarcode(data, type, opts));
+      renderPNGPreviewFromSVG("bc", generateBarcode(data, type, opts))
     }
   } catch (err) {
-    $("bc-output-png").innerHTML = `<div class="error">${(err as Error).message}</div>`;
+    $("bc-output-png").innerHTML = `<div class="error">${(err as Error).message}</div>`
   }
 }
 
@@ -470,19 +470,19 @@ function setupBarcode() {
   const render = () => {
     renderSafe($("bc-output"), () =>
       generateBarcode(val("bc-data"), val("bc-type"), getBarcodeOpts()),
-    );
-    if (previewMode.bc === "png") renderBarcodePNGPreview();
-  };
+    )
+    if (previewMode.bc === "png") renderBarcodePNGPreview()
+  }
 
-  $("bc-output-png").addEventListener("render-png", renderBarcodePNGPreview);
+  $("bc-output-png").addEventListener("render-png", renderBarcodePNGPreview)
 
   $("bc-type").addEventListener("change", () => {
-    const type = val("bc-type");
-    const def = BARCODE_DEFAULTS[type];
-    if (def) $<HTMLInputElement>("bc-data").value = def;
-    $("bc-hint").textContent = FORMAT_HINTS[type] ?? "";
-    render();
-  });
+    const type = val("bc-type")
+    const def = BARCODE_DEFAULTS[type]
+    if (def) $<HTMLInputElement>("bc-data").value = def
+    $("bc-hint").textContent = FORMAT_HINTS[type] ?? ""
+    render()
+  })
 
   listen(
     [
@@ -498,14 +498,14 @@ function setupBarcode() {
       "bc-mb",
     ],
     render,
-  );
-  setupCopyDownload("bc", () => generateBarcode(val("bc-data"), val("bc-type"), getBarcodeOpts()));
+  )
+  setupCopyDownload("bc", () => generateBarcode(val("bc-data"), val("bc-type"), getBarcodeOpts()))
 
   $("bc-download-png").addEventListener("click", () => {
     try {
-      const type = val("bc-type");
-      const data = val("bc-data");
-      const opts = getBarcodeOpts();
+      const type = val("bc-type")
+      const data = val("bc-data")
+      const opts = getBarcodeOpts()
       // Standard barcode types that support direct PNG
       if (!FOURSTATE_TYPES.has(type) && !HEALTHCARE_TYPES.has(type)) {
         const png = barcodePNG(data, {
@@ -515,23 +515,23 @@ function setupBarcode() {
           margin: opts.margin,
           color: opts.color,
           background: opts.background,
-        });
-        downloadPNG(png, `barcode-${type}`);
+        })
+        downloadPNG(png, `barcode-${type}`)
       } else {
         // Fallback: render SVG to canvas for non-standard types
-        const svg = generateBarcode(data, type, opts);
-        svgToPNG(svg).then((png) => downloadPNG(png, `barcode-${type}`));
+        const svg = generateBarcode(data, type, opts)
+        svgToPNG(svg).then((png) => downloadPNG(png, `barcode-${type}`))
       }
     } catch {}
-  });
+  })
 
-  render();
+  render()
 }
 
 // ── QR Code ──
 
 function getQRColor(): string | GradientOptions {
-  const mode = val("qr-colormode");
+  const mode = val("qr-colormode")
   if (mode === "linear")
     return {
       type: "linear",
@@ -540,7 +540,7 @@ function getQRColor(): string | GradientOptions {
         { offset: 0, color: val("qr-grad-start") },
         { offset: 1, color: val("qr-grad-end") },
       ],
-    };
+    }
   if (mode === "radial")
     return {
       type: "radial",
@@ -548,13 +548,13 @@ function getQRColor(): string | GradientOptions {
         { offset: 0, color: val("qr-radial-start") },
         { offset: 1, color: val("qr-radial-end") },
       ],
-    };
-  return val("qr-color");
+    }
+  return val("qr-color")
 }
 
 function getQRBg(): string | GradientOptions | "transparent" {
-  const mode = val("qr-bgmode");
-  if (mode === "transparent") return "transparent";
+  const mode = val("qr-bgmode")
+  if (mode === "transparent") return "transparent"
   if (mode === "linear")
     return {
       type: "linear",
@@ -563,7 +563,7 @@ function getQRBg(): string | GradientOptions | "transparent" {
         { offset: 0, color: val("qr-bg-grad-start") },
         { offset: 1, color: val("qr-bg-grad-end") },
       ],
-    };
+    }
   if (mode === "radial")
     return {
       type: "radial",
@@ -571,51 +571,51 @@ function getQRBg(): string | GradientOptions | "transparent" {
         { offset: 0, color: val("qr-bg-radial-start") },
         { offset: 1, color: val("qr-bg-radial-end") },
       ],
-    };
-  return val("qr-bg");
+    }
+  return val("qr-bg")
 }
 
 function getQRCorners() {
-  const outer = val("qr-corner-outer");
-  const inner = val("qr-corner-inner");
-  if (!outer && !inner) return undefined;
-  const c: Record<string, any> = {};
-  if (outer) c.outerShape = outer;
-  if (inner) c.innerShape = inner;
-  const oc = val("qr-corner-color");
-  const ic = val("qr-corner-inner-color");
-  if (oc !== "#000000") c.outerColor = oc;
-  if (ic !== "#000000") c.innerColor = ic;
-  return { topLeft: c, topRight: { ...c }, bottomLeft: { ...c } };
+  const outer = val("qr-corner-outer")
+  const inner = val("qr-corner-inner")
+  if (!outer && !inner) return undefined
+  const c: Record<string, any> = {}
+  if (outer) c.outerShape = outer
+  if (inner) c.innerShape = inner
+  const oc = val("qr-corner-color")
+  const ic = val("qr-corner-inner-color")
+  if (oc !== "#000000") c.outerColor = oc
+  if (ic !== "#000000") c.innerColor = ic
+  return { topLeft: c, topRight: { ...c }, bottomLeft: { ...c } }
 }
 
 function getQRLogo(): LogoOptions | undefined {
-  const t = val("qr-logo-type");
-  if (t === "none") return undefined;
-  const logo: LogoOptions = { size: Number(val("qr-logo-size")), margin: numVal("qr-logo-margin") };
+  const t = val("qr-logo-type")
+  if (t === "none") return undefined
+  const logo: LogoOptions = { size: Number(val("qr-logo-size")), margin: numVal("qr-logo-margin") }
   if (t === "path") {
-    const p = val("qr-logo-path");
-    if (!p) return undefined;
-    logo.path = p;
+    const p = val("qr-logo-path")
+    if (!p) return undefined
+    logo.path = p
   } else if (t === "url") {
-    const u = val("qr-logo-url");
-    if (!u) return undefined;
-    logo.imageUrl = u;
+    const u = val("qr-logo-url")
+    if (!u) return undefined
+    logo.imageUrl = u
   }
-  return logo;
+  return logo
 }
 
 function generateQR(): string {
-  const isMicro = val("qr-micro") === "micro";
-  const data = val("qr-data");
+  const isMicro = val("qr-micro") === "micro"
+  const data = val("qr-data")
 
   if (isMicro) {
-    const matrix = encodeMicroQR(data, { ecLevel: val("qr-ec") as any });
+    const matrix = encodeMicroQR(data, { ecLevel: val("qr-ec") as any })
     return renderMatrixSVG(matrix, {
       size: numVal("qr-size"),
       color: val("qr-color"),
       margin: numVal("qr-margin"),
-    });
+    })
   }
 
   return qrcode(data, {
@@ -629,15 +629,15 @@ function generateQR(): string {
     background: getQRBg(),
     corners: getQRCorners(),
     logo: getQRLogo(),
-  });
+  })
 }
 
 function renderQRPNGPreview() {
   try {
-    const data = val("qr-data");
-    const isMicro = val("qr-micro") === "micro";
+    const data = val("qr-data")
+    const isMicro = val("qr-micro") === "micro"
     if (isMicro) {
-      renderPNGPreviewFromSVG("qr", generateQR());
+      renderPNGPreviewFromSVG("qr", generateQR())
     } else {
       const png = qrcodePNG(data, {
         ecLevel: val("qr-ec") as any,
@@ -648,21 +648,21 @@ function renderQRPNGPreview() {
           typeof getQRBg() === "string" && getQRBg() !== "transparent"
             ? (getQRBg() as string)
             : "#ffffff",
-      });
-      renderPNGPreview("qr", png);
+      })
+      renderPNGPreview("qr", png)
     }
   } catch (err) {
-    $("qr-output-png").innerHTML = `<div class="error">${(err as Error).message}</div>`;
+    $("qr-output-png").innerHTML = `<div class="error">${(err as Error).message}</div>`
   }
 }
 
 function setupQR() {
   const render = () => {
-    renderSafe($("qr-output"), generateQR);
-    if (previewMode.qr === "png") renderQRPNGPreview();
-  };
+    renderSafe($("qr-output"), generateQR)
+    if (previewMode.qr === "png") renderQRPNGPreview()
+  }
 
-  $("qr-output-png").addEventListener("render-png", renderQRPNGPreview);
+  $("qr-output-png").addEventListener("render-png", renderQRPNGPreview)
 
   // Color mode toggles
   for (const [selectId, group] of [
@@ -670,28 +670,28 @@ function setupQR() {
     ["qr-bgmode", "qr-bg"],
   ] as const) {
     $(selectId).addEventListener("change", () => {
-      const mode = val(selectId);
+      const mode = val(selectId)
       document.querySelectorAll<HTMLElement>(`[data-colorgroup="${group}"]`).forEach((el) => {
-        el.hidden = el.dataset.mode !== mode;
-      });
-      render();
-    });
+        el.hidden = el.dataset.mode !== mode
+      })
+      render()
+    })
   }
 
   // Logo type toggle
   $("qr-logo-type").addEventListener("change", () => {
-    $("qr-logo-path-wrap").hidden = val("qr-logo-type") !== "path";
-    $("qr-logo-url-wrap").hidden = val("qr-logo-type") !== "url";
-    render();
-  });
+    $("qr-logo-path-wrap").hidden = val("qr-logo-type") !== "path"
+    $("qr-logo-url-wrap").hidden = val("qr-logo-type") !== "url"
+    render()
+  })
 
   // Range displays
   $("qr-dotsize").addEventListener("input", () => {
-    $("qr-dotsize-val").textContent = Number(val("qr-dotsize")).toFixed(1);
-  });
+    $("qr-dotsize-val").textContent = Number(val("qr-dotsize")).toFixed(1)
+  })
   $("qr-logo-size").addEventListener("input", () => {
-    $("qr-logo-size-val").textContent = Number(val("qr-logo-size")).toFixed(2);
-  });
+    $("qr-logo-size-val").textContent = Number(val("qr-logo-size")).toFixed(2)
+  })
 
   listen(
     [
@@ -725,17 +725,17 @@ function setupQR() {
       "qr-logo-margin",
     ],
     render,
-  );
+  )
 
-  setupCopyDownload("qr", generateQR);
+  setupCopyDownload("qr", generateQR)
 
   $("qr-download-png").addEventListener("click", () => {
     try {
-      const data = val("qr-data");
-      const isMicro = val("qr-micro") === "micro";
+      const data = val("qr-data")
+      const isMicro = val("qr-micro") === "micro"
       if (isMicro) {
         // Micro QR — fallback via SVG canvas
-        svgToPNG(generateQR()).then((png) => downloadPNG(png, "qr-micro"));
+        svgToPNG(generateQR()).then((png) => downloadPNG(png, "qr-micro"))
       } else {
         const png = qrcodePNG(data, {
           ecLevel: val("qr-ec") as any,
@@ -746,13 +746,13 @@ function setupQR() {
             typeof getQRBg() === "string" && getQRBg() !== "transparent"
               ? (getQRBg() as string)
               : "#ffffff",
-        });
-        downloadPNG(png, "qrcode");
+        })
+        downloadPNG(png, "qrcode")
       }
     } catch {}
-  });
+  })
 
-  render();
+  render()
 }
 
 // ── 2D Codes ──
@@ -767,23 +767,23 @@ const M2D_OPTION_PANELS: Record<string, string> = {
   jabcode: "m2d-jab-opts",
   "gs1-composite": "m2d-composite-opts",
   codablockf: "m2d-codablockf-opts",
-};
+}
 
 function generate2D(): string {
-  const format = val("m2d-format");
-  const data = val("m2d-data");
+  const format = val("m2d-format")
+  const data = val("m2d-data")
   const svgOpts = {
     size: numVal("m2d-size"),
     color: val("m2d-color"),
     background: val("m2d-bg"),
     margin: numVal("m2d-margin"),
-  };
+  }
 
   switch (format) {
     case "datamatrix":
-      return datamatrix(data, svgOpts);
+      return datamatrix(data, svgOpts)
     case "gs1datamatrix":
-      return gs1datamatrix(data, svgOpts);
+      return gs1datamatrix(data, svgOpts)
     case "pdf417":
       return pdf417(data, {
         ...svgOpts,
@@ -791,126 +791,126 @@ function generate2D(): string {
         ecLevel: numVal("m2d-pdf-ec"),
         columns: optNum("m2d-pdf-cols"),
         compact: val("m2d-pdf-compact") === "true",
-      });
+      })
     case "aztec":
       return aztec(data, {
         ...svgOpts,
         ecPercent: numVal("m2d-az-ec"),
         layers: optNum("m2d-az-layers"),
         compact: val("m2d-az-compact") === "true",
-      });
+      })
     case "micropdf417": {
-      const cols = optNum("m2d-mpdf-cols");
-      const r = encodeMicroPDF417(data, cols ? { columns: cols as any } : undefined);
-      return renderMatrixSVG(r.matrix, svgOpts);
+      const cols = optNum("m2d-mpdf-cols")
+      const r = encodeMicroPDF417(data, cols ? { columns: cols as any } : undefined)
+      return renderMatrixSVG(r.matrix, svgOpts)
     }
     case "rmqr":
-      return renderMatrixSVG(encodeRMQR(data, { ecLevel: val("m2d-rmqr-ec") as any }), svgOpts);
+      return renderMatrixSVG(encodeRMQR(data, { ecLevel: val("m2d-rmqr-ec") as any }), svgOpts)
     case "maxicode":
       return renderMatrixSVG(
         encodeMaxiCode(data, { mode: numVal("m2d-maxi-mode") as any }),
         svgOpts,
-      );
+      )
     case "dotcode":
-      return renderMatrixSVG(encodeDotCode(data), svgOpts);
+      return renderMatrixSVG(encodeDotCode(data), svgOpts)
     case "hanxin":
       return renderMatrixSVG(
         encodeHanXin(data, { ecLevel: numVal("m2d-hanxin-ec") as any }),
         svgOpts,
-      );
+      )
     case "jabcode":
       return renderJABCodeSVG(
         encodeJABCode(data, { colors: numVal("m2d-jab-colors") as any }),
         svgOpts.size,
-      );
+      )
     case "codablockf": {
-      const cols = optNum("m2d-cbf-cols");
-      const r = encodeCodablockF(data, cols ? { columns: cols } : undefined);
-      return renderMatrixSVG(r.matrix, svgOpts);
+      const cols = optNum("m2d-cbf-cols")
+      const r = encodeCodablockF(data, cols ? { columns: cols } : undefined)
+      return renderMatrixSVG(r.matrix, svgOpts)
     }
     case "code16k":
-      return renderMatrixSVG(encodeCode16K(data).matrix, svgOpts);
+      return renderMatrixSVG(encodeCode16K(data).matrix, svgOpts)
     case "gs1-composite":
       return renderMatrixSVG(
         encodeGS1Composite(data, val("m2d-comp-type") as any).composite,
         svgOpts,
-      );
+      )
     default:
-      return datamatrix(data, svgOpts);
+      return datamatrix(data, svgOpts)
   }
 }
 
 function render2DPNGPreview() {
   try {
-    const format = val("m2d-format");
-    const data = val("m2d-data");
+    const format = val("m2d-format")
+    const data = val("m2d-data")
     const pngOpts = {
       moduleSize: Math.max(2, Math.round(numVal("m2d-size") / 30)),
       margin: numVal("m2d-margin"),
       color: val("m2d-color"),
       background: val("m2d-bg"),
-    };
+    }
 
-    let png: Uint8Array | null = null;
+    let png: Uint8Array | null = null
     switch (format) {
       case "datamatrix":
-        png = datamatrixPNG(data, pngOpts);
-        break;
+        png = datamatrixPNG(data, pngOpts)
+        break
       case "gs1datamatrix":
-        png = gs1datamatrixPNG(data, pngOpts);
-        break;
+        png = gs1datamatrixPNG(data, pngOpts)
+        break
       case "pdf417":
         png = pdf417PNG(data, {
           ...pngOpts,
           ecLevel: numVal("m2d-pdf-ec"),
           columns: optNum("m2d-pdf-cols"),
           compact: val("m2d-pdf-compact") === "true",
-        });
-        break;
+        })
+        break
       case "aztec":
         png = aztecPNG(data, {
           ...pngOpts,
           ecPercent: numVal("m2d-az-ec"),
           layers: optNum("m2d-az-layers"),
           compact: val("m2d-az-compact") === "true",
-        });
-        break;
+        })
+        break
       default:
-        renderPNGPreviewFromSVG("m2d", generate2D());
-        return;
+        renderPNGPreviewFromSVG("m2d", generate2D())
+        return
     }
-    if (png) renderPNGPreview("m2d", png);
+    if (png) renderPNGPreview("m2d", png)
   } catch (err) {
-    $("m2d-output-png").innerHTML = `<div class="error">${(err as Error).message}</div>`;
+    $("m2d-output-png").innerHTML = `<div class="error">${(err as Error).message}</div>`
   }
 }
 
 function setup2D() {
   const render = () => {
-    renderSafe($("m2d-output"), generate2D);
-    if (previewMode.m2d === "png") render2DPNGPreview();
-  };
+    renderSafe($("m2d-output"), generate2D)
+    if (previewMode.m2d === "png") render2DPNGPreview()
+  }
 
-  $("m2d-output-png").addEventListener("render-png", render2DPNGPreview);
+  $("m2d-output-png").addEventListener("render-png", render2DPNGPreview)
 
   $("m2d-format").addEventListener("change", () => {
-    const format = val("m2d-format");
+    const format = val("m2d-format")
     // Hide all option panels
     for (const panelId of Object.values(M2D_OPTION_PANELS)) {
-      $<HTMLDetailsElement>(panelId).hidden = true;
+      $<HTMLDetailsElement>(panelId).hidden = true
     }
     // Show relevant panel
-    const panelId = M2D_OPTION_PANELS[format];
+    const panelId = M2D_OPTION_PANELS[format]
     if (panelId) {
-      const panel = $<HTMLDetailsElement>(panelId);
-      panel.hidden = false;
-      panel.open = true;
+      const panel = $<HTMLDetailsElement>(panelId)
+      panel.hidden = false
+      panel.open = true
     }
     // Update default data
-    const def = M2D_DEFAULTS[format];
-    if (def) $<HTMLInputElement>("m2d-data").value = def;
-    render();
-  });
+    const def = M2D_DEFAULTS[format]
+    if (def) $<HTMLInputElement>("m2d-data").value = def
+    render()
+  })
 
   listen(
     [
@@ -935,70 +935,70 @@ function setup2D() {
       "m2d-cbf-cols",
     ],
     render,
-  );
+  )
 
-  setupCopyDownload("m2d", generate2D);
+  setupCopyDownload("m2d", generate2D)
 
   $("m2d-download-png").addEventListener("click", () => {
     try {
-      const format = val("m2d-format");
-      const data = val("m2d-data");
+      const format = val("m2d-format")
+      const data = val("m2d-data")
       const pngOpts = {
         moduleSize: Math.max(2, Math.round(numVal("m2d-size") / 30)),
         margin: numVal("m2d-margin"),
         color: val("m2d-color"),
         background: val("m2d-bg"),
-      };
+      }
 
-      let png: Uint8Array | null = null;
+      let png: Uint8Array | null = null
       switch (format) {
         case "datamatrix":
-          png = datamatrixPNG(data, pngOpts);
-          break;
+          png = datamatrixPNG(data, pngOpts)
+          break
         case "gs1datamatrix":
-          png = gs1datamatrixPNG(data, pngOpts);
-          break;
+          png = gs1datamatrixPNG(data, pngOpts)
+          break
         case "pdf417":
           png = pdf417PNG(data, {
             ...pngOpts,
             ecLevel: numVal("m2d-pdf-ec"),
             columns: optNum("m2d-pdf-cols"),
             compact: val("m2d-pdf-compact") === "true",
-          });
-          break;
+          })
+          break
         case "aztec":
           png = aztecPNG(data, {
             ...pngOpts,
             ecPercent: numVal("m2d-az-ec"),
             layers: optNum("m2d-az-layers"),
             compact: val("m2d-az-compact") === "true",
-          });
-          break;
+          })
+          break
         default:
           // Fallback for formats without direct PNG support
-          svgToPNG(generate2D()).then((p) => downloadPNG(p, `2d-${format}`));
-          return;
+          svgToPNG(generate2D()).then((p) => downloadPNG(p, `2d-${format}`))
+          return
       }
-      if (png) downloadPNG(png, `2d-${format}`);
+      if (png) downloadPNG(png, `2d-${format}`)
     } catch {}
-  });
+  })
 
-  render();
+  render()
 }
 
 // ── Helpers ──
 
-const helperSVGs = new Map<string, string>();
+const helperSVGs = new Map<string, string>()
 
 function renderHelper(id: string, fn: () => string) {
-  const target = $(`${id}-out`);
+  const target = $(`${id}-out`)
   try {
-    const svg = fn();
-    helperSVGs.set(id, svg);
-    target.innerHTML = svg;
+    const svg = fn()
+    helperSVGs.set(id, svg)
+    target.innerHTML = svg
   } catch (err) {
-    helperSVGs.delete(id);
-    target.innerHTML = `<div class="error">${(err as Error).message}</div>`;
+    helperSVGs.delete(id)
+    target.innerHTML = `<div class="error">${(err as Error).message}</div>`
   }
 }
 
@@ -1006,30 +1006,30 @@ function setupHelpers() {
   const rWifi = () =>
     renderHelper("h-wifi", () =>
       wifi(val("h-wifi-ssid"), val("h-wifi-pass"), { encryption: val("h-wifi-enc") as any }),
-    );
-  listen(["h-wifi-ssid", "h-wifi-pass", "h-wifi-enc"], rWifi);
-  rWifi();
+    )
+  listen(["h-wifi-ssid", "h-wifi-pass", "h-wifi-enc"], rWifi)
+  rWifi()
 
-  const rUrl = () => renderHelper("h-url", () => url(val("h-url")));
-  listen(["h-url"], rUrl);
-  rUrl();
+  const rUrl = () => renderHelper("h-url", () => url(val("h-url")))
+  listen(["h-url"], rUrl)
+  rUrl()
 
-  const rEmail = () => renderHelper("h-email", () => email(val("h-email")));
-  listen(["h-email"], rEmail);
-  rEmail();
+  const rEmail = () => renderHelper("h-email", () => email(val("h-email")))
+  listen(["h-email"], rEmail)
+  rEmail()
 
   const rSms = () =>
-    renderHelper("h-sms", () => sms(val("h-sms-num"), val("h-sms-body") || undefined));
-  listen(["h-sms-num", "h-sms-body"], rSms);
-  rSms();
+    renderHelper("h-sms", () => sms(val("h-sms-num"), val("h-sms-body") || undefined))
+  listen(["h-sms-num", "h-sms-body"], rSms)
+  rSms()
 
-  const rPhone = () => renderHelper("h-phone", () => phone(val("h-phone")));
-  listen(["h-phone"], rPhone);
-  rPhone();
+  const rPhone = () => renderHelper("h-phone", () => phone(val("h-phone")))
+  listen(["h-phone"], rPhone)
+  rPhone()
 
-  const rGeo = () => renderHelper("h-geo", () => geo(numVal("h-geo-lat"), numVal("h-geo-lng")));
-  listen(["h-geo-lat", "h-geo-lng"], rGeo);
-  rGeo();
+  const rGeo = () => renderHelper("h-geo", () => geo(numVal("h-geo-lat"), numVal("h-geo-lng")))
+  listen(["h-geo-lat", "h-geo-lng"], rGeo)
+  rGeo()
 
   const rVcard = () =>
     renderHelper("h-vcard", () =>
@@ -1042,12 +1042,12 @@ function setupHelpers() {
         title: val("h-vc-title") || undefined,
         url: val("h-vc-url") || undefined,
       }),
-    );
+    )
   listen(
     ["h-vc-fn", "h-vc-ln", "h-vc-phone", "h-vc-email", "h-vc-org", "h-vc-title", "h-vc-url"],
     rVcard,
-  );
-  rVcard();
+  )
+  rVcard()
 
   const rMecard = () =>
     renderHelper("h-mecard", () =>
@@ -1056,9 +1056,9 @@ function setupHelpers() {
         phone: val("h-mc-phone") || undefined,
         email: val("h-mc-email") || undefined,
       }),
-    );
-  listen(["h-mc-name", "h-mc-phone", "h-mc-email"], rMecard);
-  rMecard();
+    )
+  listen(["h-mc-name", "h-mc-phone", "h-mc-email"], rMecard)
+  rMecard()
 
   const rEvent = () =>
     renderHelper("h-event", () =>
@@ -1068,9 +1068,9 @@ function setupHelpers() {
         end: val("h-ev-end") || undefined,
         location: val("h-ev-loc") || undefined,
       }),
-    );
-  listen(["h-ev-title", "h-ev-start", "h-ev-end", "h-ev-loc"], rEvent);
-  rEvent();
+    )
+  listen(["h-ev-title", "h-ev-start", "h-ev-end", "h-ev-loc"], rEvent)
+  rEvent()
 
   const rSwiss = () =>
     renderHelper("h-swiss", () =>
@@ -1085,7 +1085,7 @@ function setupHelpers() {
         amount: numVal("h-sq-amount"),
         currency: val("h-sq-currency") as any,
       }),
-    );
+    )
   listen(
     [
       "h-sq-iban",
@@ -1097,8 +1097,8 @@ function setupHelpers() {
       "h-sq-currency",
     ],
     rSwiss,
-  );
-  rSwiss();
+  )
+  rSwiss()
 
   const rGS1 = () =>
     renderHelper("h-gs1", () =>
@@ -1107,38 +1107,38 @@ function setupHelpers() {
         batch: val("h-gs1-batch") || undefined,
         serial: val("h-gs1-serial") || undefined,
       }),
-    );
-  listen(["h-gs1-gtin", "h-gs1-batch", "h-gs1-serial"], rGS1);
-  rGS1();
+    )
+  listen(["h-gs1-gtin", "h-gs1-batch", "h-gs1-serial"], rGS1)
+  rGS1()
 
   // Delegation for copy/download
   document.querySelectorAll<HTMLButtonElement>("[data-helper-copy]").forEach((btn) => {
     btn.addEventListener("click", () => {
-      const svg = helperSVGs.get(btn.dataset.helperCopy!);
-      if (svg) copySVG(svg);
-    });
-  });
+      const svg = helperSVGs.get(btn.dataset.helperCopy!)
+      if (svg) copySVG(svg)
+    })
+  })
   document.querySelectorAll<HTMLButtonElement>("[data-helper-dl]").forEach((btn) => {
     btn.addEventListener("click", () => {
-      const svg = helperSVGs.get(btn.dataset.helperDl!);
-      if (svg) downloadSVG(svg, btn.dataset.helperDl!);
-    });
-  });
+      const svg = helperSVGs.get(btn.dataset.helperDl!)
+      if (svg) downloadSVG(svg, btn.dataset.helperDl!)
+    })
+  })
   document.querySelectorAll<HTMLButtonElement>("[data-helper-png]").forEach((btn) => {
     btn.addEventListener("click", () => {
-      const svg = helperSVGs.get(btn.dataset.helperPng!);
-      if (svg) svgToPNG(svg).then((png) => downloadPNG(png, btn.dataset.helperPng!));
-    });
-  });
+      const svg = helperSVGs.get(btn.dataset.helperPng!)
+      if (svg) svgToPNG(svg).then((png) => downloadPNG(png, btn.dataset.helperPng!))
+    })
+  })
 }
 
 // ── Init ──
 
 export function setupApp() {
-  setupTabs();
-  setupPreviewToggles();
-  setupBarcode();
-  setupQR();
-  setup2D();
-  setupHelpers();
+  setupTabs()
+  setupPreviewToggles()
+  setupBarcode()
+  setupQR()
+  setup2D()
+  setupHelpers()
 }

--- a/web/app/entry-client.ts
+++ b/web/app/entry-client.ts
@@ -1,3 +1,3 @@
-import { setupApp } from "./app.ts";
+import { setupApp } from "./app.ts"
 
-setupApp();
+setupApp()

--- a/web/nitro.config.ts
+++ b/web/nitro.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "nitro";
+import { defineConfig } from "nitro"
 
 export default defineConfig({
   serverDir: "./server",
-});
+})

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from "vite";
-import { nitro } from "nitro/vite";
+import { defineConfig } from "vite"
+import { nitro } from "nitro/vite"
 
 export default defineConfig({
   plugins: [nitro()],
   resolve: {
     tsconfigPaths: true,
   },
-});
+})


### PR DESCRIPTION
Turns off statement-ending semicolons in the formatter and reformats the repository.

## The setting

oxfmt exposes `semi` (boolean, default `true`) in `.oxfmtrc.json`:

```json
{
  "$schema": "https://unpkg.com/oxfmt/configuration_schema.json",
  "semi": false,
  "ignorePatterns": ["CHANGELOG.md"]
}
```

Running `oxfmt .` then strips them everywhere — `src`, `test`, `web` and the code samples inside `docs`. 207 files touched.

## ASI safety

Dropping semicolons is only safe if lines that begin with `(`, `[`, `` ` ``, `+`, `-` or `/` are guarded, since automatic semicolon insertion would otherwise join them to the previous line and change meaning. oxfmt handles this by prefixing such lines with a semicolon. Six were needed:

- five IIFEs that build the Galois field lookup tables — `dotcode`, `maxicode`, `hanxin`, and the two Reed-Solomon modules. These are required and stay.
- one in `docs/rendering/index.md`, where a bare template literal illustrated an `<img>` tag. Rather than ship example code opening with a stray `;`, I assigned it to a const:

```ts
const html = `<img src="${uri}" alt="QR Code" />`
```

`AGENTS.md` is updated, since it documented the old convention as "double quotes, semicolons".

## Verification

Formatting only — no behaviour change intended, and none observed:

- `pnpm test` (lint + typecheck + **1613 tests**) green
- `pnpm build` clean
- built `dist/` smoke-tested across all 8 entry points and the CLI bin, since ASI bugs would surface at runtime rather than at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)