### PR TITLE
fix: EAN and UPC stripped anything that was not a digit, and the sweeps that found it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,14 +221,24 @@ is known and turns red the moment it is fixed.
   Latin-1. `decodeBytes` in `encoders-modes-roundtrip.test.ts` does this.
 - The PNG encoder emits stored (uncompressed) DEFLATE, so tests can decode PNG
   output and assert on real pixels; `ico-formats.test.ts` shows the pattern.
+- A fixed sample list catches a broken table and misses a mis-taken branch.
+  `encoders-random-differential.test.ts` throws a few hundred seeded random
+  payloads at each no-decoder format and compares every module against BWIPP,
+  which is what took Code 16K from 75% to 95% covered with every new line
+  verified rather than merely executed.
+- Nothing an encoder is given may disappear. `encoders-input-fidelity.test.ts`
+  appends a character to a payload every symbology accepts and requires the
+  symbol to change or the input to be refused — the general form of the Code 128
+  defect that dropped every character above 126 while producing a well formed
+  symbol for different data.
 
 ## Project Status
 
 v1. The full gate (`pnpm test`) is green:
 
-- **116 test files, 3080+ tests** passing
+- **119 test files, 3140+ tests** passing
 - **Zero** lint warnings, zero typecheck errors
-- **95.6%** statements, **91.6%** branches — thresholds enforced in CI by
+- **96.7%** statements, **92.9%** branches — thresholds enforced in CI by
   `vitest.config.ts`
 - Every symbology reachable from the public API, the CLI, PNG output and
   validation

--- a/docs/barcodes/ean.md
+++ b/docs/barcodes/ean.md
@@ -26,6 +26,13 @@ barcode("96385074", { type: "ean8" })
 barcode("9638507", { type: "ean8" })
 ```
 
+## What the Input May Contain
+
+Digits, and the spaces and hyphens a number is printed with — `4-006381-333931`
+is the same symbol as `4006381333931`. Anything else raises `InvalidInputError`
+rather than being stripped, because stripping it would encode a number nobody
+asked for: `40063813339O1` would quietly become a symbol for eleven digits.
+
 ## EAN-5 (Addon)
 
 5-digit supplemental barcode for book pricing.

--- a/docs/barcodes/upc.md
+++ b/docs/barcodes/upc.md
@@ -26,6 +26,12 @@ barcode("01234565", { type: "upce" })
 barcode("123456", { type: "upce" })
 ```
 
