### PR TITLE
fix(qr): Micro QR segmentation and the pad codewords M1 and M3 owe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ src/
     barcode.ts              # Per-format validation
     qr.ts                   # QR validation with metadata
 test/
-  *.test.ts                 # 112 test files, 2800+ tests
+  *.test.ts                 # 123 test files, 3200+ tests
   _bwip.ts                  # bwip-js (BWIPP) oracle: module data extraction
   bwip-compare.test.ts      # Module-for-module comparison against BWIPP
   qr-roundtrip.test.ts      # QR encode→decode via jsQR (all versions, EC, masks)
@@ -236,7 +236,7 @@ is known and turns red the moment it is fixed.
 
 v1. The full gate (`pnpm test`) is green:
 
-- **122 test files, 3200+ tests** passing
+- **123 test files, 3200+ tests** passing
 - **Zero** lint warnings, zero typecheck errors
 - **96.7%** statements, **92.9%** branches — thresholds enforced in CI by
   `vitest.config.ts`

--- a/docs/qr-code/micro-qr.md
+++ b/docs/qr-code/micro-qr.md
@@ -54,7 +54,9 @@ and no recovery from damage. M2 accepts numeric and alphanumeric data only; byte
 mode starts at M3.
 
 With no `version` the encoder takes the smallest one that holds the data at the
-requested EC level.
+requested EC level. With no `ecLevel` it uses `L`, which is the level that
+reaches the smallest symbol; ask for a stronger one and the symbol grows to
+whichever version can provide it.
 
 ## Options
 
