### PR TITLE
feat: EAN and UPC symbols print their digits the way retail symbols do

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -99,6 +99,8 @@ encodeBars("12345", { type: "code128" })
 | `rotation`                              | `0 \| 90 \| 180 \| 270`         | `0`             |
 | `margin`, `marginTop/Bottom/Left/Right` | `number`                        | `10`            |
 | `bearerBars` / `bearerBarWidth`         | `boolean` / `number`            | `false` / `4`   |
+| `guardBars` / `guardExtension`          | `number[]` / `number`           | — / `5`         |
+| `textSegments`                          | `{ text, center }[]`            | —               |
 | `ariaLabel`, `role`, `title`, `desc`    | `string`                        | —               |
 
 ```ts

--- a/docs/barcodes/ean.md
+++ b/docs/barcodes/ean.md
@@ -26,6 +26,24 @@ barcode("96385074", { type: "ean8" })
 barcode("9638507", { type: "ean8" })
 ```
 
+## Human Readable Text
+
+`showText` gives an EAN symbol the layout a retail barcode has: the guard
+patterns run past the other bars, the digits sit in the gaps they leave, and the
+lead digit of an EAN-13 goes in the left quiet zone. The symbol also gets the
+quiet zones ISO/IEC 15420 asks for — eleven modules to the left, seven to the
+right — because that is where the outside digit has to go.
+
+```ts
+import { barcode } from "etiket"
+
+barcode("4006381333931", { type: "ean13", showText: true })
+// 4  006381  333931, with the guard bars running down between them
+```
+
+Passing `text` yourself turns that off and centres your string under the symbol
+in the ordinary way.
+
 ## What the Input May Contain
 
 Digits, and the spaces and hyphens a number is printed with — `4-006381-333931`

