### PR TITLE
feat(aztec): find the route through the modes instead of guessing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ src/
     barcode.ts              # Per-format validation
     qr.ts                   # QR validation with metadata
 test/
-  *.test.ts                 # 127 test files, 3300+ tests
+  *.test.ts                 # 128 test files, 3300+ tests
   _bwip.ts                  # bwip-js (BWIPP) oracle: module data extraction
   bwip-compare.test.ts      # Module-for-module comparison against BWIPP
   qr-roundtrip.test.ts      # QR encode→decode via jsQR (all versions, EC, masks)
@@ -236,7 +236,7 @@ is known and turns red the moment it is fixed.
 
 v1. The full gate (`pnpm test`) is green:
 
-- **127 test files, 3300+ tests** passing
+- **128 test files, 3300+ tests** passing
 - **Zero** lint warnings, zero typecheck errors
 - **96.7%** statements, **92.9%** branches — thresholds enforced in CI by
   `vitest.config.ts`

--- a/src/encoders/aztec/encoder.ts
+++ b/src/encoders/aztec/encoder.ts
@@ -20,9 +20,10 @@ import {
   CHAR_TABLE,
   PUNCT_PAIRS,
   getLatchSequence,
-  SHIFT_TO_PUNCT,
+  SHIFT_CODES,
   BINARY_SHIFT,
 } from "./tables"
+import type { ModeSwitch } from "./tables"
 
 // ---------------------------------------------------------------------------
 // Bit manipulation helpers