@@ -69,13 +71,22 @@ Plus the [shared matrix rendering options](/2d-codes/#shared-rendering-options).
 Micro QR has four mask patterns, not the eight of full QR; they correspond to
 full QR's masks 1, 4, 6 and 7.
 
-## Mode Detection
+## Modes
 
-The mode is detected from the input — all digits gives numeric, the QR
-alphanumeric set (`0-9 A-Z $%*+-./: ` and space) gives alphanumeric, anything
-else gives byte. There is no `mode` option, and the capacity table above is per
-mode, so a single lowercase letter in an otherwise numeric string drops the
-symbol from 35 characters of capacity to 15.
+Numeric, alphanumeric (`0-9 A-Z $%*+-./:` and space) and byte — chosen per run
+of characters rather than once for the whole message. The encoder splits the
+input wherever switching pays for itself: `A0123456789Z` becomes an
+alphanumeric segment, a numeric one and another alphanumeric one, because ten
+bits per three digits beats eleven bits per two characters by more than the
+segment header costs.
+
+The capacity table above is per mode and assumes one segment. A mixed message
+gets whatever the split works out to, which is never worse than encoding all of
+it in the widest mode it needs — so a single lowercase letter no longer drops an
+otherwise numeric message into byte mode for its whole length.
+
+There is no `mode` option. Kanji mode, which the standard reserves for M4, is
+not implemented.
 
 ## PNG
 
@@ -91,12 +102,11 @@ microqrPNGDataURI("12345")
 - **No ECI, no Structured Append, no kanji mode.** The standard reserves kanji
   mode for M4; etiket does not implement it, and the other two are not part of
   Micro QR at all. Use a full QR code when you need any of them.
-- **An EC level a version cannot provide is silently downgraded to `L`.** `Q`
-  only exists on M4, and M1 has no error correction at all, so
-  `microqr("12345", { version: 2, ecLevel: "Q" })` produces an M2 symbol at
-  level L. With no `version`, the same fallback means a short payload with
-  `ecLevel: "Q"` lands on a small symbol at L rather than on M4 at Q — pin
-  `version: 4` when the level matters more than the size.
+- **A requested EC level is never downgraded.** `Q` exists on M4 alone, so
+  `microqr("12345", { ecLevel: "Q" })` grows to a 17×17 symbol rather than
+  quietly settling for `L` on a smaller one. Pinning a version that cannot
+  provide the level — `{ version: 2, ecLevel: "Q" }` — raises
+  `InvalidInputError` instead.
 - Data past the version's capacity raises `CapacityError`.
 - Empty input raises `InvalidInputError`.
 - The quiet zone is 2 modules, not 4. Passing a larger `margin` is harmless;

--- a/src/encoders/pdf417/encoder.ts
+++ b/src/encoders/pdf417/encoder.ts
@@ -149,7 +149,7 @@ function encodeSegments(
         codewords.push(MODE_LATCH.BYTE_SHIFT, bytes[segment.start]!)
         break
       case "byte":
-        encodeByteSegment([...bytes.slice(segment.start, segment.end)], codewords)
+        encodeByteSegment(bytes.slice(segment.start, segment.end), codewords)
         inText = false
         break
     }

--- a/src/encoders/qr/micro.ts
+++ b/src/encoders/qr/micro.ts
@@ -10,6 +10,8 @@
 
 import { CapacityError, InvalidInputError } from "../../errors"
 import { pushBits, encodeNumericData, encodeAlphanumericData, encodeByteData } from "./mode"
+import { optimizeSegments } from "./segment"
+import type { QRSegment } from "./types"
 import { generateECCodewords } from "./reed-solomon"
 
 export interface MicroQROptions {
@@ -102,22 +104,10 @@ export function encodeMicroQR(text: string, options: MicroQROptions = {}): boole
     throw new InvalidInputError("Micro QR input must not be empty")
   }
 
-  // Detect mode
-  const isNum = /^\d+$/.test(text)
-  const isAlpha = !isNum && /^[0-9A-Z $%*+\-./:]+$/.test(text)
-  const mode: "numeric" | "alphanumeric" | "byte" = isNum
-    ? "numeric"
-    : isAlpha
-      ? "alphanumeric"
-      : "byte"
-
-  // Select version
-  const { version, cap, ecKey } = selectMicroVersion(text, mode, options)
+  const { version, cap, ecKey, segments } = selectMicroVersion(text, options)
   const size = version * 2 + 9 // M1=11, M2=13, M3=15, M4=17
 
-  // Encode data
-  const data = new TextEncoder().encode(text)
-  const bits = buildMicroDataBits(text, data, mode, version, cap)
+  const bits = buildMicroDataBits(segments, version, cap)
 
   // Convert to full 8-bit codewords (RS needs full bytes)
   const dataBytes: number[] = []
@@ -177,14 +167,61 @@ export function encodeMicroQR(text: string, options: MicroQROptions = {}): boole
   return matrix.map((row) => row.map((cell) => cell === 1))
 }
 