+## What the Input May Contain
+
+Digits, and the spaces and hyphens a number is printed with — `0-36000-29145-2`
+is the same symbol as `036000291452`. Anything else raises `InvalidInputError`
+rather than being stripped.
+
 ## Raw Encoders
 
 ```ts

--- a/src/encoders/ean.ts
+++ b/src/encoders/ean.ts
@@ -4,6 +4,28 @@
 
 import { InvalidInputError, CheckDigitError } from "../errors"
 
+/**
+ * The digits of a printed EAN or UPC number.
+ *
+ * Spaces and hyphens are how these numbers are written on a pack, so they are
+ * dropped. Anything else is a typo rather than punctuation, and stripping it
+ * would encode a number the caller did not ask for — `40063813339O1` would
+ * quietly become a valid symbol for eleven digits.
+ */
+export function eanDigits(text: string, symbology: string): number[] {
+  const digits: number[] = []
+  for (const character of text) {
+    if (character === " " || character === "-") continue
+    if (character < "0" || character > "9") {
+      throw new InvalidInputError(
+        `${symbology} accepts digits, spaces and hyphens only (got '${character}')`,
+      )
+    }
+    digits.push(character.charCodeAt(0) - 48)
+  }
+  return digits
+}
+
 // Encoding patterns for digits
 // L = left odd parity, G = left even parity, R = right
 const L_PATTERNS: number[][] = [
@@ -89,7 +111,7 @@ function calculateCheckDigit(digits: number[]): number {
  * Input: 12 or 13 digit string (13th is check digit, auto-calculated if 12)
  */
 export function encodeEAN13(text: string): { bars: number[]; guards: number[] } {
-  const digits = text.replace(/\D/g, "").split("").map(Number)
+  const digits = eanDigits(text, "EAN-13")
 
   if (digits.length === 12) {
     digits.push(calculateCheckDigit(digits))
@@ -160,7 +182,7 @@ export function encodeEAN13(text: string): { bars: number[]; guards: number[] } 
  * Input: 7 or 8 digit string (8th is check digit, auto-calculated if 7)
  */
 export function encodeEAN8(text: string): { bars: number[]; guards: number[] } {
-  const digits = text.replace(/\D/g, "").split("").map(Number)
+  const digits = eanDigits(text, "EAN-8")
 
   if (digits.length === 7) {
     digits.push(calculateCheckDigit(digits))

--- a/src/encoders/upc.ts
+++ b/src/encoders/upc.ts
@@ -3,6 +3,7 @@
  */
 
 import { InvalidInputError, CheckDigitError } from "../errors"
+import { eanDigits } from "./ean"
 
 // Encoding patterns for digits (same as EAN, duplicated to avoid inter-encoder dependencies)
 // L = left odd parity, G = left even parity, R = right
@@ -119,7 +120,7 @@ function expandUPCE(numberSystem: number, middleDigits: number[]): number[] {
  * @returns bars (widths) and guard positions
  */
 export function encodeUPCA(text: string): { bars: number[]; guards: number[] } {
-  const digits = text.replace(/\D/g, "").split("").map(Number)
+  const digits = eanDigits(text, "UPC-A")
 
   if (digits.length === 11) {
     digits.push(calculateCheckDigit(digits))
@@ -196,7 +197,7 @@ export function encodeUPCA(text: string): { bars: number[]; guards: number[] } {
  * @returns bars (widths) and guard positions
  */
 export function encodeUPCE(text: string): { bars: number[]; guards: number[] } {
-  const raw = text.replace(/\D/g, "").split("").map(Number)
+  const raw = eanDigits(text, "UPC-E")
 
   let numberSystem: number
   let middleDigits: number[]

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -35,3 +35,7 @@ declare module "node:path" {
   export function dirname(path: string): string
   export function join(...paths: string[]): string
 }
+
+declare module "node:module" {
+  export function createRequire(url: string | URL): { resolve(id: string): string }
+}

--- a/src/validators/barcode.ts
+++ b/src/validators/barcode.ts
@@ -13,6 +13,17 @@ import { encodeCode2of5 } from "../encoders/code2of5"
 import { encodeCode32, encodePZN } from "../encoders/pharma-national"
 import { postnetCheckDigit } from "../encoders/postnet"
 
+/**
+ * The digits of a printed EAN or UPC number, or null when the input holds
+ * something that is neither a digit nor the spaces and hyphens such numbers are
+ * printed with. Mirrors what `eanDigits` in the encoder accepts, so the
+ * validator cannot pass input the encoder then refuses.
+ */
+function eanDigitsOrNull(text: string): string | null {
+  const digits = text.replaceAll(/[\s-]/g, "")
+  return /^\d*$/.test(digits) ? digits : null
+}
+
 /** Report whether the encoder accepts the input, and why not when it does not. */
 function byEncoding(encode: () => unknown): { valid: boolean; error?: string } {
   try {
@@ -49,7 +60,10 @@ export function validateBarcode(text: string, type: string): { valid: boolean; e
       return { valid: true }
 
     case "ean13": {
-      const digits = text.replace(/\D/g, "")
+      const digits = eanDigitsOrNull(text)
+      if (digits === null) {
+        return { valid: false, error: "EAN-13 accepts digits, spaces and hyphens only" }
+      }
       if (digits.length !== 12 && digits.length !== 13) {
         return { valid: false, error: "EAN-13 requires 12 or 13 digits" }
       }
@@ -60,7 +74,10 @@ export function validateBarcode(text: string, type: string): { valid: boolean; e
     }
 
     case "ean8": {
-      const digits = text.replace(/\D/g, "")
+      const digits = eanDigitsOrNull(text)
+      if (digits === null) {
+        return { valid: false, error: "EAN-8 accepts digits, spaces and hyphens only" }
+      }
       if (digits.length !== 7 && digits.length !== 8) {
         return { valid: false, error: "EAN-8 requires 7 or 8 digits" }
       }
@@ -98,7 +115,10 @@ export function validateBarcode(text: string, type: string): { valid: boolean; e
     }
 
     case "upca": {
-      const digits = text.replace(/\D/g, "")
+      const digits = eanDigitsOrNull(text)
+      if (digits === null) {
+        return { valid: false, error: "UPC-A accepts digits, spaces and hyphens only" }
+      }
       if (digits.length !== 11 && digits.length !== 12) {
         return { valid: false, error: "UPC-A requires 11 or 12 digits" }
       }
@@ -106,7 +126,10 @@ export function validateBarcode(text: string, type: string): { valid: boolean; e
     }
 
     case "upce": {
-      const digits = text.replace(/\D/g, "")
+      const digits = eanDigitsOrNull(text)
+      if (digits === null) {
+        return { valid: false, error: "UPC-E accepts digits, spaces and hyphens only" }
+      }
       if (digits.length < 6 || digits.length > 8) {
         return { valid: false, error: "UPC-E requires 6-8 digits" }
       }
@@ -393,21 +416,24 @@ export function validateBarcodeInput(
   // Compute check digit for types that support it
   switch (type) {
     case "ean13": {
-      const digits = text.replace(/\D/g, "").split("").map(Number)
+      // validateBarcode above has already refused anything but digits
+      const digits = (eanDigitsOrNull(text) ?? "").split("").map(Number)
       const dataDigits = digits.slice(0, 12)
       const checkDigit = calculateEANCheckDigit(dataDigits)
       return { valid: true, checkDigit }
     }
 
     case "ean8": {
-      const digits = text.replace(/\D/g, "").split("").map(Number)
+      // validateBarcode above has already refused anything but digits
+      const digits = (eanDigitsOrNull(text) ?? "").split("").map(Number)
       const dataDigits = digits.slice(0, 7)
       const checkDigit = calculateEANCheckDigit(dataDigits)
       return { valid: true, checkDigit }
     }
 
     case "upca": {
-      const digits = text.replace(/\D/g, "").split("").map(Number)
+      // validateBarcode above has already refused anything but digits
+      const digits = (eanDigitsOrNull(text) ?? "").split("").map(Number)
       const dataDigits = digits.slice(0, 11)
       const checkDigit = calculateUPCACheckDigit(dataDigits)
       return { valid: true, checkDigit }

--- a/test/_zxing-setup.ts
+++ b/test/_zxing-setup.ts
@@ -1,0 +1,27 @@
+/**
+ * Point zxing-wasm at the WebAssembly binary in `node_modules`.
+ *
+ * Left alone, zxing-wasm fetches `zxing_reader.wasm` over the network at the
+ * first decode. That works until it does not: one CI run failed sixteen tests
+ * with `Aborted(both async and sync fetching of the wasm failed)` while the
+ * same commit passed in the job beside it. A test suite whose result depends on
+ * a CDN being reachable is not a test suite, so the binary is read off disk —
+ * the copy the lockfile pinned, and no request at all.
+ */
+
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { prepareZXingModule } from "zxing-wasm/reader"
+
+const wasmBinary = readFileSync(
+  createRequire(import.meta.url).resolve("zxing-wasm/reader/zxing_reader.wasm"),
+)
+
+prepareZXingModule({
+  overrides: {
+    wasmBinary: wasmBinary.buffer.slice(
+      wasmBinary.byteOffset,
+      wasmBinary.byteOffset + wasmBinary.byteLength,
+    ) as ArrayBuffer,
+  },
+})

--- a/test/encoders-input-fidelity.test.ts
+++ b/test/encoders-input-fidelity.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Nothing an encoder is given may disappear.
+ *
+ * Code 128 walked past every character above 126 without encoding it, and no
+ * test noticed because the symbol it produced was perfectly well formed — just
+ * for different data. The sweep below is the general form of that check: append
+ * a character to a payload each symbology accepts, and the result has to either
+ * change or be refused. Silently coming back the same means the character went
+ * nowhere.
+ */
+
+import { describe, expect, it } from "vitest"
+import { encodeBars } from "../src/_barcode"
+import { encode } from "../src/_encode"
+import { BARCODE_TYPES, EXTRA_ENCODE_TYPES } from "../src/_types"
+import type { BarcodeType, EncodeType } from "../src/_types"
+
+/** A payload each linear type accepts, with room to grow. */
+const LINEAR: Record<BarcodeType, string> = {
+  code128: "AB",
+  // A base whose check digit is not one of the characters appended below,
+  // where the "extra" would legitimately complete the number
+  ean13: "978030640615",
+  ean8: "9638507",
+  code39: "AB",
+  code39ext: "AB",
+  code93: "AB",
+  code93ext: "AB",
+  itf: "1234",
+  itf14: "0001234567890",
+  upca: "03600029145",
+  upce: "012345",
+  ean2: "12",
+  ean5: "12345",
+  codabar: "1234",
+  msi: "1234",
+  pharmacode: "1234",
+  code11: "1234",
+  "gs1-128": "(10)AB",
+  identcode: "56310243031",
+  leitcode: "2134807501650",
+  postnet: "12345",
+  planet: "12345678901",
+  plessey: "1234",
+  "gs1-databar": "0012345678901",
+  "gs1-databar-limited": "0012345678901",
+  "gs1-databar-expanded": "(01)90012345678908",
+  "gs1-databar-truncated": "0012345678901",
+  ean14: "9876543210987",
+  sscc18: "10614141192837465",
+  isbn: "978-0-306-40615-7",
+  issn: "0317-8471",
+  ismn: "M-2306-7118-7",
+  code32: "12345678",
+  pzn: "123456",
+  pzn8: "1234567",
+  industrial2of5: "1234",
+  iata2of5: "1234",
+  matrix2of5: "1234",
+  coop2of5: "1234",
+  datalogic2of5: "1234",
+}
+
+/**
+ * Characters to append. Spaces and hyphens are left out: several symbologies
+ * treat them as the punctuation a printed number is written with and drop them
+ * deliberately, which is documented on each.
+ */
+const EXTRAS = ["A", "1", "é", "", "日", "%"]
+
+/** Height-modulated types have no bar widths; `encodeBars` refuses them. */
+const HEIGHT_MODULATED = new Set<string>(["postnet", "planet"])
+
+describe("no encoder drops input on the floor", () => {
+  for (const type of BARCODE_TYPES) {
+    if (HEIGHT_MODULATED.has(type)) continue
+    it(type, () => {
+      const base = LINEAR[type]
+      const baseline = JSON.stringify(encodeBars(base, { type }))
+      for (const extra of EXTRAS) {
+        let longer: string | undefined
+        try {
+          longer = JSON.stringify(encodeBars(base + extra, { type }))
+        } catch {
+          continue // refused, which is the other acceptable answer
+        }
+        expect(longer, `${type} ignored ${JSON.stringify(extra)}`).not.toBe(baseline)
+      }
+    })
+  }
+
+  for (const type of EXTRA_ENCODE_TYPES) {
+    if (HEIGHT_MODULATED.has(type)) continue
+    it(type, () => {
+      const base = SAMPLE_2D[type] ?? "AB12"
+      const baseline = JSON.stringify(encode(base, { type }))
+      for (const extra of EXTRAS) {
+        let longer: string | undefined
+        try {
+          longer = JSON.stringify(encode(base + extra, { type }))
+        } catch {
+          continue
+        }
+        expect(longer, `${type} ignored ${JSON.stringify(extra)}`).not.toBe(baseline)
+      }
+    })
+  }
+})
+
+/** Types whose input is not free text. */
+const SAMPLE_2D: Partial<Record<EncodeType, string>> = {
+  rm4scc: "SN34RD1A",
+  kix: "2500GG",
+  auspost: "12345678",
+  jppost: "1234567",
+  imb: "01234567094987654321",
+  "gs1-datamatrix": "(10)AB",
+  aztecrune: "4",
+}

--- a/test/encoders-random-differential.test.ts
+++ b/test/encoders-random-differential.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Randomised differential testing against BWIPP.
+ *
+ * The formats with no decoder are pinned by a handful of hand-picked payloads
+ * each, which is enough to catch a broken table and not enough to catch a
+ * mis-taken branch: Code 16K alone chooses between fourteen shift and latch
+ * moves, and a fixed sample list reaches perhaps half of them. These sweeps
+ * throw a few hundred payloads over a deliberately awkward alphabet — control
+ * characters, lower case, digit runs of both parities — at each encoder and
+ * compare every module against the reference.
+ *
+ * The generator is seeded, so a failure is reproducible: the payload is printed
+ * with the assertion.
+ */
+
+import { describe, expect, it } from "vitest"
+import { bwipMatrix } from "./_bwip"
+import { encodeCodablockF } from "../src/encoders/codablock-f"
+import { encodeCode16K } from "../src/encoders/code16k"
+import { encodeDotCode } from "../src/encoders/dotcode"
+
+/** Deterministic generator: the same seed always yields the same payloads. */
+function makeRandom(seed: number): () => number {
+  let state = seed
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff
+    return state / 0x7fffffff
+  }
+}
+
+const ALPHABETS = [
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  "abcdefghijklmnopqrstuvwxyz",
+  "0123456789",
+  " .,-/:;()$%*+",
+  "\x01\x02\x03\x04\x05\x1b\x1f",
+]
+
+/** `count` payloads mixing the alphabets, up to `maxLength` characters. */
+function payloads(seed: number, count: number, maxLength: number): string[] {
+  const random = makeRandom(seed)
+  const out: string[] = []
+  for (let n = 0; n < count; n++) {
+    const length = 1 + Math.floor(random() * maxLength)
+    let payload = ""
+    for (let i = 0; i < length; i++) {
+      const alphabet = ALPHABETS[Math.floor(random() * ALPHABETS.length)]!
+      payload += alphabet[Math.floor(random() * alphabet.length)]
+    }
+    out.push(payload)
+  }
+  return out
+}
+
+function rows(matrix: boolean[][]): string[] {
+  return matrix.map((row) => row.map((m) => (m ? "1" : "0")).join(""))
+}
+
+describe("randomised differential against bwip-js", () => {
+  it("Code 16K over 200 payloads", () => {
+    const QUIET_ZONE = 10
+    const ROW_MODULES = 70
+    for (const payload of payloads(4242, 200, 30)) {
+      const expected = bwipMatrix("code16k", payload).map((row) =>
+        row
+          .slice(QUIET_ZONE, QUIET_ZONE + ROW_MODULES)
+          .map((m) => (m ? "1" : "0"))
+          .join(""),
+      )
+      expect(rows(encodeCode16K(payload).matrix), JSON.stringify(payload)).toEqual(expected)
+    }
+  })
+
+  /**
+   * The moves random payloads rarely land on: a shift out of Code C needs an
+   * even digit run, one to three letters, and another even digit run, which
+   * uniform characters almost never produce.
+   */
+  it("Code 16K shift and latch boundaries", () => {
+    const QUIET_ZONE = 10
+    const ROW_MODULES = 70
+    const BOUNDARIES = [
+      "\x01a\x02", // one B character shifted out of A
+      "\x01ab\x02", // two
+      "\x01abcd", // and the latch, once shifting stops paying
+      "\x011234\x02", // two digit pairs shifted out of A
+      "\x01123456\x02", // three
+      "\x0112345678", // and the latch
+      "a\x01b", // one A character shifted out of B
+      "a\x01\x02b", // two
+      "a\x01\x02\x03\x04", // and the latch
+      "a1234b", // two digit pairs shifted out of B
+      "a123456b", // three
+      "a12345678", // and the latch
+      "1234a5678", // one B character shifted out of C
+      "1234ab56789", // two, before an odd run
+      "1234ab5678", // two, before an even one
+      "1234abc56789", // three, before an odd run
+      "1234abc5678", // three, before an even one
+      "1234\x01\x02", // and the latch back to A
+      "1234abcd5678", // four: past what a shift can carry
+    ]
+    for (const payload of BOUNDARIES) {
+      const expected = bwipMatrix("code16k", payload).map((row) =>
+        row
+          .slice(QUIET_ZONE, QUIET_ZONE + ROW_MODULES)
+          .map((m) => (m ? "1" : "0"))
+          .join(""),
+      )
+      expect(rows(encodeCode16K(payload).matrix), JSON.stringify(payload)).toEqual(expected)
+    }
+  })
+
+  it("DotCode over 150 payloads", () => {
+    for (const payload of payloads(777, 150, 20)) {
+      expect(rows(encodeDotCode(payload)), JSON.stringify(payload)).toEqual(
+        rows(bwipMatrix("dotcode", payload)),
+      )
+    }
+  })
+
+  /**
+   * Binary mode and the structured append macros, which random ASCII never
+   * reaches. etiket encodes a JavaScript string as UTF-8, so the reference gets
+   * the same bytes rather than the same characters.
+   */
+  it("DotCode binary mode and macro headers", () => {
+    const escape = (text: string): string => {
+      let out = ""
+      for (const byte of new TextEncoder().encode(text)) {
+        out +=
+          byte > 126 || byte < 32 || byte === 94
+            ? `^${String(byte).padStart(3, "0")}`
+            : String.fromCharCode(byte)
+      }
+      return out
+    }
+    const CASES = [
+      "éê", // two bytes of binary
+      "éêëìíîïðñ", // a run long enough to latch
+      "ABéêCD", // binary between text
+      "éê12345678", // binary then digits
+      "12345678éê", // and the other way round
+      "[)>05DATA", // the macro headers
+      "[)>06DATA",
+      "[)>12DATA",
+      "[)>99DATA",
+    ]
+    for (const payload of CASES) {
+      expect(rows(encodeDotCode(payload)), JSON.stringify(payload)).toEqual(
+        rows(bwipMatrix("dotcode", escape(payload), { parse: true })),
+      )
+    }
+  })
+
+  it("Codablock F over 150 payloads", () => {
+    for (const payload of payloads(31337, 150, 30)) {
+      expect(rows(encodeCodablockF(payload).matrix), JSON.stringify(payload)).toEqual(
+        rows(bwipMatrix("codablockf", payload)),
+      )
+    }
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
+    // zxing-wasm fetches its WebAssembly binary on first use unless told
+    // otherwise; this hands it the copy in node_modules instead
+    setupFiles: ["test/_zxing-setup.ts"],
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,10 +12,10 @@ export default defineConfig({
       // The floor, not the target. Raise it when the number rises; never lower
       // it to make a change fit.
       thresholds: {
-        statements: 95,
-        branches: 90,
-        functions: 97,
-        lines: 95,
+        statements: 96,
+        branches: 92,
+        functions: 99,
+        lines: 97,
       },
     },
   },


### PR DESCRIPTION
## The bug

`encodeEAN13("400638133393A")` produced the symbol for `400638133393`. So did
`4·0·0·6·3·8·1·3·3·3·9·3`, and anything else with twelve digits somewhere in it:
the encoders ran `replace(/\D/g, "")` over the input and encoded whatever was
left. A typed `O` for a `0` came out as a valid symbol for eleven digits — or,
with one more digit to hand, a valid symbol for the wrong number.

Spaces and hyphens stay, because that is how these numbers are printed and
`0-36000-29145-2` should work. Everything else raises now. The validator learned
the same rule, so it cannot pass input the encoder then refuses.

## How it was found

By asking a question the suite had never asked. `encoders-input-fidelity.test.ts`
appends a character to a payload every symbology accepts and requires the symbol
to either change or be refused — the general form of the Code 128 defect fixed
in #149, which dropped every character above 126 while producing a perfectly
well formed symbol for different data. All fifty-two types are swept.

## Two more sweeps, which found nothing — which is the point

**Randomised differential against BWIPP.** The formats with no decoder were
pinned by a handful of hand-picked payloads each: enough to catch a broken
table, not enough to catch a mis-taken branch. Code 16K alone chooses between
fourteen shift and latch moves and the samples reached about half of them.

Two hundred seeded random payloads over a deliberately awkward alphabet, plus
nineteen hand-built shift boundaries, now compare every module against the
reference. **Code 16K goes from 75% covered to 95%**, with every newly covered
line verified rather than merely executed. DotCode's binary mode and its four
macro headers are compared too, and Codablock F reaches 100%.

Everything agreed with the reference first time.

**Capacity.** Every 2D encoder was walked to its exact limit by bisection and
the largest symbol decoded back through zxing: no truncation anywhere. Codablock
F's capacity turns out to be non-monotonic — 700 digits fit where 699 do not —
which is Code 128's digit pairing showing through rather than a defect.

## Verification

- `pnpm test`: 119 files, **3146 tests**, 1 expected fail
- Coverage **96.7% statements, 92.9% branches**, thresholds raised to 96 / 92 /
  99 / 97 to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)