### PR TITLE
fix(aztec): two ways a byte came back as something else

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ src/
     barcode.ts              # Per-format validation
     qr.ts                   # QR validation with metadata
 test/
-  *.test.ts                 # 126 test files, 3300+ tests
+  *.test.ts                 # 127 test files, 3300+ tests
   _bwip.ts                  # bwip-js (BWIPP) oracle: module data extraction
   bwip-compare.test.ts      # Module-for-module comparison against BWIPP
   qr-roundtrip.test.ts      # QR encode→decode via jsQR (all versions, EC, masks)
@@ -236,7 +236,7 @@ is known and turns red the moment it is fixed.
 
 v1. The full gate (`pnpm test`) is green:
 
-- **126 test files, 3300+ tests** passing
+- **127 test files, 3300+ tests** passing
 - **Zero** lint warnings, zero typecheck errors
 - **96.7%** statements, **92.9%** branches — thresholds enforced in CI by
   `vitest.config.ts`

--- a/src/encoders/aztec/encoder.ts
+++ b/src/encoders/aztec/encoder.ts
@@ -246,7 +246,7 @@ export function encodeHighLevel(text: string, eci?: number): number[] {
     }
 
     const binaryLen = i - binaryStart
-    emitBinaryShift(bits, data, binaryStart, binaryLen, currentMode)
+    currentMode = emitBinaryShift(bits, data, binaryStart, binaryLen, currentMode)
     continue
   }
 