+/** Mode indicator width in bits, by version. M1 carries none. */
+const MODE_BITS: Record<number, number> = { 1: 0, 2: 1, 3: 2, 4: 3 }
+
+/** Mode indicator value, by mode. */
+const MODE_VALUE: Record<string, number> = { numeric: 0, alphanumeric: 1, byte: 2, kanji: 3 }
+
+/** The order `optimizeSegments` reports head costs in. */
+const SEGMENT_MODES = ["numeric", "alphanumeric", "byte", "kanji"] as const
+
+/**
+ * Data bits a version holds.
+ *
+ * M1 and M3 finish on a four bit codeword rather than a whole byte, which is
+ * exactly the four bits between their codeword count and their capacity.
+ */
+function usableBits(version: number, cap: MicroQRCapacity): number {
+  return cap.dataCW * 8 - (version === 1 || version === 3 ? 4 : 0)
+}
+
+/** What a segment header costs in each mode at this version, or Infinity. */
+function headBitsFor(version: number): number[] {
+  return SEGMENT_MODES.map((mode) => {
+    const count = CC_BITS[version]?.[mode]
+    // Kanji is not implemented for Micro QR, and M1 and M2 have fewer modes
+    return count === undefined ? Infinity : MODE_BITS[version]! + count
+  })
+}
+
+/** Bits a run of segments takes, headers included. */
+function segmentBits(segments: QRSegment[], version: number): number {
+  let bits = 0
+  for (const segment of segments) {
+    const count = CC_BITS[version]?.[segment.mode]
+    if (count === undefined) return Infinity
+    bits += MODE_BITS[version]! + count
+    if (segment.mode === "numeric") {
+      const digits = segment.charCount
+      bits += Math.floor(digits / 3) * 10 + [0, 4, 7][digits % 3]!
+    } else if (segment.mode === "alphanumeric") {
+      bits += Math.floor(segment.charCount / 2) * 11 + (segment.charCount % 2) * 6
+    } else if (segment.mode === "byte") {
+      bits += segment.charCount * 8
+    } else {
+      return Infinity
+    }
+  }
+  return bits
+}
+
 function selectMicroVersion(
   text: string,
-  mode: string,
   options: MicroQROptions,
-): { version: number; cap: MicroQRCapacity; ecKey: string } {
+): { version: number; cap: MicroQRCapacity; ecKey: string; segments: QRSegment[] } {
   const requestedEc = options.ecLevel
 
-  // Determine the EC key for the given version
   /**
    * The EC key a version will actually use.
    *
@@ -196,6 +233,12 @@ function selectMicroVersion(
     if (v === 1) return "_"
     if (!requestedEc) return "L"
     return CAPACITY[v]![requestedEc] ? requestedEc : undefined
+  }
+
+  /** The cheapest split of the text for a version, and what it costs. */
+  function planFor(v: number): { segments: QRSegment[]; bits: number } {
+    const segments = optimizeSegments(text, v, headBitsFor(v))
+    return { segments, bits: segmentBits(segments, v) }
   }
 
   if (options.version) {
@@ -210,25 +253,28 @@ function selectMicroVersion(
     if (!cap) throw new CapacityError(`Micro QR M${v} does not support EC level ${ecKey}`)
 
     // A pinned version still has to hold the data. M1 is numeric only and M2
-    // adds alphanumeric, so the mode has to be checked as well as the length —
-    // without this the symbol comes out silently truncated.
-    // The table records an unavailable mode as a capacity of 0
-    const limit = cap[mode as keyof MicroQRCapacity]
-    if (typeof limit !== "number" || limit === 0) {
+    // adds alphanumeric, so the modes the text needs have to exist as well as
+    // fit — without this the symbol comes out silently truncated.
+    const plan = planFor(v)
+    if (plan.bits === Infinity) {
       throw new InvalidInputError(
-        `Micro QR M${v} does not support ${mode} mode — M1 is numeric only, M2 adds alphanumeric, M3 and M4 add byte and kanji`,
+        `Micro QR M${v} cannot encode this data — M1 is numeric only, M2 adds alphanumeric, M3 and M4 add byte`,
       )
     }
-    const pinnedLen = mode === "byte" ? new TextEncoder().encode(text).length : text.length
-    if (pinnedLen > limit) {
+    if (plan.bits > usableBits(v, cap)) {
+      const level = ecKey === "_" ? "none" : ecKey
+      // One segment has a character capacity worth quoting; a mixed message
+      // only has a bit budget
+      const only = plan.segments.length === 1 ? plan.segments[0] : undefined
+      const limit = only ? cap[only.mode as keyof MicroQRCapacity] : undefined
       throw new CapacityError(
-        `Data too long for Micro QR M${v} at EC level ${ecKey === "_" ? "none" : ecKey}: ${pinnedLen} ${mode} characters, capacity is ${limit}`,
+        only && typeof limit === "number"
+          ? `Data too long for Micro QR M${v} at EC level ${level}: ${only.charCount} ${only.mode} characters, capacity is ${limit}`
+          : `Data too long for Micro QR M${v} at EC level ${level}: ${plan.bits} bits needed, capacity is ${usableBits(v, cap)}`,
       )
     }
-    return { version: v, cap, ecKey }
+    return { version: v, cap, ecKey, segments: plan.segments }
   }
-
-  const dataLen = mode === "byte" ? new TextEncoder().encode(text).length : text.length
 
   for (let v = 1; v <= 4; v++) {
     const ecKey = getEcKey(v)
@@ -237,71 +283,65 @@ function selectMicroVersion(
     if (!ecKey) continue
     const cap = CAPACITY[v]![ecKey]
     if (!cap) continue
-    const modeKey = mode as keyof MicroQRCapacity
-    if (typeof cap[modeKey] === "number" && dataLen <= (cap[modeKey] as number)) {
-      return { version: v, cap, ecKey }
+    const plan = planFor(v)
+    if (plan.bits <= usableBits(v, cap)) {
+      return { version: v, cap, ecKey, segments: plan.segments }
     }
   }
 
   throw new CapacityError(
-    `Data too long for Micro QR Code with ${mode} mode${requestedEc ? ` at EC level ${requestedEc}` : ""}`,
+    `Data too long for Micro QR Code${requestedEc ? ` at EC level ${requestedEc}` : ""}`,
   )
 }
 
 function buildMicroDataBits(
-  text: string,
-  data: Uint8Array,
-  mode: string,
+  segments: QRSegment[],
   version: number,
   cap: MicroQRCapacity,
 ): number[] {
   const bits: number[] = []
 
-  // Mode indicator (variable length for Micro QR)
-  // M1: no mode indicator (numeric only)
-  // M2: 1 bit (0=numeric, 1=alphanumeric)
-  // M3: 2 bits (00=numeric, 01=alpha, 10=byte)
-  // M4: 3 bits (000=numeric, 001=alpha, 010=byte)
-  if (version === 2) {
-    pushBits(bits, mode === "numeric" ? 0 : 1, 1)
-  } else if (version === 3) {
-    pushBits(bits, mode === "numeric" ? 0 : mode === "alphanumeric" ? 1 : 2, 2)
-  } else if (version === 4) {
-    pushBits(bits, mode === "numeric" ? 0 : mode === "alphanumeric" ? 1 : 2, 3)
+  for (const segment of segments) {
+    // Mode indicator, which is one to three bits wide in Micro QR and absent
+    // from M1 — where numeric is the only mode there is
+    const modeBits = MODE_BITS[version]!
+    if (modeBits > 0) pushBits(bits, MODE_VALUE[segment.mode]!, modeBits)
+
+    pushBits(bits, segment.charCount, CC_BITS[version]![segment.mode]!)
+
+    if (segment.mode === "numeric") bits.push(...encodeNumericData(segment.data as string))
+    else if (segment.mode === "alphanumeric") {
+      bits.push(...encodeAlphanumericData(segment.data as string))
+    } else bits.push(...encodeByteData(segment.data as Uint8Array))
   }
 
-  // Character count indicator (correct bit lengths per ISO spec)
-  const ccBits = CC_BITS[version]![mode]!
-  const count = mode === "byte" ? data.length : text.length
-  pushBits(bits, count, ccBits)
-
-  // Data encoding
-  if (mode === "numeric") bits.push(...encodeNumericData(text))
-  else if (mode === "alphanumeric") bits.push(...encodeAlphanumericData(text))
-  else bits.push(...encodeByteData(data))
-
-  // Terminator + padding
+  // Terminator and padding, ISO/IEC 18004 7.4.10. The bit stream is sized to
+  // whole codewords because the Reed-Solomon step needs bytes; M1 and M3 then
+  // give up the low four bits of their last one when the symbol is written.
   const totalBits = cap.dataCW * 8
-  const termLen = Math.min(
-    version === 1 ? 3 : version === 2 ? 5 : version === 3 ? 7 : 9,
-    totalBits - bits.length,
-  )
-  pushBits(bits, 0, termLen)
+  const usable = usableBits(version, cap)
 
-  // M1 and M3: zero-pad to fill remaining capacity (4-bit final CW)
-  // M2 and M4: pad to byte boundary then add alternating 0xEC/0x11
-  if (version === 1 || version === 3) {
-    while (bits.length < totalBits) bits.push(0)
-  } else {
-    while (bits.length % 8 !== 0) bits.push(0)
-    let toggle = true
-    while (bits.length < totalBits) {
-      pushBits(bits, toggle ? 236 : 17, 8)
-      toggle = !toggle
-    }
+  // Terminator, truncated where what is left of the capacity is shorter
+  pushBits(
+    bits,
+    0,
+    Math.min(version === 1 ? 3 : version === 2 ? 5 : version === 3 ? 7 : 9, usable - bits.length),
+  )
+
+  // Zero fill to the codeword boundary
+  while (bits.length % 8 !== 0 && bits.length < usable) bits.push(0)
+
+  // Whole codewords left over take the alternating pad pattern
+  let toggle = true
+  while (usable - bits.length >= 8) {
+    pushBits(bits, toggle ? 236 : 17, 8)
+    toggle = !toggle
   }
 
-  return bits
+  // The four bit final codeword of M1 and M3 is zero filled, never padded
+  while (bits.length < totalBits) bits.push(0)
+
+  return bits.slice(0, totalBits)
 }
 
 /**

--- a/src/encoders/qr/segment.ts
+++ b/src/encoders/qr/segment.ts
@@ -70,12 +70,22 @@ function roundToBit(cost: number): number {
  * @param text - The text to segment
  * @param version - Target QR version; it sets the character-count width and
  *   therefore how expensive a mode switch is
+ * @param headBits - What a segment header costs in each mode, in bits, when it
+ *   is not QR's four bit indicator plus a version-dependent count. Micro QR
+ *   passes its own: the indicator is one to three bits wide there, the counts
+ *   are narrower, and a mode a version does not offer costs `Infinity`.
  */
-export function optimizeSegments(text: string, version: number): QRSegment[] {
+export function optimizeSegments(
+  text: string,
+  version: number,
+  headBits?: readonly number[],
+): QRSegment[] {
   const chars = [...text]
   if (chars.length === 0) return []
 
-  const headCost = MODES.map((mode) => (4 + getCharCountBits(version, mode)) * 6)
+  const headCost = headBits
+    ? headBits.map((bits) => bits * 6)
+    : MODES.map((mode) => (4 + getCharCountBits(version, mode)) * 6)
 
   // charModes[i][m] = the mode character i-1 was in, on the cheapest path that
   // puts character i in mode m

--- a/test/encoders-micro-qr-segments.test.ts
+++ b/test/encoders-micro-qr-segments.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Micro QR segmentation, and the codeword M1 and M3 finish on.
+ *
+ * Two things here, both found by putting the encoder next to BWIPP:
+ *
+ * - A Micro QR message is split into segments the way a full QR message is, so
+ *   a run of digits inside a byte message costs ten bits per three characters
+ *   rather than eight bits each. One mode used to be chosen for the whole
+ *   message, which sent some payloads to a symbol one size class larger than
+ *   they needed.
+ * - M1 and M3 finish on a four bit data codeword. Every whole codeword before
+ *   it takes the alternating 11101100 / 00010001 pad pattern and only that last
+ *   four bits is zero filled (ISO/IEC 18004 7.4.10). etiket zero filled all of
+ *   it, which still decodes — a reader stops at the character count — but is
+ *   not the symbol the standard describes, and no test could see it.
+ *
+ * BWIPP is the oracle for the module data. It takes the smallest symbol that
+ * holds the message and then the strongest error correction level that still
+ * fits in it, so these comparisons ask etiket for the same symbol rather than
+ * for its own default, which is L.
+ */
+
+import { describe, expect, it } from "vitest"
+import { readBarcodes } from "zxing-wasm/reader"
+import { encodeMicroQR } from "../src/index"
+import { bwipMatrix } from "./_bwip"
+
+function rows(matrix: boolean[][]): string[] {
+  return matrix.map((row) => row.map((m) => (m ? "1" : "0")).join(""))
+}
+
+/**
+ * etiket's symbol for a payload at the level BWIPP would have chosen: the
+ * strongest one that still fits the symbol size BWIPP settled on.
+ */
+function atBwipLevel(payload: string, size: number): boolean[][] {
+  let chosen: boolean[][] | undefined
+  for (const ecLevel of ["L", "M", "Q"] as const) {
+    let matrix: boolean[][]
+    try {
+      matrix = encodeMicroQR(payload, { ecLevel })
+    } catch {
+      continue // the level does not reach a symbol this small
+    }
+    if (matrix.length === size) chosen = matrix
+  }
+  if (!chosen) throw new Error(`no EC level gives etiket a ${size}x${size} symbol for ${payload}`)
+  return chosen
+}
+
+function expectMatchesBwip(payload: string): void {
+  const theirs = bwipMatrix("microqrcode", payload)
+  expect(rows(atBwipLevel(payload, theirs.length)), JSON.stringify(payload)).toEqual(rows(theirs))
+}
+
+/** Deterministic payloads over one character set. */
+function payloads(seed: number, count: number, alphabet: string, maxLength: number): string[] {
+  let state = seed
+  const random = () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff
+    return state / 0x7fffffff
+  }
+  const out: string[] = []
+  for (let n = 0; n < count; n++) {
+    let payload = ""
+    const length = 1 + Math.floor(random() * maxLength)
+    for (let i = 0; i < length; i++) payload += alphabet[Math.floor(random() * alphabet.length)]
+    out.push(payload)
+  }
+  return out
+}
+
+const NUMERIC = "0123456789"
+const ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 $%*+-./:"
+const BYTE = "abcdefghijklmnopqrstuvwxyz~"
+const MIXED = "ABCdef123 /:xyZ$%*+-.abcXYZ789"
+
+async function decode(matrix: boolean[][]): Promise<string | null> {
+  const scale = 8
+  const margin = 4
+  const size = matrix.length
+  const width = (size + margin * 2) * scale
+  const data = new Uint8ClampedArray(width * width * 4)
+  data.fill(255)
+  for (let y = 0; y < width; y++) {
+    for (let x = 0; x < width; x++) {
+      const r = Math.floor(y / scale) - margin
+      const c = Math.floor(x / scale) - margin
+      if (r >= 0 && r < size && c >= 0 && c < size && matrix[r]![c]) {
+        const idx = (y * width + x) * 4
+        data[idx] = 0
+        data[idx + 1] = 0
+        data[idx + 2] = 0
+      }
+    }
+  }
+  const results = await readBarcodes({ data, width, height: width } as ImageData, {
+    tryHarder: true,
+  })
+  return results[0]?.text ?? null
+}
+
+describe("Micro QR against BWIPP", () => {
+  // A single mode holds the whole message, so both implementations have the
+  // same one segment to encode and the module data has to agree exactly
+  it("matches for numeric messages", () => {
+    for (const payload of payloads(2024, 40, NUMERIC, 30)) expectMatchesBwip(payload)
+  })
+
+  it("matches for alphanumeric messages", () => {
+    for (const payload of payloads(1201, 40, ALPHANUMERIC, 20)) expectMatchesBwip(payload)
+  })
+
+  it("matches for byte messages", () => {
+    for (const payload of payloads(555, 40, BYTE, 14)) expectMatchesBwip(payload)
+  })
+
+  // These were all wrong before the padding fix: the data agreed and every pad
+  // codeword after it did not
+  it.each(["vd", "igor", "AV/YOCS", "a", "Z", "7", "hello world"])(
+    "pads %j the way the standard does",
+    (payload) => {
+      expectMatchesBwip(payload)
+    },
+  )
+
+  it("never reaches for a larger symbol than BWIPP", () => {
+    let compared = 0
+    for (const payload of payloads(31_415, 120, MIXED, 12)) {
+      const theirs = bwipMatrix("microqrcode", payload)
+      expect(encodeMicroQR(payload).length, JSON.stringify(payload)).toBeLessThanOrEqual(
+        theirs.length,
+      )
+      compared++
+    }
+    expect(compared).toBe(120)
+  })
+})
+
+describe("Micro QR segmentation", () => {
+  it("splits a mixed message rather than paying byte mode for all of it", () => {
+    // Ten characters, four of them lowercase. As one byte segment that is
+    // 6 + 80 bits and needs M4; split, it fits M3
+    const payload = "D/4K9XG*sw"
+    expect(encodeMicroQR(payload)).toHaveLength(15)
+    expect(encodeMicroQR(payload, { version: 3 })).toEqual(encodeMicroQR(payload))
+  })
+
+  it("breaks a digit run out of an alphanumeric message", () => {
+    // Alphanumeric costs 11 bits per two characters, numeric 10 per three, and
+    // the digit run here is long enough to be worth its own segment header:
+    // 65 bits split against 72 in one segment, which is the difference between
+    // fitting M3 at level M and not
+    expect(encodeMicroQR("A0123456789Z", { version: 3, ecLevel: "M" })).toHaveLength(15)
+  })
+
+  it("keeps a single segment when splitting would cost more", () => {
+    // Two lowercase letters either side of one digit: a numeric segment header
+    // costs more than the two bits it would save
+    expect(encodeMicroQR("ab1cd")).toEqual(encodeMicroQR("ab1cd", { version: 3 }))
+  })
+
+  it("decodes every mixed message back byte for byte", async () => {
+    for (const payload of payloads(99, 30, MIXED, 12)) {
+      expect(await decode(encodeMicroQR(payload)), JSON.stringify(payload)).toBe(payload)
+    }
+  })
+
+  it("still refuses a mode the pinned version cannot carry", () => {
+    // Splitting must not open a back door into M1 and M2, which have no byte
+    // mode however the message is divided
+    expect(() => encodeMicroQR("12a45", { version: 1 })).toThrow(/numeric only/)
+    expect(() => encodeMicroQR("AB1cd", { version: 2 })).toThrow(/numeric only|cannot encode/)
+  })
+})


### PR DESCRIPTION
Two defects, both found by putting the encoder next to BWIPP rather than by any test we had.

## The padding M1 and M3 finish on

M1 and M3 end on a four bit data codeword. ISO/IEC 18004 7.4.10 fills every whole codeword after the terminator with the alternating `11101100` / `00010001` pattern and zero fills only that last four bits. etiket zero filled all of it.

Symbols still decoded — a reader stops at the character count — so nothing caught it, but every padded M1 and M3 symbol differed from the reference from the first pad codeword onwards. `"vd"` at M3 is 22 bits of data, 7 of terminator, 3 of alignment, and then four pad codewords that were all zero.

The terminator is now measured against the usable bits rather than the codeword total, which is the same number for M2 and M4 and four bits shorter for M1 and M3.

## Segmentation

Micro QR picked one mode for the whole message where a full QR splits into segments. `optimizeSegments` now takes the per-version header cost as an argument so the same dynamic program serves both, and Micro QR selects its version from the cheapest split rather than from the widest mode the message needs.

`D/4K9XG*sw` is 15×15 instead of 17×17. Across 120 random mixed payloads the symbol is never larger than BWIPP's and once smaller.

## Verification

`test/encoders-micro-qr-segments.test.ts`:

- module for module against BWIPP for 120 numeric, alphanumeric and byte messages, at the error correction level BWIPP would have chosen — it takes the smallest symbol that holds the message and then the strongest level that still fits, so the comparison asks etiket for the same symbol rather than for its own default of `L`
- the payloads that were wrong before the padding fix, by name
- 30 mixed messages encoded and decoded back byte for byte through zxing-wasm
- symbol size never larger than BWIPP's, over 120 mixed payloads

Before this change 13 of 120 random payloads matched BWIPP exactly; now every single-mode payload does, and the ones that do not are the mixed messages where etiket's split is the cheaper of the two.

Docs: the Micro QR page said the mode is detected once for the whole input, and still carried a caveat about EC levels being silently downgraded to `L`, which stopped being true when that was fixed. Both rewritten.

Also drops a redundant spread oxlint flagged in the PDF417 encoder, restoring zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)