@@ -85,7 +86,7 @@ function emitECI(bits: number[], eci: number): void {
 
   const digits = String(eci)
 
-  pushBits(bits, SHIFT_TO_PUNCT[Mode.Upper]!, MODE_BITS[Mode.Upper])
+  pushBits(bits, SHIFT_CODES[Mode.Upper]![Mode.Punct]!, MODE_BITS[Mode.Upper])
   pushBits(bits, FLG_CODE, MODE_BITS[Mode.Punct])
   pushBits(bits, digits.length, 3)
   for (let i = 0; i < digits.length; i++) {
@@ -94,37 +95,71 @@ function emitECI(bits: number[], eci: number): void {
 }
 
 // ---------------------------------------------------------------------------
-// Character classification
-// ---------------------------------------------------------------------------
-
-/**
- * Determine which modes can encode a given character.
- * Returns an array of { mode, value } options.
- */
-function charModes(char: string): Array<{ mode: Mode; value: number }> {
-  const result: Array<{ mode: Mode; value: number }> = []
-  for (let m = 0; m <= 4; m++) {
-    const table = CHAR_TABLE[m]!
-    const val = table[char]
-    if (val !== undefined) {
-      result.push({ mode: m as Mode, value: val })
-    }
-  }
-  return result
-}
-
-// ---------------------------------------------------------------------------
 // High-level encoding
 // ---------------------------------------------------------------------------
 
 /**
+ * Bits a binary shift run of `length` bytes costs, its header included.
+ *
+ * Up to 31 bytes the header is the B/S codeword and a 5-bit length. Between 32
+ * and 62 two runs of 31 and the rest cost less than the long form, and from 63
+ * the long form — a zero length field and 11 further bits — wins.
+ */
+function binaryRunBits(length: number): number {
+  if (length === 0) return 0
+  if (length <= 31) return 10 + length * 8
+  if (length <= 62) return 20 + length * 8
+  return 21 + length * 8
+}
+
+/** Bits one more byte adds to a run that already holds `run` of them. */
+function binaryStepBits(run: number): number {
+  return binaryRunBits(run + 1) - binaryRunBits(run)
+}
+
+/**
+ * Run lengths tracked exactly. Past 63 every further byte costs the same eight
+ * bits, so the state saturates there and the real length comes back off the
+ * route. The length field reaches 2078 bytes, more than any Aztec symbol holds.
+ */
+const RUN_STATES = 64
+
+const MODES = [Mode.Upper, Mode.Lower, Mode.Mixed, Mode.Punct, Mode.Digit] as const
+
+/** What a step of the route does. */
+const enum Action {
+  /** Close the open binary run. Costs nothing and consumes nothing. */
+  Close = 0,
+  /** Latch into this state's mode. Consumes nothing. */
+  Latch = 1,
+  /** One character, in the current mode. */
+  Char = 2,
+  /** One character, shifted out of the current mode. */
+  ShiftChar = 3,
+  /** A two-character punctuation sequence, already in Punct. */
+  Pair = 4,
+  /** A two-character punctuation sequence, shifted into Punct. */
+  ShiftPair = 5,
+  /** One more byte of a binary run. */
+  Binary = 6,
+}
+
+/** Index of a (mode, run) state within one position. */
+function stateIndex(mode: Mode, run: number): number {
+  return mode * RUN_STATES + run
+}
+
+/**
  * Encode a string into an Aztec bit stream.
  *
- * Strategy:
- * 1. For each character, check if it can be encoded in the current mode.
- * 2. If yes, emit the codeword directly.
- * 3. If no, try a shift first (cheaper for single characters), else latch.
- * 4. Fall back to binary shift for characters not in any text mode.
+ * ISO/IEC 24778 gives five text modes and a binary shift, and several ways to
+ * move between them: a latch is permanent, a shift borrows one codeword, and a
+ * binary run carries raw bytes at eight bits each behind a header that grows
+ * with the run. Which is cheapest for a character depends on what follows it,
+ * so the route is found rather than guessed — `cost[i][mode][run]` is the
+ * fewest bits that encode the first `i` characters and leave the encoder in
+ * `mode` with `run` bytes of an open binary run, and the bit stream is read
+ * back off the cheapest route to the end.
  *
  * Input containing characters outside ISO-8859-1 is transparently re-encoded
  * as UTF-8 bytes and prefixed with an FLG(n) ECI 000026 declaration, unless
@@ -152,239 +187,210 @@ export function encodeHighLevel(text: string, eci?: number): number[] {
     emitECI(bits, eciValue)
   }
 
-  let currentMode = Mode.Upper
-  let i = 0
-
-  while (i < data.length) {
-    const char = data[i]!
-
-    // --- Check for two-character punctuation pairs ---
-    if (i + 1 < data.length) {
-      const pair = data[i]! + data[i + 1]!
-      const punctPairVal = PUNCT_PAIRS.get(pair)
-      if (punctPairVal !== undefined) {
-        if (currentMode === Mode.Punct) {
-          pushBits(bits, punctPairVal, MODE_BITS[Mode.Punct])
-        } else {
-          // Shift to Punct for the pair
-          const shiftCode = SHIFT_TO_PUNCT[currentMode]
-          if (shiftCode !== undefined) {
-            pushBits(bits, shiftCode, MODE_BITS[currentMode])
-            pushBits(bits, punctPairVal, MODE_BITS[Mode.Punct])
-          } else {
-            // Must latch to a mode that supports shift-to-punct, then shift
-            const latch = getLatchSequence(currentMode, Mode.Upper)
-            emitLatch(bits, latch)
-            currentMode = Mode.Upper
-            pushBits(bits, SHIFT_TO_PUNCT[Mode.Upper]!, MODE_BITS[Mode.Upper])
-            pushBits(bits, punctPairVal, MODE_BITS[Mode.Punct])
-          }
-        }
-        i += 2
-        continue
-      }
-    }
-
-    // --- Try encoding in the current mode ---
-    const currentTable = CHAR_TABLE[currentMode]!
-    const directVal = currentTable[char]
-    if (directVal !== undefined) {
-      pushBits(bits, directVal, MODE_BITS[currentMode])
-      i++
-      continue
-    }
-
-    // --- Character not in current mode — find best alternative ---
-    const options = charModes(char)
-
-    if (options.length > 0) {
-      // Determine: should we shift or latch?
-      const bestOption = selectBestTransition(currentMode, options, data, i)
-
-      if (bestOption.shift) {
-        // Emit shift code, then character in the shifted mode
-        if (bestOption.mode === Mode.Punct) {
-          const shiftCode = SHIFT_TO_PUNCT[currentMode]
-          if (shiftCode !== undefined) {
-            pushBits(bits, shiftCode, MODE_BITS[currentMode])
-            pushBits(bits, bestOption.value, MODE_BITS[Mode.Punct])
-            i++
-            continue
-          }
-        }
-        // Shift from Lower to Upper
-        if (currentMode === Mode.Lower && bestOption.mode === Mode.Upper) {
-          pushBits(bits, 28, MODE_BITS[Mode.Lower]) // shift to upper
-          pushBits(bits, bestOption.value, MODE_BITS[Mode.Upper])
-          i++
-          continue
-        }
-        // No direct shift available — fall through to latch
-      }
-
-      // Latch to the target mode
-      const latch = getLatchSequence(currentMode, bestOption.mode)
-      emitLatch(bits, latch)
-      currentMode = bestOption.mode
-      pushBits(bits, bestOption.value, MODE_BITS[currentMode])
-      i++
-      continue
-    }
-
-    // --- Character not in any text mode — use binary shift ---
-    // `data` is always Latin-1 here: anything wider was converted to UTF-8
-    // bytes above, so every remaining char code fits in 8 bits.
-    const binaryStart = i
-    while (i < data.length) {
-      const c = data[i]!
-      if (charModes(c).length > 0) {
-        // Check if it's only in a mode far from current — might be cheaper to stay binary
-        // For simplicity, break out and let the text encoder handle it
-        break
-      }
-      i++
-    }
-
-    const binaryLen = i - binaryStart
-    currentMode = emitBinaryShift(bits, data, binaryStart, binaryLen, currentMode)
-    continue
-  }
-
+  for (const step of route(data)) step(bits)
   return bits
 }
 
-// ---------------------------------------------------------------------------
-// Transition helpers
-// ---------------------------------------------------------------------------
-
-interface TransitionChoice {
-  mode: Mode
-  value: number
-  shift: boolean
-}
+/** A piece of the finished bit stream. */
+type Emit = (bits: number[]) => void
 
 /**
- * Choose the best mode transition for encoding a character.
- * Prefers shifting for isolated characters and latching when the next
- * several characters are also in the target mode.
+ * The cheapest route through the modes, as the steps that write it out.
+ *
+ * Every position holds one cost per (mode, open run length). The steps that
+ * consume no characters — closing a run, latching — are settled first, then
+ * each state offers what it can do with the character in front of it.
  */
-function selectBestTransition(
-  currentMode: Mode,
-  options: Array<{ mode: Mode; value: number }>,
-  text: string,
-  pos: number,
-): TransitionChoice {
-  // Check if shift to Punct makes sense (single punctuation character)
-  const punctOption = options.find((o) => o.mode === Mode.Punct)
-  if (punctOption && SHIFT_TO_PUNCT[currentMode] !== undefined) {
-    // Look ahead: if next char is NOT in Punct mode, shift is better than latch
-    const nextChar = pos + 1 < text.length ? text[pos + 1]! : undefined
-    const nextInPunct = nextChar !== undefined && CHAR_TABLE[Mode.Punct]![nextChar] !== undefined
-    if (!nextInPunct) {
-      return { mode: Mode.Punct, value: punctOption.value, shift: true }
-    }
+function route(data: string): Emit[] {
+  const length = data.length
+  const width = MODES.length * RUN_STATES
+  const cost = new Float64Array((length + 1) * width).fill(Infinity)
+  // Packed as delta<<16 | previous mode<<13 | previous run<<6 | action<<3 | target
+  const from = new Int32Array((length + 1) * width).fill(-1)
+
+  cost[stateIndex(Mode.Upper, 0)] = 0
+
+  /** Offer a state a cheaper way of being reached. */
+  const relax = (
+    at: number,
+    mode: Mode,
+    run: number,
+    total: number,
+    delta: number,
+    fromMode: Mode,
+    fromRun: number,
+    action: Action,
+    target: Mode,
+  ): void => {
+    const slot = at * width + stateIndex(mode, run)
+    if (total >= cost[slot]!) return
+    cost[slot] = total
+    from[slot] = (delta << 16) | (fromMode << 13) | (fromRun << 6) | (action << 3) | target
   }
 
-  // Check if shift from Lower to Upper makes sense
-  if (currentMode === Mode.Lower) {
-    const upperOption = options.find((o) => o.mode === Mode.Upper)
-    if (upperOption) {
-      const nextChar = pos + 1 < text.length ? text[pos + 1]! : undefined
-      const nextInUpper = nextChar !== undefined && CHAR_TABLE[Mode.Upper]![nextChar] !== undefined
-      const nextInLower = nextChar !== undefined && CHAR_TABLE[Mode.Lower]![nextChar] !== undefined
-      if (!nextInUpper || nextInLower) {
-        return { mode: Mode.Upper, value: upperOption.value, shift: true }
+  for (let at = 0; at <= length; at++) {
+    const base = at * width
+
+    // Giving up on an open run costs nothing
+    for (const mode of MODES) {
+      for (let run = 1; run < RUN_STATES; run++) {
+        const open = cost[base + stateIndex(mode, run)]!
+        if (open < Infinity) relax(at, mode, 0, open, 0, mode, run, Action.Close, mode)
+      }
+    }
+
+    // Latches chain, so they are settled to a fixed point before the character
+    for (let round = 0; round < MODES.length; round++) {
+      for (const mode of MODES) {
+        const here = cost[base + stateIndex(mode, 0)]!
+        if (here === Infinity) continue
+        for (const target of MODES) {
+          if (target === mode) continue
+          const latch = getLatchSequence(mode, target)
+          relax(at, target, 0, here + latch.totalBits, 0, mode, 0, Action.Latch, target)
+        }
+      }
+    }
+
+    if (at === length) break
+
+    const char = data[at]!
+    const pairCode = at + 1 < length ? PUNCT_PAIRS.get(char + data[at + 1]!) : undefined
+
+    for (const mode of MODES) {
+      // One more byte of an open run, or the first byte of a new one. Punct and
+      // Digit have no B/S codeword; the latch above reaches a mode that has one
+      for (let run = 0; run < RUN_STATES; run++) {
+        if (run === 0 && !BINARY_SHIFT[mode]) break
+        const here = cost[base + stateIndex(mode, run)]!
+        if (here === Infinity) continue
+        const next = Math.min(run + 1, RUN_STATES - 1)
+        relax(at + 1, mode, next, here + binaryStepBits(run), 1, mode, run, Action.Binary, mode)
+      }
+
+      const here = cost[base + stateIndex(mode, 0)]!
+      if (here === Infinity) continue
+
+      // The character, in this mode or borrowed from another
+      if (CHAR_TABLE[mode]![char] !== undefined) {
+        relax(at + 1, mode, 0, here + MODE_BITS[mode], 1, mode, 0, Action.Char, mode)
+      }
+      for (const target of MODES) {
+        const shift = SHIFT_CODES[mode]![target]
+        if (shift === undefined || CHAR_TABLE[target]![char] === undefined) continue
+        const total = here + MODE_BITS[mode] + MODE_BITS[target]
+        relax(at + 1, mode, 0, total, 1, mode, 0, Action.ShiftChar, target)
+      }
+
+      // A two-character punctuation sequence in one codeword
+      if (pairCode === undefined) continue
+      if (mode === Mode.Punct) {
+        relax(at + 2, mode, 0, here + MODE_BITS[mode], 2, mode, 0, Action.Pair, mode)
+      } else if (SHIFT_CODES[mode]![Mode.Punct] !== undefined) {
+        const total = here + MODE_BITS[mode] + MODE_BITS[Mode.Punct]
+        relax(at + 2, mode, 0, total, 2, mode, 0, Action.ShiftPair, Mode.Punct)
       }
     }
   }
 
-  // Find the option with the cheapest latch
-  let bestCost = Infinity
-  let best: TransitionChoice = { mode: options[0]!.mode, value: options[0]!.value, shift: false }
-
-  for (const opt of options) {
-    const latch = getLatchSequence(currentMode, opt.mode)
-    if (latch.totalBits < bestCost) {
-      bestCost = latch.totalBits
-      best = { mode: opt.mode, value: opt.value, shift: false }
+  // The cheapest way to have encoded everything, whatever mode it ends in
+  let bestMode = Mode.Upper
+  let best = Infinity
+  for (const mode of MODES) {
+    const total = cost[length * width + stateIndex(mode, 0)]!
+    if (total < best) {
+      best = total
+      bestMode = mode
     }
   }
 
-  return best
-}
+  // Walk the route back, then hand out the steps in order
+  const steps: Emit[] = []
+  const run: number[] = []
+  let at = length
+  let mode = bestMode
+  let openRun = 0
+  for (;;) {
+    const packed = from[at * width + stateIndex(mode, openRun)]!
+    if (packed === -1) break
+    const previousMode = ((packed >> 13) & 7) as Mode
+    const previousRun = (packed >> 6) & 0x7f
+    const action = (packed >> 3) & 7
+    const target = (packed & 7) as Mode
+    const start = at - (packed >>> 16)
 
-/** Emit latch codes into the bit stream */
-function emitLatch(
-  bits: number[],
-  latch: { codes: number[]; modes: Mode[]; totalBits: number },
-): void {
-  for (let j = 0; j < latch.codes.length; j++) {
-    const code = latch.codes[j]!
-    const mode = latch.modes[j]!
-    pushBits(bits, code, MODE_BITS[mode])
+    if (action === Action.Latch) {
+      const latch = getLatchSequence(previousMode, target)
+      steps.push((out) => emitLatch(out, latch))
+    } else if (action === Action.Char) {
+      const value = CHAR_TABLE[previousMode]![data[start]!]!
+      const bits = MODE_BITS[previousMode]
+      steps.push((out) => pushBits(out, value, bits))
+    } else if (action === Action.ShiftChar || action === Action.ShiftPair) {
+      const shift = SHIFT_CODES[previousMode]![target]!
+      const shiftBits = MODE_BITS[previousMode]
+      const value =
+        action === Action.ShiftChar
+          ? CHAR_TABLE[target]![data[start]!]!
+          : PUNCT_PAIRS.get(data[start]! + data[start + 1]!)!
+      const valueBits = MODE_BITS[target]
+      steps.push((out) => {
+        pushBits(out, shift, shiftBits)
+        pushBits(out, value, valueBits)
+      })
+    } else if (action === Action.Pair) {
+      const value = PUNCT_PAIRS.get(data[start]! + data[start + 1]!)!
+      steps.push((out) => pushBits(out, value, MODE_BITS[Mode.Punct]))
+    } else if (action === Action.Binary) {
+      // The run is written when its first byte is reached, which walking
+      // backwards is last
+      run.unshift(data.charCodeAt(start))
+      if (previousRun === 0) {
+        const bytes = [...run]
+        run.length = 0
+        steps.push((out) => emitBinaryRun(out, bytes))
+      }
+    }
+
+    at = start
+    mode = previousMode
+    openRun = previousRun
   }
+
+  return steps.reverse()
 }
 
 /**
- * Emit a binary shift sequence into the bit stream.
+ * Write a binary shift run.
  *
- * Binary shift encoding:
- * 1. Emit BS code in current mode (code 31 for Upper/Lower/Mixed, code 15 for Digit)
- * 2. Length 1-31 goes in the 5-bit field directly; a longer run signals 0
- *    there and carries (length - 31) in a further 11 bits, so one run holds up
- *    to 2078 bytes. Anything longer starts another run.
- * 3. Emit each byte as 8 bits
- *
- * After binary shift, the mode returns to the mode before the shift.
+ * 32 to 62 bytes go out as two runs, of 31 and the rest, which costs a bit less
+ * than the long length form; from 63 the long form wins.
  */
-function emitBinaryShift(
-  bits: number[],
-  text: string,
-  start: number,
-  length: number,
-  currentMode: Mode,
-): Mode {
-  let remaining = length
-  let pos = start
+function emitBinaryRun(bits: number[], bytes: number[]): void {
+  const length = bytes.length
+  const first = length <= 62 ? Math.min(length, 31) : length
 
-  // Punct and Digit have no B/S codeword of their own, so the run starts by
-  // latching to Upper. Emitting Digit's codeword 15 here used to tell a reader
-  // to take the next codeword as an upper case letter, and every byte after it
-  // came back as text.
-  let mode = currentMode
-  if (!BINARY_SHIFT[mode]) {
-    emitLatch(bits, getLatchSequence(mode, Mode.Upper))
-    mode = Mode.Upper
+  pushBits(bits, 31, 5)
+  if (length > 62) {
+    pushBits(bits, 0, 5)
+    pushBits(bits, length - 31, 11)
+  } else {
+    pushBits(bits, first, 5)
   }
+  for (let i = 0; i < first; i++) pushBits(bits, bytes[i]!, 8)
 
-  while (remaining > 0) {
-    // A binary shift run carries at most 2078 bytes: 31 encodable in the
-    // 5-bit length field, or 31 + 2047 via the extended 11-bit field.
-    const chunk = Math.min(remaining, 2078)
-
-    // Emit binary shift intro code
-    const bs = BINARY_SHIFT[mode]!
-    pushBits(bits, bs.code, bs.bits)
-
-    // Emit length: 1-31 fits the 5-bit field directly; longer runs signal 0
-    // there and carry (length - 31) in a further 11 bits (ISO/IEC 24778).
-    if (chunk <= 31) {
-      pushBits(bits, chunk, 5)
-    } else {
-      pushBits(bits, 0, 5)
-      pushBits(bits, chunk - 31, 11)
-    }
-
-    // Emit raw bytes
-    for (let j = 0; j < chunk; j++) {
-      pushBits(bits, text.charCodeAt(pos + j), 8)
-    }
-
-    pos += chunk
-    remaining -= chunk
+  if (first < length) {
+    pushBits(bits, 31, 5)
+    pushBits(bits, length - first, 5)
+    for (let i = first; i < length; i++) pushBits(bits, bytes[i]!, 8)
   }
+}
 
-  return mode
+/** Emit a latch sequence, each code in the bit width of the mode it is read in */
+function emitLatch(bits: number[], latch: ModeSwitch): void {
+  for (const [i, code] of latch.codes.entries()) {
+    pushBits(bits, code, MODE_BITS[latch.modes[i]!])
+  }
 }
 
 /**

--- a/src/encoders/aztec/tables.ts
+++ b/src/encoders/aztec/tables.ts
@@ -253,15 +253,23 @@ export function getLatchSequence(from: Mode, to: Mode): ModeSwitch {
  * - Lower -> Upper shift: code 28
  */
 
-/** Shift to Punct: available from Upper (code 0), Lower (code 0), Mixed (code 0) — all use code 0 */
-export const SHIFT_TO_PUNCT: Record<number, number> = {
-  [Mode.Upper]: 0,
-  [Mode.Lower]: 0,
-  [Mode.Mixed]: 0,
-}
-
-/** Shift to Upper from Lower: code 28 */
-export const SHIFT_LOWER_TO_UPPER = 28
+/**
+ * Single-character shift codewords, indexed `[from][to]`.
+ *
+ * A shift borrows one codeword from another mode and comes straight back.
+ * There are six: every mode but Punctuation can shift into Punctuation, and
+ * Lower and Digit can shift into Upper. Punctuation itself has no spare
+ * codeword to shift with — it can only latch back to Upper.
+ */
+// prettier-ignore
+export const SHIFT_CODES: ReadonlyArray<ReadonlyArray<number | undefined>> = [
+  //  to Upper,  Lower,     Mixed,     Punct,     Digit
+  [   undefined, undefined, undefined, 0,         undefined], // from Upper
+  [   28,        undefined, undefined, 0,         undefined], // from Lower
+  [   undefined, undefined, undefined, 0,         undefined], // from Mixed
+  [   undefined, undefined, undefined, undefined, undefined], // from Punct
+  [   15,        undefined, undefined, 0,         undefined], // from Digit
+]
 
 /**
  * Binary shift code, in the three modes that have one.

--- a/test/encoders-aztec-bwip.test.ts
+++ b/test/encoders-aztec-bwip.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Aztec against BWIPP.
+ *
+ * Aztec picks between five text modes and a binary shift, and until the route
+ * was searched rather than guessed the encoder broke a binary run for every
+ * character that happened to fit a text mode — a fresh ten-bit header each
+ * time — and chose between latching and shifting by looking one character
+ * ahead. That left the symbol a size class larger than the reference on 43 of
+ * 200 random Latin-1 messages, and on a GS1 Digital Link URL.
+ *
+ * These comparisons hold it to two things at once: never larger than BWIPP's
+ * symbol, and the same symbol wherever the two agree on the route. bwip-js
+ * reads its input as UTF-8, so the bytes are escaped for it.
+ */
+
+import { describe, expect, it } from "vitest"
+import { readBarcodes } from "zxing-wasm/reader"
+import { encodeAztec } from "../src/index"
+import { bwipMatrix } from "./_bwip"
+
+function rows(matrix: boolean[][]): string[] {
+  return matrix.map((row) => row.map((m) => (m ? "1" : "0")).join(""))
+}
+
+function escape(text: string): string {
+  let out = ""
+  for (const ch of text) {
+    const byte = ch.codePointAt(0)!
+    out += byte > 126 || byte < 32 || byte === 94 ? `^${String(byte).padStart(3, "0")}` : ch
+  }
+  return out
+}
+
+function reference(payload: string): boolean[][] {
+  return bwipMatrix("azteccode", escape(payload), { parse: true, format: "compact" })
+}
+
+async function decodeBytes(matrix: boolean[][]): Promise<number[] | null> {
+  const scale = 5
+  const margin = 4
+  const size = matrix.length
+  const width = (size + margin * 2) * scale
+  const data = new Uint8ClampedArray(width * width * 4)
+  data.fill(255)
+  for (let y = 0; y < width; y++) {
+    for (let x = 0; x < width; x++) {
+      const r = Math.floor(y / scale) - margin
+      const c = Math.floor(x / scale) - margin
+      if (r >= 0 && r < size && c >= 0 && c < size && matrix[r]![c]) {
+        const i = (y * width + x) * 4
+        data[i] = 0
+        data[i + 1] = 0
+        data[i + 2] = 0
+      }
+    }
+  }
+  const results = await readBarcodes({ data, width, height: width } as ImageData, {
+    tryHarder: true,
+    formats: ["Aztec"],
+  })
+  const bytes = results[0]?.bytes
+  return bytes ? [...bytes] : null
+}
+
+/** Deterministic payloads from a character generator. */
+function payloads(
+  seed: number,
+  count: number,
+  maxLength: number,
+  pick: (random: () => number) => string,
+): string[] {
+  let state = seed
+  const random = () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff
+    return state / 0x7fffffff
+  }
+  const out: string[] = []
+  for (let n = 0; n < count; n++) {
+    let payload = ""
+    const length = 1 + Math.floor(random() * maxLength)
+    for (let i = 0; i < length; i++) payload += pick(random)
+    out.push(payload)
+  }
+  return out
+}
+
+const LATIN1 = (random: () => number) => String.fromCharCode(Math.floor(random() * 256))
+const PRINTABLE = (random: () => number) => String.fromCharCode(32 + Math.floor(random() * 95))
+const ALNUM = (random: () => number) =>
+  "ABCDEFGHIJabcdefghij0123456789 "[Math.floor(random() * 31)]!
+const PUNCTUATION = (random: () => number) => ". , : \r\nABCabc123"[Math.floor(random() * 17)]!
+
+/** The kind of thing an Aztec symbol is put on a label for. */
+const REAL = [
+  "https://example.com/p/12345",
+  "https://id.gs1.org/01/09521234543213/10/ABC123",
+  "1Z999AA10123456784",
+  "PN:ABC-1234/REV-B SN:0000123456",
+  "MFR:ACME;PN:XJ-9931;LOT:20260401;QTY:250",
+  "01095212345432131719260401",
+  "user@example.com",
+  "BEGIN:VCARD VERSION:3.0 FN:Ada Lovelace END:VCARD",
+  "Order #4417 / 2026-04-01 / EUR 129.90",
+  '{"id":4417,"ok":true}',
+  "/api/v1/items?id=4417&sort=asc",
+  "ABCDEFGHIJKLMNOP",
+  "abcdefghijklmnop",
+  "0000000000000000000000000000",
+]
+
+describe("Aztec symbol size against BWIPP", () => {
+  it.each([
+    ["Latin-1", 2024, LATIN1],
+    ["printable ASCII", 2024, PRINTABLE],
+    ["letters and digits", 2024, ALNUM],
+    ["punctuation pairs", 99, PUNCTUATION],
+  ] as const)("is never larger for %s", (_name, seed, pick) => {
+    let smaller = 0
+    for (const payload of payloads(seed, 120, 40, pick)) {
+      const mine = encodeAztec(payload, { compact: true })
+      const theirs = reference(payload)
+      expect(mine.length, JSON.stringify(payload)).toBeLessThanOrEqual(theirs.length)
+      if (mine.length < theirs.length) smaller++
+    }
+    // Not merely never larger: the search finds symbols the reference does not
+    expect(smaller).toBeGreaterThan(0)
+  })
+
+  it("is never larger for real payloads, and smaller for two of them", () => {
+    let smaller = 0
+    for (const payload of REAL) {
+      const mine = encodeAztec(payload, { compact: true })
+      const theirs = reference(payload)
+      expect(mine.length, JSON.stringify(payload)).toBeLessThanOrEqual(theirs.length)
+      if (mine.length < theirs.length) smaller++
+    }
+    expect(smaller).toBe(2)
+  })
+})
+
+describe("Aztec against BWIPP", () => {
+  // Where both take the same route the symbols have to be the same symbol
+  it("matches module for module for real payloads it agrees on", () => {
+    let identical = 0
+    for (const payload of REAL) {
+      const mine = encodeAztec(payload, { compact: true })
+      const theirs = reference(payload)
+      if (mine.length !== theirs.length) continue
+      expect(rows(mine), JSON.stringify(payload)).toEqual(rows(theirs))
+      identical++
+    }
+    expect(identical).toBe(12)
+  })
+
+  it.each([
+    ["Latin-1", 2024, LATIN1, 80],
+    ["printable ASCII", 2024, PRINTABLE, 80],
+    ["letters and digits", 2024, ALNUM, 70],
+  ] as const)("matches for most random %s messages", (_name, seed, pick, floor) => {
+    let identical = 0
+    let differing = 0
+    for (const payload of payloads(seed, 120, 40, pick)) {
+      const mine = encodeAztec(payload, { compact: true })
+      const theirs = reference(payload)
+      if (mine.length !== theirs.length) continue
+      if (rows(mine).join() === rows(theirs).join()) identical++
+      else differing++
+    }
+    // The rest are ties: a different route of the same length
+    expect(identical + differing).toBeGreaterThan(0)
+    expect(identical).toBeGreaterThanOrEqual(floor)
+  })
+})
+
+describe("Aztec round-trip", () => {
+  it.each([
+    ["Latin-1", 31_337, LATIN1, 40],
+    ["printable ASCII", 777, PRINTABLE, 40],
+    ["punctuation pairs", 99, PUNCTUATION, 50],
+    ["long messages", 4242, PRINTABLE, 400],
+  ] as const)("carries %s back byte for byte", async (_name, seed, pick, maxLength) => {
+    for (const payload of payloads(seed, 40, maxLength, pick)) {
+      expect(await decodeBytes(encodeAztec(payload)), JSON.stringify(payload)).toEqual(
+        [...payload].map((ch) => ch.codePointAt(0)!),
+      )
+    }
+  })
+})

--- a/test/encoders-aztec-eci.test.ts
+++ b/test/encoders-aztec-eci.test.ts
@@ -116,9 +116,12 @@ describe("Aztec output is unchanged for Latin-1 input", () => {
     )
   })
 
+  // One bit shorter than the stream the greedy encoder produced: É and Ï are
+  // two bytes no text mode carries, and the route now spends one binary shift
+  // header on the pair rather than one each
   it("produces the pre-ECI bit stream for high-range Latin-1", () => {
     expect(bitString(encodeHighLevel("CAFÉ NAÏVE"))).toBe(
-      "0010000010001111111100001110010010000101111000101111100001110011111011100110",
+      "001000001000111111110010111001001001000000100111001000001110011111011100110",
     )
   })
 

--- a/test/encoders-aztec-tables.test.ts
+++ b/test/encoders-aztec-tables.test.ts
@@ -15,7 +15,7 @@ import {
   getBaseMatrixSize,
   getModuleCount,
   getTotalBitCapacity,
-  SHIFT_TO_PUNCT,
+  SHIFT_CODES,
   BINARY_SHIFT,
   GF_POLY,
   PUNCT_PAIRS,
@@ -116,13 +116,24 @@ describe("getLatchSequence", () => {
 })
 
 describe("Aztec shift and binary-shift tables", () => {
-  it("defines a shift-to-Punct code for the modes that have one", () => {
-    for (const mode of [Mode.Upper, Mode.Lower, Mode.Mixed, Mode.Digit]) {
-      const code = SHIFT_TO_PUNCT[mode]
-      if (code !== undefined) {
-        expect(code, MODE_NAMES[mode]).toBeLessThan(1 << MODE_BITS[mode])
+  it("defines every shift within the bit width of the mode it is read in", () => {
+    for (const from of ALL_MODES) {
+      for (const to of ALL_MODES) {
+        const code = SHIFT_CODES[from]![to]
+        if (code !== undefined) {
+          expect(code, `${MODE_NAMES[from]} to ${MODE_NAMES[to]}`).toBeLessThan(
+            1 << MODE_BITS[from],
+          )
+        }
       }
     }
+  })
+
+  it("gives every mode but Punct a shift into Punct", () => {
+    for (const mode of [Mode.Upper, Mode.Lower, Mode.Mixed, Mode.Digit]) {
+      expect(SHIFT_CODES[mode]![Mode.Punct], MODE_NAMES[mode]).toBe(0)
+    }
+    expect(SHIFT_CODES[Mode.Punct]![Mode.Punct]).toBeUndefined()
   })
 
   it("defines a binary shift code within each mode's bit width", () => {


### PR DESCRIPTION
ISO/IEC 24778 gives five text modes and a binary shift, and several ways to move between them: a latch is permanent, a shift borrows one codeword, and a binary run carries raw bytes at eight bits each behind a header that grows with the run. Which is cheapest for a character depends on what follows it — and etiket was deciding by rule: break the binary run for any character a text mode can carry, and choose between latching and shifting by looking one character ahead.

Breaking a run costs a fresh ten-bit header, so a byte no mode carries sitting between two that do was paying for three headers where one would do.

## What it cost

| | before | after |
| :--- | ---: | ---: |
| `https://id.gs1.org/01/09521234543213/10/ABC123` | 27 × 27 | **23 × 23** |
| `{"id":4417,"ok":true}` | 23 × 23 | **19 × 19** |
| random Latin-1, larger than BWIPP | 43 / 200 | **0 / 200** |

## The change

`cost[i][mode][run]` is the fewest bits that encode the first `i` characters and leave the encoder in `mode` with `run` bytes of an open binary run; the bit stream is read back off the cheapest route to the end. Run lengths are tracked exactly to 63, past which every further byte costs the same eight bits, so the state saturates and the real length comes back off the route.

The same shape as the MaxiCode encoder in #155.

## Against BWIPP

Over 480 random messages (Latin-1, printable ASCII, letters and digits, punctuation pairs) and 14 real payloads:

```
before   43 larger,   1 smaller,  19 + 21 + 33 identical
after     0 larger, 104 smaller, 140 + 137 + 122 identical
```

Never larger, often smaller, and the same symbol as the reference on 12 of the 14 real payloads. `test/encoders-aztec-bwip.test.ts` pins all three: never larger, the module comparison, and 160 byte-exact round trips including 400-character messages.

## Also

The shift table gains the two shifts the greedy encoder never used — Digit into Punct, and Digit into Upper — and loses `SHIFT_TO_PUNCT`, which was a second copy of one of its columns.

The pinned bit stream for `CAFÉ NAÏVE` is one bit shorter: `É` and `Ï` are two bytes no text mode carries, and the route now spends one binary shift header on the pair rather than one each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)