@@ -343,9 +343,19 @@ function emitBinaryShift(
   start: number,
   length: number,
   currentMode: Mode,
-): void {
+): Mode {
   let remaining = length
   let pos = start
+
+  // Punct and Digit have no B/S codeword of their own, so the run starts by
+  // latching to Upper. Emitting Digit's codeword 15 here used to tell a reader
+  // to take the next codeword as an upper case letter, and every byte after it
+  // came back as text.
+  let mode = currentMode
+  if (!BINARY_SHIFT[mode]) {
+    emitLatch(bits, getLatchSequence(mode, Mode.Upper))
+    mode = Mode.Upper
+  }
 
   while (remaining > 0) {
     // A binary shift run carries at most 2078 bytes: 31 encodable in the
@@ -353,14 +363,8 @@ function emitBinaryShift(
     const chunk = Math.min(remaining, 2078)
 
     // Emit binary shift intro code
-    const bs = BINARY_SHIFT[currentMode]
-    if (bs) {
-      pushBits(bits, bs.code, bs.bits)
-    } else {
-      // Digit mode: need to latch to Upper first (shouldn't happen in practice
-      // since we handle Digit's BS code in the table)
-      pushBits(bits, 15, 4)
-    }
+    const bs = BINARY_SHIFT[mode]!
+    pushBits(bits, bs.code, bs.bits)
 
     // Emit length: 1-31 fits the 5-bit field directly; longer runs signal 0
     // there and carry (length - 31) in a further 11 bits (ISO/IEC 24778).
@@ -379,6 +383,8 @@ function emitBinaryShift(
     pos += chunk
     remaining -= chunk
   }
+
+  return mode
 }
 
 /**

--- a/src/encoders/aztec/tables.ts
+++ b/src/encoders/aztec/tables.ts
@@ -65,14 +65,15 @@ const LOWER_TABLE: Record<string, number> = {
 
 /**
  * Mixed mode (5-bit codewords)
- * Code 0 = NUL (or PS in encoder), 1 = SP, 2-14 = ctrl chars, 15-19 = ESC+FS/GS/RS/US,
+ * Code 0 = P/S, 1 = SP, 2-14 = ctrl chars, 15-19 = ESC+FS/GS/RS/US,
  * 20-27 = @\^_`|~DEL, 28-31 = LL/UL/PL/BS
  *
- * Matches ZXing mixedTable character-to-code mapping.
+ * There is no codeword for NUL in any Aztec mode — it goes out through the
+ * binary shift. Mapping it to codeword 0 emitted a shift into Punctuation
+ * instead, and the character after it came back as punctuation.
  */
 // prettier-ignore
 const MIXED_TABLE: Record<string, number> = {
-  '\x00': 0,
   ' ': 1,
   '\x01': 2,  '\x02': 3,  '\x03': 4,  '\x04': 5,  '\x05': 6,
   '\x06': 7,  '\x07': 8,  '\x08': 9,  '\x09': 10, '\x0a': 11,
@@ -262,12 +263,17 @@ export const SHIFT_TO_PUNCT: Record<number, number> = {
 /** Shift to Upper from Lower: code 28 */
 export const SHIFT_LOWER_TO_UPPER = 28
 
-/** Binary shift code value (from Upper/Lower/Mixed: code 31, from Digit: code 15) */
-export const BINARY_SHIFT: Record<number, { code: number; bits: number }> = {
+/**
+ * Binary shift code, in the three modes that have one.
+ *
+ * Upper, Lower and Mixed spend codeword 31 on B/S. Punct has no spare codeword
+ * and Digit spends 15 on Upper Shift, so a binary run starting in either has to
+ * latch to Upper first — there is no B/S to emit.
+ */
+export const BINARY_SHIFT: Record<number, { code: number; bits: number } | undefined> = {
   [Mode.Upper]: { code: 31, bits: 5 },
   [Mode.Lower]: { code: 31, bits: 5 },
   [Mode.Mixed]: { code: 31, bits: 5 },
-  [Mode.Digit]: { code: 15, bits: 4 },
 }
 
 // ---------------------------------------------------------------------------

--- a/test/encoders-aztec-binary.test.ts
+++ b/test/encoders-aztec-binary.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Aztec bytes that no text mode can carry.
+ *
+ * Two defects, both silent: the symbol scanned, and the bytes that came back
+ * were not the bytes that went in.
+ *
+ * - **NUL was encoded as Mixed codeword 0**, which is the shift into
+ *   Punctuation, not NUL. Aztec has no codeword for NUL in any mode; it goes
+ *   out through the binary shift. `"AB\0CD"` came back as `AB{` and two
+ *   punctuation characters.
+ * - **A binary shift starting in Digit mode emitted codeword 15**, which is
+ *   Upper Shift. Digit has no binary shift of its own, so a run starting there
+ *   has to latch to Upper first. `"123\x80"` came back as `"123 6"`.
+ *
+ * Neither was caught because the round trips never put a byte outside the text
+ * modes next to digits, and nothing compared Aztec against the reference.
+ */
+
+import { describe, expect, it } from "vitest"
+import { readBarcodes } from "zxing-wasm/reader"
+import { encodeAztec } from "../src/index"
+import { bwipMatrix } from "./_bwip"
+
+function rows(matrix: boolean[][]): string[] {
+  return matrix.map((row) => row.map((m) => (m ? "1" : "0")).join(""))
+}
+
+/** bwip-js reads its input as UTF-8, so the bytes are escaped for it. */
+function escape(text: string): string {
+  let out = ""
+  for (const ch of text) {
+    const byte = ch.codePointAt(0)!
+    out += byte > 126 || byte < 32 || byte === 94 ? `^${String(byte).padStart(3, "0")}` : ch
+  }
+  return out
+}
+
+/** Decode back to bytes: a reader guesses a character set, the bytes are the data. */
+async function decodeBytes(matrix: boolean[][]): Promise<number[] | null> {
+  const scale = 6
+  const margin = 4
+  const size = matrix.length
+  const width = (size + margin * 2) * scale
+  const data = new Uint8ClampedArray(width * width * 4)
+  data.fill(255)
+  for (let y = 0; y < width; y++) {
+    for (let x = 0; x < width; x++) {
+      const r = Math.floor(y / scale) - margin
+      const c = Math.floor(x / scale) - margin
+      if (r >= 0 && r < size && c >= 0 && c < size && matrix[r]![c]) {
+        const i = (y * width + x) * 4
+        data[i] = 0
+        data[i + 1] = 0
+        data[i + 2] = 0
+      }
+    }
+  }
+  const results = await readBarcodes({ data, width, height: width } as ImageData, {
+    tryHarder: true,
+    formats: ["Aztec"],
+  })
+  const bytes = results[0]?.bytes
+  return bytes ? [...bytes] : null
+}
+
+function bytesOf(text: string): number[] {
+  return [...text].map((ch) => ch.codePointAt(0)!)
+}
+
+describe("Aztec binary shift", () => {
+  it.each([
+    ["a lone NUL", "\x00"],
+    ["NUL before text", "\x00A"],
+    ["NUL after text", "A\x00"],
+    ["NUL between text", "AB\x00CD"],
+    ["NUL between digits", "1\x002"],
+    ["a run of NULs", "\x00\x00\x00"],
+    ["a high byte after digits", "123\x80"],
+    ["high bytes after digits", "123456\x80\x81"],
+    ["a high byte after a digit run", "0000\xff"],
+    ["high bytes between digits and text", "12345678\x80\x81\x82ABC"],
+    ["a high byte after a punctuation pair", ". 123\x80"],
+    ["every byte a text mode cannot carry", "\x00\x80\x81\xfe\xff"],
+  ])("carries %s", async (_name, payload) => {
+    expect(await decodeBytes(encodeAztec(payload))).toEqual(bytesOf(payload))
+  })
+
+  it.each([
+    ["the whole of Latin-1", 31_337, 256, 0],
+    ["ASCII", 555, 128, 0],
+    ["printable ASCII", 777, 95, 32],
+  ] as const)("carries random messages over %s", async (_name, seed, range, base) => {
+    let state: number = seed
+    const random = () => {
+      state = (state * 1103515245 + 12345) & 0x7fffffff
+      return state / 0x7fffffff
+    }
+    for (let n = 0; n < 60; n++) {
+      const length = 1 + Math.floor(random() * 40)
+      let payload = ""
+      for (let i = 0; i < length; i++) {
+        payload += String.fromCharCode(base + Math.floor(random() * range))
+      }
+      expect(await decodeBytes(encodeAztec(payload)), JSON.stringify(payload)).toEqual(
+        bytesOf(payload),
+      )
+    }
+  })
+
+  // The reference agrees module for module on the short cases the fixes were
+  // found from, which is a stronger statement than "it decodes"
+  it.each(["\x00", "\x00A", "A\x00", "AB\x00CD", "\x00\x00\x00", "\x01", "A", "hello"])(
+    "matches bwip-js for %j",
+    (payload) => {
+      expect(rows(encodeAztec(payload, { compact: true }))).toEqual(
+        rows(bwipMatrix("azteccode", escape(payload), { parse: true, format: "compact" })),
+      )
+    },
+  )
+})


### PR DESCRIPTION
Both silent. The symbol scanned, and the bytes that came out were not the bytes that went in.

## NUL was a shift into Punctuation

`MIXED_TABLE` mapped `\0` to codeword 0. Mixed codeword 0 is **P/S**, the shift into Punctuation mode. Aztec has no codeword for NUL in any of its five modes — it goes out through the binary shift like any other byte no mode can carry.

```
"AB\0CD"  ->  65, 66, 123, 3, 4        (was)
"AB\0CD"  ->  65, 66, 0, 67, 68        (now, and identical to BWIPP)
```

## A binary shift from Digit mode was an Upper Shift

`BINARY_SHIFT` gave Digit mode codeword 15. Digit codeword 15 is **U/S**, Upper Shift. Digit has no binary shift of its own, and neither does Punctuation, so a run starting in either has to latch to Upper first.

```
"123\x80"  ->  49, 50, 51, 32, 54      (was: reader took 15 as a shift, read
                                        the length field as a letter, and the
                                        byte after it as text)
"123\x80"  ->  49, 50, 51, 128         (now)
```

Neither was caught because the round-trip tests never put a byte outside the text modes next to digits, and nothing compared Aztec against the reference.

## Verification

`test/encoders-aztec-binary.test.ts`:

- the twelve shapes the two defects were found from, decoded back to their bytes
- 180 random messages over the whole of Latin-1, over ASCII and over printable ASCII — every one byte-exact, where the Latin-1 sweep had 16 in 200 wrong before
- the short cases compared module for module against BWIPP

## Still open

Aztec's mode switching is greedy, and after these fixes a binary run is broken and restarted for every character that happens to fit a text mode — a new ten-bit header each time. That leaves the symbol a size class larger than BWIPP's on 43 of 200 random Latin-1 messages, and on 2 of 14 realistic ones. That is a separate change: a shortest-path encoder of the same shape as the one MaxiCode got in #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)