--- a/docs/barcodes/upc.md
+++ b/docs/barcodes/upc.md
@@ -26,6 +26,23 @@ barcode("01234565", { type: "upce" })
 barcode("123456", { type: "upce" })
 ```
 
+## Human Readable Text
+
+`showText` gives a UPC symbol its retail layout: the number system digit to the
+left of the bars, five digits under each half, and the check digit to the right,
+with the guard bars running down between the groups.
+
+```ts
+import { barcode } from "etiket"
+
+barcode("036000291452", { type: "upca", showText: true })
+// 0  36000  29145  2
+barcode("01234565", { type: "upce", showText: true })
+// 0  123456  5
+```
+
+Passing `text` yourself turns that off and centres your string instead.
+
 ## What the Input May Contain
 
 Digits, and the spaces and hyphens a number is printed with — `0-36000-29145-2`

--- a/docs/getting-started/typescript.md
+++ b/docs/getting-started/typescript.md
@@ -74,7 +74,8 @@ barcode("1234", both)
 deprecated alias), `barGap`, `unit`, `color`, `background`, `showText`, `text`,
 `fontSize`, `fontFamily`, `margin`, `marginTop`, `marginBottom`, `marginLeft`,
 `marginRight`, `textAlign`, `textPosition`, `rotation`, `bearerBars`,
-`bearerBarWidth`, plus everything in `SVGAccessibilityOptions`.
+`bearerBarWidth`, `guardBars`, `guardExtension`, `textSegments`, plus everything
+in `SVGAccessibilityOptions`.
 
 ### Postal
 

--- a/src/_barcode.ts
+++ b/src/_barcode.ts
@@ -26,6 +26,7 @@ import { encodeCode32, encodePZN } from "./encoders/pharma-national"
 import { encodeIdentcode, encodeLeitcode } from "./encoders/deutsche-post"
 import { encodePlessey } from "./encoders/plessey"
 import { renderBarcodeSVG } from "./renderers/svg/barcode"
+import { eanLayout } from "./renderers/svg/ean-layout"
 import { renderPostalSVG } from "./renderers/svg/postal"
 import { svgToDataURI, svgToBase64 } from "./renderers/data-uri"
 import { encodePostal } from "./_postal"
@@ -164,6 +165,27 @@ export function barcode(text: string, options: BarcodeOptions = {}): string {
     })
   }
 
+  // A retail symbol prints its digits in the gaps its guard bars leave, with
+  // the ones that fall outside the symbol in the quiet zones. Only worth doing
+  // when the caller wants the standard text: `text` means they want their own.
+  const retail = RETAIL_TYPES[options.type ?? ""]
+  if (retail && svgOptions.showText === true && svgOptions.text === undefined) {
+    const symbol = retail(text)
+    const layout = eanLayout(options.type as "ean13", symbol.digits, symbol.guards)
+    if (layout) {
+      // The quiet zones of ISO/IEC 15420, which are also where the outside
+      // digits go: eleven modules to the left, seven to the right.
+      const moduleSize = svgOptions.moduleSize ?? svgOptions.barWidth ?? 2
+      return renderBarcodeSVG(symbol.bars, {
+        ...svgOptions,
+        marginLeft: svgOptions.marginLeft ?? Math.max(svgOptions.margin ?? 10, 11 * moduleSize),
+        marginRight: svgOptions.marginRight ?? Math.max(svgOptions.margin ?? 10, 7 * moduleSize),
+        ...layout,
+        showText: true,
+      })
+    }
+  }
+
   const bars = encodeBars(text, options)
 
   return renderBarcodeSVG(bars, {
@@ -171,6 +193,17 @@ export function barcode(text: string, options: BarcodeOptions = {}): string {
     text: svgOptions.showText !== false ? (svgOptions.text ?? text) : undefined,
     showText: svgOptions.showText ?? false,
   })
+}
+
+/** The symbologies whose human readable text follows the retail layout. */
+const RETAIL_TYPES: Record<
+  string,
+  ((text: string) => { bars: number[]; guards: number[]; digits: string }) | undefined
+> = {
+  ean13: encodeEAN13,
+  ean8: encodeEAN8,
+  upca: encodeUPCA,
+  upce: encodeUPCE,
 }
 
 /**

--- a/src/encoders/ean.ts
+++ b/src/encoders/ean.ts
@@ -110,7 +110,11 @@ function calculateCheckDigit(digits: number[]): number {
  * Encode EAN-13 barcode
  * Input: 12 or 13 digit string (13th is check digit, auto-calculated if 12)
  */
-export function encodeEAN13(text: string): { bars: number[]; guards: number[] } {
+export function encodeEAN13(text: string): {
+  bars: number[]
+  guards: number[]
+  digits: string
+} {
   const digits = eanDigits(text, "EAN-13")
 
   if (digits.length === 12) {
@@ -174,14 +178,18 @@ export function encodeEAN13(text: string): { bars: number[]; guards: number[] } 
     pos++
   }
 
-  return { bars, guards }
+  return { bars, guards, digits: digits.join("") }
 }
 
 /**
  * Encode EAN-8 barcode
  * Input: 7 or 8 digit string (8th is check digit, auto-calculated if 7)
  */
-export function encodeEAN8(text: string): { bars: number[]; guards: number[] } {
+export function encodeEAN8(text: string): {
+  bars: number[]
+  guards: number[]
+  digits: string
+} {
   const digits = eanDigits(text, "EAN-8")
 
   if (digits.length === 7) {
@@ -242,5 +250,5 @@ export function encodeEAN8(text: string): { bars: number[]; guards: number[] } {
     pos++
   }
 
-  return { bars, guards }
+  return { bars, guards, digits: digits.join("") }
 }

--- a/src/encoders/upc.ts
+++ b/src/encoders/upc.ts
@@ -119,7 +119,11 @@ function expandUPCE(numberSystem: number, middleDigits: number[]): number[] {
  * @param text - 11 or 12 digit string (12th is check digit, auto-calculated if 11)
  * @returns bars (widths) and guard positions
  */
-export function encodeUPCA(text: string): { bars: number[]; guards: number[] } {
+export function encodeUPCA(text: string): {
+  bars: number[]
+  guards: number[]
+  digits: string
+} {
   const digits = eanDigits(text, "UPC-A")
 
   if (digits.length === 11) {
@@ -180,7 +184,7 @@ export function encodeUPCA(text: string): { bars: number[]; guards: number[] } {
     pos++
   }
 
-  return { bars, guards }
+  return { bars, guards, digits: digits.join("") }
 }
 
 /**
@@ -196,7 +200,11 @@ export function encodeUPCA(text: string): { bars: number[]; guards: number[] } {
  * @param text - 6, 7, or 8 digit string
  * @returns bars (widths) and guard positions
  */
-export function encodeUPCE(text: string): { bars: number[]; guards: number[] } {
+export function encodeUPCE(text: string): {
+  bars: number[]
+  guards: number[]
+  digits: string
+} {
   const raw = eanDigits(text, "UPC-E")
 
   let numberSystem: number
@@ -286,5 +294,9 @@ export function encodeUPCE(text: string): { bars: number[]; guards: number[] } {
     pos++
   }
 
-  return { bars, guards }
+  return {
+    bars,
+    guards,
+    digits: `${numberSystem}${middleDigits.join("")}${checkDigit}`,
+  }
 }

--- a/src/renderers/svg/barcode.ts
+++ b/src/renderers/svg/barcode.ts
@@ -30,6 +30,9 @@ export function renderBarcodeSVG(bars: number[], options: BarcodeSVGOptions = {}
     role = "img",
     title,
     desc,
+    guardBars,
+    guardExtension = 5,
+    textSegments,
   } = options
   const u = unit === "px" ? "" : unit
 
@@ -51,7 +54,11 @@ export function renderBarcodeSVG(bars: number[], options: BarcodeSVGOptions = {}
       : barWidth
 
   const barcodeWidth = totalUnits * moduleWidth
-  const textHeight = showText ? fontSize + 8 : 0
+  // Guard bars run past the others into the band the digits sit in, so that
+  // band has to be at least as deep as they reach.
+  const guards = new Set(guardBars)
+  const guardDrop = guards.size > 0 ? guardExtension * moduleWidth : 0
+  const textHeight = Math.max(showText ? fontSize + 8 : 0, guardDrop === 0 ? 0 : guardDrop + 4)
   const bearerHeight = bearerBars ? bearerBarWidth * 2 : 0
 
   const contentWidth = barcodeWidth + mLeft + mRight
@@ -117,13 +124,14 @@ export function renderBarcodeSVG(bars: number[], options: BarcodeSVGOptions = {}
   let x = mLeft
   let isBar = true
   const halfGap = barGap / 2
-  for (const w of bars) {
+  for (const [index, w] of bars.entries()) {
     const barPixelWidth = w * moduleWidth
     if (isBar) {
       const gappedWidth = barPixelWidth - barGap
       if (gappedWidth > 0) {
+        const drawnHeight = guards.has(index) ? barHeight + guardDrop : barHeight
         parts.push(
-          `<rect x="${x + halfGap}" y="${barTop}" width="${gappedWidth}" height="${barHeight}" fill="${escapeAttr(color)}"/>`,
+          `<rect x="${x + halfGap}" y="${barTop}" width="${gappedWidth}" height="${drawnHeight}" fill="${escapeAttr(color)}"/>`,
         )
       }
     }
@@ -131,8 +139,16 @@ export function renderBarcodeSVG(bars: number[], options: BarcodeSVGOptions = {}
     isBar = !isBar
   }
 
-  // Text
-  if (showText && text) {
+  // Text placed by module position: the EAN and UPC layout, where the digits
+  // sit in the gaps the extended guard bars leave.
+  if (showText && textSegments && textSegments.length > 0) {
+    const baseline = barTop + barHeight + guardDrop
+    for (const segment of textSegments) {
+      parts.push(
+        `<text x="${mLeft + segment.center * moduleWidth}" y="${baseline}" text-anchor="middle" font-family="${escapeAttr(fontFamily)}" font-size="${fontSize}" fill="${escapeAttr(color)}">${escapeXml(segment.text)}</text>`,
+      )
+    }
+  } else if (showText && text) {
     let textY: number
     if (textIsTop) {
       textY = mTop + fontSize

--- a/src/renderers/svg/ean-layout.ts
+++ b/src/renderers/svg/ean-layout.ts
@@ -1,0 +1,106 @@
+/**
+ * The human readable layout of an EAN or UPC symbol.
+ *
+ * A retail barcode does not print its digits as one centred line. The guard
+ * patterns run past the other bars, the digits sit in the gaps they leave, and
+ * the digits that fall outside the symbol — the lead digit of an EAN-13, both
+ * ends of a UPC-A — are printed in the quiet zones. That layout is what makes a
+ * retail symbol recognisable, and it is only derivable here, where the
+ * symbology and the guard positions are both known.
+ */
+
+/** Where a run of digits is centred, in modules from the left edge of the symbol. */
+export interface EANTextSegment {
+  text: string
+  center: number
+}
+
+export interface EANLayout {
+  /** Element indices of the guard bars, which run into the text band. */
+  guardBars: number[]
+  textSegments: EANTextSegment[]
+}
+
+/** Every EAN/UPC symbol starts with a three element guard: bar, space, bar. */
+const START_BARS = [0, 2]
+
+/** A middle guard is space, bar, space, bar, space. */
+function middleBars(at: number): number[] {
+  return [at + 1, at + 3]
+}
+
+/** Modules a digit takes in the data area. */
+const DIGIT = 7
+
+/**
+ * Lay out the digits of an EAN or UPC symbol.
+ *
+ * @param type - Symbology
+ * @param digits - The full number, check digit included
+ * @param guards - Element index of each guard pattern, as the encoders report
+ * @returns The layout, or undefined when the digits do not match the symbology
+ */
+export function eanLayout(
+  type: "ean13" | "ean8" | "upca" | "upce",
+  digits: string,
+  guards: number[],
+): EANLayout | undefined {
+  const [start, middle, end] = guards
+  if (start === undefined || middle === undefined) return undefined
+
+  // The left data area begins after the three element start guard.
+  const left = 3
+
+  if (type === "ean13" && digits.length === 13) {
+    const right = left + 6 * DIGIT + 5
+    return {
+      guardBars: [...START_BARS, ...middleBars(middle), end!, end! + 2],
+      textSegments: [
+        { text: digits.slice(0, 1), center: -4 },
+        { text: digits.slice(1, 7), center: left + 3 * DIGIT },
+        { text: digits.slice(7), center: right + 3 * DIGIT },
+      ],
+    }
+  }
+
+  if (type === "ean8" && digits.length === 8) {
+    const right = left + 4 * DIGIT + 5
+    return {
+      guardBars: [...START_BARS, ...middleBars(middle), end!, end! + 2],
+      textSegments: [
+        { text: digits.slice(0, 4), center: left + 2 * DIGIT },
+        { text: digits.slice(4), center: right + 2 * DIGIT },
+      ],
+    }
+  }
+
+  if (type === "upca" && digits.length === 12) {
+    // The number system digit and the check digit are printed outside the
+    // symbol, so each half shows five of its six digits.
+    const right = left + 6 * DIGIT + 5
+    return {
+      guardBars: [...START_BARS, ...middleBars(middle), end!, end! + 2],
+      textSegments: [
+        { text: digits.slice(0, 1), center: -4 },
+        { text: digits.slice(1, 6), center: left + DIGIT + 2.5 * DIGIT },
+        { text: digits.slice(6, 11), center: right + 2.5 * DIGIT },
+        { text: digits.slice(11), center: right + 6 * DIGIT + 3 + 4 },
+      ],
+    }
+  }
+
+  if (type === "upce" && digits.length === 8) {
+    // Six digits under the symbol, the number system and check digit outside.
+    // The end guard is six elements — space, bar, space, bar, space, bar.
+    return {
+      guardBars: [...START_BARS, middle + 1, middle + 3, middle + 5],
+      textSegments: [
+        { text: digits.slice(0, 1), center: -4 },
+        { text: digits.slice(1, 7), center: left + 3 * DIGIT },
+        { text: digits.slice(7), center: left + 6 * DIGIT + 6 + 4 },
+      ],
+    }
+  }
+
+  return undefined
+}

--- a/src/renderers/svg/types.ts
+++ b/src/renderers/svg/types.ts
@@ -127,4 +127,19 @@ export interface BarcodeSVGOptions extends SVGAccessibilityOptions {
   rotation?: 0 | 90 | 180 | 270
   bearerBars?: boolean
   bearerBarWidth?: number
+  /**
+   * Element indices of bars that run past the others into the text band. The
+   * guard patterns of an EAN or UPC symbol do this, which is what makes the
+   * digits sit in the gaps between them.
+   */
+  guardBars?: number[]
+  /** How far a guard bar runs past the others, in modules. Default 5. */
+  guardExtension?: number
+  /**
+   * Human readable text placed by module position rather than as one centred
+   * string — an EAN-13 prints its lead digit in the left quiet zone and its two
+   * halves under their own six digits. Takes precedence over `text`, and always
+   * sits below the symbol.
+   */
+  textSegments?: { text: string; center: number }[]
 }

--- a/test/renderers-retail-text.test.ts
+++ b/test/renderers-retail-text.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The human readable layout of a retail symbol.
+ *
+ * An EAN or UPC symbol does not print its digits as one centred line. The guard
+ * patterns run past the other bars, the digits sit in the gaps they leave, and
+ * the digits that fall outside — the lead digit of an EAN-13, both ends of a
+ * UPC-A — go in the quiet zones. The encoders reported the guard positions from
+ * the start and nothing consumed them; this is what consumes them.
+ */
+
+import { describe, expect, it } from "vitest"
+import { barcode } from "../src/_barcode"
+import { renderBarcodeSVG } from "../src/renderers/svg/barcode"
+import { eanLayout } from "../src/renderers/svg/ean-layout"
+import { encodeEAN13 } from "../src/encoders/ean"
+
+/** The `<text>` elements of an SVG, in document order. */
+function texts(svg: string): { x: number; text: string }[] {
+  return [...svg.matchAll(/<text x="([\d.-]+)"[^>]*>([^<]*)<\/text>/g)].map((match) => ({
+    x: Number(match[1]),
+    text: match[2]!,
+  }))
+}
+
+/** Every distinct bar height in the symbol, smallest first. */
+function barHeights(svg: string): number[] {
+  const heights = [...svg.matchAll(/<rect [^>]*height="([\d.]+)"[^>]*fill="#000"/g)].map((m) =>
+    Number(m[1]),
+  )
+  return [...new Set(heights)].sort((a, b) => a - b)
+}
+
+describe("retail human readable text", () => {
+  it("splits an EAN-13 into lead digit and two halves", () => {
+    const svg = barcode("4006381333931", { type: "ean13", showText: true, moduleSize: 3 })
+    expect(texts(svg).map((t) => t.text)).toEqual(["4", "006381", "333931"])
+  })
+
+  it("splits an EAN-8 into two halves with nothing outside", () => {
+    const svg = barcode("96385074", { type: "ean8", showText: true, moduleSize: 3 })
+    expect(texts(svg).map((t) => t.text)).toEqual(["9638", "5074"])
+  })
+
+  it("puts the UPC-A number system and check digit outside the symbol", () => {
+    const svg = barcode("036000291452", { type: "upca", showText: true, moduleSize: 3 })
+    const parts = texts(svg)
+    expect(parts.map((t) => t.text)).toEqual(["0", "36000", "29145", "2"])
+    // The outer two sit beyond the bars at either end
+    const barXs = [...svg.matchAll(/<rect x="([\d.]+)"[^>]*fill="#000"/g)].map((m) => Number(m[1]))
+    expect(parts[0]!.x).toBeLessThan(Math.min(...barXs))
+    expect(parts[3]!.x).toBeGreaterThan(Math.max(...barXs))
+  })
+
+  it("splits a UPC-E the same way", () => {
+    const svg = barcode("01234565", { type: "upce", showText: true, moduleSize: 3 })
+    expect(texts(svg).map((t) => t.text)).toEqual(["0", "123456", "5"])
+  })
+
+  it("runs the guard bars past the others", () => {
+    const svg = barcode("4006381333931", {
+      type: "ean13",
+      showText: true,
+      moduleSize: 3,
+      height: 70,
+    })
+    // Six guard bars — two per guard pattern — five modules longer than the rest
+    expect(barHeights(svg)).toEqual([70, 85])
+    const long = [...svg.matchAll(/height="85"/g)]
+    expect(long).toHaveLength(6)
+  })
+
+  it("gives the symbol the quiet zones the standard asks for", () => {
+    // Eleven modules to the left, seven to the right, which is also where the
+    // digits outside the symbol go
+    const svg = barcode("4006381333931", { type: "ean13", showText: true, moduleSize: 3 })
+    const firstBar = Number(/<rect x="([\d.]+)"[^>]*fill="#000"/.exec(svg)![1])
+    expect(firstBar).toBe(33)
+  })
+
+  it("leaves the plain layout alone when the caller supplies their own text", () => {
+    const svg = barcode("4006381333931", { type: "ean13", showText: true, text: "own text" })
+    expect(texts(svg).map((t) => t.text)).toEqual(["own text"])
+    expect(barHeights(svg)).toHaveLength(1)
+  })
+
+  it("leaves every other symbology centred", () => {
+    const svg = barcode("HELLO", { type: "code39", showText: true })
+    expect(texts(svg).map((t) => t.text)).toEqual(["HELLO"])
+    expect(barHeights(svg)).toHaveLength(1)
+  })
+
+  it("draws no text and no extension when showText is off", () => {
+    const svg = barcode("4006381333931", { type: "ean13" })
+    expect(texts(svg)).toEqual([])
+    expect(barHeights(svg)).toHaveLength(1)
+  })
+})
+
+describe("eanLayout", () => {
+  it("refuses digits that do not match the symbology", () => {
+    const { guards } = encodeEAN13("4006381333931")
+    expect(eanLayout("ean13", "123", guards)).toBeUndefined()
+    expect(eanLayout("ean8", "4006381333931", guards)).toBeUndefined()
+  })
+
+  it("refuses a symbol with no guard positions", () => {
+    expect(eanLayout("ean13", "4006381333931", [])).toBeUndefined()
+  })
+})
+
+describe("renderBarcodeSVG guard options", () => {
+  it("extends the bars it is given and no others", () => {
+    const svg = renderBarcodeSVG([1, 1, 1, 1, 1], {
+      guardBars: [0],
+      guardExtension: 4,
+      moduleSize: 2,
+      height: 50,
+    })
+    expect(barHeights(svg)).toEqual([50, 58])
+  })
+
+  it("makes room for the extension even with no text", () => {
+    const plain = renderBarcodeSVG([1, 1, 1], { moduleSize: 2, height: 50 })
+    const extended = renderBarcodeSVG([1, 1, 1], { moduleSize: 2, height: 50, guardBars: [0] })
+    const heightOf = (svg: string) => Number(/height="(\d+)"/.exec(svg)![1])
+    expect(heightOf(extended)).toBeGreaterThan(heightOf(plain))
+  })
+})


### PR DESCRIPTION
## What this does

The EAN and UPC encoders have reported guard positions since the beginning and
**nothing consumed them**. `showText` centred one line of digits under the bars,
which is not what a retail barcode looks like.

A retail symbol's guard patterns run past the other bars, the digits sit in the
gaps they leave, and the ones that fall outside the symbol go in the quiet
zones — the lead digit of an EAN-13, both ends of a UPC-A, both ends of a UPC-E.
That is what the guard positions were for, and now that is what they do.

```
before:   ||| |||| ||| |||| |||       after:    ||| |||| ||| |||| |||
              4006381333931                     | | |          | | |
                                              4   006381   333931
```

The symbol also gets the quiet zones ISO/IEC 15420 asks for — eleven modules to
the left, seven to the right — because the outside digits have to go somewhere,
and a retail symbol needs them anyway.

## The renderer options that carry it

Two additions to `BarcodeSVGOptions`, useful on their own:

- `guardBars` — element indices of bars that run past the others, with
  `guardExtension` (default 5 modules) saying how far
- `textSegments` — text placed by module position instead of one centred string

## What is unchanged

- Passing `text` yourself still gets the plain centred layout
- Every other symbology is untouched
- `showText: false` draws neither text nor extension, so nothing about a
  bare symbol moves

## Verification

Thirteen new tests covering all four symbologies, the guard geometry, the quiet
zones, and every fallback. `pnpm test`: 119 files, **3159 tests**, 1 expected
fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)