### PR TITLE
feat: Structured Append for Data Matrix and MaxiCode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ src/
     barcode.ts              # Per-format validation
     qr.ts                   # QR validation with metadata
 test/
-  *.test.ts                 # 133 test files, 3300+ tests
+  *.test.ts                 # 134 test files, 3400+ tests
   _bwip.ts                  # bwip-js (BWIPP) oracle: module data extraction
   bwip-compare.test.ts      # Module-for-module comparison against BWIPP
   qr-roundtrip.test.ts      # QR encode→decode via jsQR (all versions, EC, masks)
@@ -139,8 +139,10 @@ family including the stacked variants. A composite symbol assembles over every
 primary of ISO/IEC 24723 — EAN/UPC, GS1-128 and the seven DataBar variants —
 and only a GS1-128 can carry a CC-C component, whose width sets its columns.
 
-Sequences: `encodeQRSequence()` (Structured Append), `encodePDF417Sequence()`
-(Macro PDF417).
+Sequences: `encodeQRSequence()`, `encodeDataMatrixSequence()` and
+`encodeMaxiCodeSequence()` (Structured Append), `encodePDF417Sequence()`
+(Macro PDF417). Data Matrix and MaxiCode also take a `structuredAppend` option
+for placing one symbol of a sequence by hand.
 
 Batch: `barcodes()`, `qrcodes()`, `barcodeSheet()`, `qrcodeSheet()`.
 
@@ -236,7 +238,7 @@ is known and turns red the moment it is fixed.
 
 v1. The full gate (`pnpm test`) is green:
 
-- **133 test files, 3300+ tests** passing
+- **134 test files, 3400+ tests** passing
 - **Zero** lint warnings, zero typecheck errors
 - **96.7%** statements, **92.9%** branches — thresholds enforced in CI by
   `vitest.config.ts`

--- a/docs/2d-codes/datamatrix.md
+++ b/docs/2d-codes/datamatrix.md
@@ -114,6 +114,30 @@ encodeDataMatrix("日本語") // UTF-8 bytes under ECI 26, automatically
 encodeDataMatrix("Grüße", { eci: 3 })
 ```
 
+## Structured Append
+
+A message too long for one symbol goes across up to sixteen, which a reader
+puts back together in order.
+
+```ts
+import { encodeDataMatrixSequence, encodeDataMatrix } from "etiket"
+
+const symbols = encodeDataMatrixSequence(longText, { symbols: 3 })
+symbols.length // 3
+
+// Or place one symbol of a sequence by hand
+encodeDataMatrix(part, { structuredAppend: { index: 2, total: 3, fileId: [17, 42] } })
+```
+
+Each symbol opens with four codewords — a marker, its position and the count,
+and a two byte file identifier that tells one sequence from another — so a
+sequence holds a little less than the sum of its parts. `fileId` defaults to
+`[1, 1]`; give the same one to every symbol of a sequence and a different one
+to sequences that might be scanned together.
+
+With no `symbols` count the encoder takes the fewest that hold the message, and
+never fewer than two: a sequence of one is not something the standard allows.
+
 ## GS1 DataMatrix
 
 `gs1datamatrix()` takes a parenthesised Application Identifier string and emits

--- a/docs/2d-codes/maxicode.md
+++ b/docs/2d-codes/maxicode.md
@@ -113,6 +113,24 @@ maxicode("PACKAGE", {
 
 `countryCode` and `serviceClass` must each be an integer 0–999.
 
+## Structured Append
+
+Every MaxiCode symbol is the same fixed size whatever it holds, so a message
+longer than one takes has to go across several — up to eight.
+
+```ts
+import { encodeMaxiCodeSequence, encodeMaxiCode } from "etiket"
+
+const symbols = encodeMaxiCodeSequence(longText, { symbols: 3 })
+
+// Or place one symbol of a sequence by hand
+encodeMaxiCode(part, { mode: 4, structuredAppend: { index: 2, total: 3 } })
+```
+
+Each symbol opens with two codewords: a pad and one holding the position and
+the count. With no `symbols` count the encoder takes the fewest that hold the
+message, and never fewer than two.
+
 ## PNG
 
 ```ts

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -701,26 +701,28 @@ or `"numeric"` (2 bars per digit).
 
 ### 2D
 
-| Function                               | Returns                                     |
-| :------------------------------------- | :------------------------------------------ |
-| `encodeQR(text, options?)`             | `boolean[][]`                               |
-| `encodeQRSequence(text, options?)`     | `boolean[][][]`                             |
-| `encodeMicroQR(text, options?)`        | `boolean[][]`                               |
-| `encodeRMQR(text, options?)`           | `boolean[][]`                               |
-| `encodeDataMatrix(text, options?)`     | `boolean[][]`                               |
-| `encodeGS1DataMatrix(text, options?)`  | `boolean[][]`                               |
-| `encodePDF417(text, options?)`         | `{ matrix, rows, cols }`                    |
-| `encodePDF417Sequence(text, options?)` | `{ matrix, rows, cols }[]` — Macro PDF417   |
-| `encodeMicroPDF417(text, options?)`    | `{ matrix, rows, cols }`                    |
-| `encodeAztec(text, options?)`          | `boolean[][]`                               |
-| `encodeAztecRune(value)`               | `boolean[][]` — 11x11, a byte 0 to 255      |
-| `encodeMailmark(text, options?)`       | `boolean[][]` — a Data Matrix of fixed size |
-| `encodeMaxiCode(text, options?)`       | `boolean[][]` — 33×30                       |
-| `encodeDotCode(text, options?)`        | `boolean[][]`                               |
-| `encodeHanXin(text, options?)`         | `boolean[][]`                               |
-| `encodeCodablockF(text, options?)`     | `{ matrix, rows, cols, separatorRows }`     |
-| `encodeCode16K(text)`                  | `{ matrix, rows, cols, separatorRows }`     |
-| `encodeJABCode(text, options?)`        | `JABCodeResult`                             |
+| Function                                | Returns                                     |
+| :-------------------------------------- | :------------------------------------------ |
+| `encodeQR(text, options?)`              | `boolean[][]`                               |
+| `encodeQRSequence(text, options?)`      | `boolean[][][]`                             |
+| `encodeMicroQR(text, options?)`         | `boolean[][]`                               |
+| `encodeRMQR(text, options?)`            | `boolean[][]`                               |
+| `encodeDataMatrix(text, options?)`      | `boolean[][]`                               |
+| `encodeDataMatrixSequence(text, opts?)` | `boolean[][][]` — Structured Append         |
+| `encodeGS1DataMatrix(text, options?)`   | `boolean[][]`                               |
+| `encodePDF417(text, options?)`          | `{ matrix, rows, cols }`                    |
+| `encodePDF417Sequence(text, options?)`  | `{ matrix, rows, cols }[]` — Macro PDF417   |
+| `encodeMicroPDF417(text, options?)`     | `{ matrix, rows, cols }`                    |
+| `encodeAztec(text, options?)`           | `boolean[][]`                               |
+| `encodeAztecRune(value)`                | `boolean[][]` — 11x11, a byte 0 to 255      |
+| `encodeMailmark(text, options?)`        | `boolean[][]` — a Data Matrix of fixed size |
+| `encodeMaxiCode(text, options?)`        | `boolean[][]` — 33×30                       |
+| `encodeMaxiCodeSequence(text, opts?)`   | `boolean[][][]` — Structured Append         |
+| `encodeDotCode(text, options?)`         | `boolean[][]`                               |
+| `encodeHanXin(text, options?)`          | `boolean[][]`                               |
+| `encodeCodablockF(text, options?)`      | `{ matrix, rows, cols, separatorRows }`     |
+| `encodeCode16K(text)`                   | `{ matrix, rows, cols, separatorRows }`     |
+| `encodeJABCode(text, options?)`         | `JABCodeResult`                             |
 
 ```ts
 import {
@@ -729,6 +731,7 @@ import {
   encodeMicroQR,
   encodeRMQR,
   encodeDataMatrix,
+  encodeDataMatrixSequence,
   encodeGS1DataMatrix,
   encodePDF417,
   encodePDF417Sequence,
@@ -737,6 +740,7 @@ import {
   encodeAztecRune,
   encodeMailmark,
   encodeMaxiCode,
+  encodeMaxiCodeSequence,
   encodeDotCode,
   encodeHanXin,
   encodeCodablockF,
@@ -749,6 +753,7 @@ encodeQRSequence("A".repeat(200), { symbols: 3 }).length // 3
 encodeMicroQR("12345", { version: 2, ecLevel: "L" })
 encodeRMQR("Hello", { ecLevel: "M" })
 encodeDataMatrix("Hello", { shape: "auto", dmre: true })
+encodeDataMatrixSequence("A".repeat(200), { symbols: 3 }).length // 3
 encodeGS1DataMatrix("(01)09501101020917")
 encodePDF417("Hello", { columns: 4 }).rows
 encodePDF417Sequence("A".repeat(3000), { symbols: 3 }).length // 3
@@ -757,6 +762,7 @@ encodeAztec("Hello", { ecPercent: 33 })
 encodeAztecRune(42)
 encodeMailmark("JGB 012100123456789AB19XY1A 0                ", { type: 9 })
 encodeMaxiCode("Hello", { mode: 4 }).length // 33
+encodeMaxiCodeSequence("A".repeat(200), { symbols: 3 }).length // 3
 encodeDotCode("Hello")
 encodeHanXin("Hello", { ecLevel: 2 })
 

--- a/docs/getting-started/typescript.md
+++ b/docs/getting-started/typescript.md
@@ -202,27 +202,32 @@ barcode("12345", { unit: print, moduleSize: 0.33, height: 25 })
 
 ### 2D encoders
 
-| Type                       | Fields                                                                |
-| :------------------------- | :-------------------------------------------------------------------- |
-| `DataMatrixShape`          | `"square" \| "rectangle" \| "auto"`                                   |
-| `DataMatrixSizeOptions`    | `shape`, `dmre`, `symbolSize`                                         |
-| `DataMatrixSymbolSize`     | One row of the size table: rows, cols, data regions, codewords        |
-| `PDF417Options`            | `ecLevel`, `columns`, `compact`, `eci`, `macro`, `readerInit`         |
-| `MicroPDF417Options`       | `columns` (1–4)                                                       |
-| `AztecOptions`             | `ecPercent`, `layers`, `compact`, `eci`                               |
-| `MaxiCodeOptions`          | `mode` (2–6), `postalCode`, `countryCode`, `serviceClass`             |
-| `DotCodeOptions`           | `rows`, `columns`, `mask`                                             |
-| `HanXinOptions`            | `ecLevel` (1–4), `version` (1–84), `mask` (1–4)                       |
-| `JABCodeOptions`           | `colors` (4 or 8), `ecPercent`                                        |
-| `JABCodeResult`            | `matrix` of palette indices, `rows`, `cols`, `palette`                |
-| `CompositeType`            | `"CC-A" \| "CC-B" \| "CC-C"`                                          |
-| `CompositeLinearType`      | The linear symbology a composite component sits above                 |
-| `GS1CompositeOptions`      | `type`, `columns`, `linear`, `linearWidth`                            |
-| `GS1CompositeResult`       | `composite`, `type`, `rows`, `cols`, `columns`                        |
-| `GS1CompositeSymbolResult` | The complete symbol: `matrix`, `rowHeights`, `linear`, `separator`, … |
-| `PDF417MacroOptions`       | One symbol's Macro PDF417 control block                               |
-| `PDF417SharedMacroOptions` | The macro fields that stay the same across a sequence                 |
-| `PDF417SequenceOptions`    | `PDF417Options` without `macro`, plus `symbols` and `fileId`          |
+| Type                         | Fields                                                                        |
+| :--------------------------- | :---------------------------------------------------------------------------- |
+| `DataMatrixShape`            | `"square" \| "rectangle" \| "auto"`                                           |
+| `DataMatrixSizeOptions`      | `shape`, `dmre`, `symbolSize`                                                 |
+| `DataMatrixEncodeOptions`    | `eci`, `structuredAppend`                                                     |
+| `DataMatrixStructuredAppend` | `index` (from 1), `total` (2–16), `fileId`                                    |
+| `DataMatrixSequenceOptions`  | The size and encode options, plus `symbols` and `fileId`                      |
+| `DataMatrixSymbolSize`       | One row of the size table: rows, cols, data regions, codewords                |
+| `PDF417Options`              | `ecLevel`, `columns`, `compact`, `eci`, `macro`, `readerInit`                 |
+| `MicroPDF417Options`         | `columns` (1–4)                                                               |
+| `AztecOptions`               | `ecPercent`, `layers`, `compact`, `eci`                                       |
+| `MaxiCodeOptions`            | `mode` (2–6), `postalCode`, `countryCode`, `serviceClass`, `structuredAppend` |
+| `MaxiCodeStructuredAppend`   | `index` (from 1), `total` (2–8)                                               |
+| `MaxiCodeSequenceOptions`    | `MaxiCodeOptions` without `structuredAppend`, plus `symbols`                  |
+| `DotCodeOptions`             | `rows`, `columns`, `mask`                                                     |
+| `HanXinOptions`              | `ecLevel` (1–4), `version` (1–84), `mask` (1–4)                               |
+| `JABCodeOptions`             | `colors` (4 or 8), `ecPercent`                                                |
+| `JABCodeResult`              | `matrix` of palette indices, `rows`, `cols`, `palette`                        |
+| `CompositeType`              | `"CC-A" \| "CC-B" \| "CC-C"`                                                  |
+| `CompositeLinearType`        | The linear symbology a composite component sits above                         |
+| `GS1CompositeOptions`        | `type`, `columns`, `linear`, `linearWidth`                                    |
+| `GS1CompositeResult`         | `composite`, `type`, `rows`, `cols`, `columns`                                |
+| `GS1CompositeSymbolResult`   | The complete symbol: `matrix`, `rowHeights`, `linear`, `separator`, …         |
+| `PDF417MacroOptions`         | One symbol's Macro PDF417 control block                                       |
+| `PDF417SharedMacroOptions`   | The macro fields that stay the same across a sequence                         |
+| `PDF417SequenceOptions`      | `PDF417Options` without `macro`, plus `symbols` and `fileId`                  |
 
 ```ts
 import type {

--- a/src/encoders/datamatrix/encoder.ts
+++ b/src/encoders/datamatrix/encoder.ts
@@ -426,6 +426,25 @@ export function encodeECI(eci: number): number[] {
   ]
 }
 
+/**
+ * One symbol's place in a Structured Append sequence.
+ *
+ * ISO/IEC 16022 5.6 splits a message across up to sixteen symbols. Each carries
+ * its position, how many there are in all, and a file identifier the reader
+ * uses to tell one sequence from another.
+ */
+export interface DataMatrixStructuredAppend {
+  /** Position of this symbol, from 1. */
+  index: number
+  /** Symbols in the sequence, 2 to 16. */
+  total: number
+  /**
+   * File identifier, shared by every symbol of the sequence. Two values of
+   * 1 to 254; defaults to `[1, 1]`.
+   */
+  fileId?: readonly [number, number]
+}
+
 export interface DataMatrixEncodeOptions {
   /**
    * ECI assignment number declaring the character set.
@@ -433,6 +452,35 @@ export interface DataMatrixEncodeOptions {
    * contains a character Latin-1 cannot represent.
    */
   eci?: number
+  /** Place of this symbol in a Structured Append sequence. */
+  structuredAppend?: DataMatrixStructuredAppend
+}
+
+/** The four codewords that open a symbol belonging to a sequence. */
+function encodeStructuredAppend(header: DataMatrixStructuredAppend): number[] {
+  const { index, total, fileId = [1, 1] } = header
+  if (!Number.isInteger(total) || total < 2 || total > 16) {
+    throw new InvalidInputError(
+      `Data Matrix Structured Append holds 2 to 16 symbols, got ${String(total)}`,
+    )
+  }
+  if (!Number.isInteger(index) || index < 1 || index > total) {
+    throw new InvalidInputError(
+      `Data Matrix Structured Append symbol ${String(index)} is outside a sequence of ${total}`,
+    )
+  }
+  for (const value of fileId) {
+    if (!Number.isInteger(value) || value < 1 || value > 254) {
+      throw new InvalidInputError(
+        `Data Matrix Structured Append file identifier values run from 1 to 254, got ${String(value)}`,
+      )
+    }
+  }
+  // Codeword 233 has to be the first in the symbol. The one after it holds the
+  // position in its high nibble, counting from zero, and the number of symbols
+  // in the low one — counting *down*, so a sequence of two is 15 and one of
+  // sixteen is 1. Then the file identifier.
+  return [233, ((index - 1) << 4) | (17 - total), fileId[0], fileId[1]]
 }
 
 /**
@@ -454,10 +502,14 @@ export function encodeCandidates(
     encode: (capacity) => (codewords.length <= capacity ? codewords : undefined),
   })
 
+  // Codeword 233 has to come first in the symbol, so a sequence header goes in
+  // front of everything, an ECI declaration after it
+  const sequence = options.structuredAppend ? encodeStructuredAppend(options.structuredAppend) : []
+
   // Anything Latin-1 cannot hold goes out as UTF-8 bytes under an ECI
   // declaration, in Base 256 so no byte is reinterpreted.
   if ([...text].some((ch) => ch.codePointAt(0)! > 0xff)) {
-    const eci = encodeECI(options.eci ?? 26)
+    const eci = [...sequence, ...encodeECI(options.eci ?? 26)]
     return [fixed([...eci, ...encodeBase256(new TextEncoder().encode(text), eci.length + 1)])]
   }
 
@@ -471,10 +523,10 @@ export function encodeCandidates(
   const edifact = edifactCandidate(text)
   if (edifact) candidates.push(edifact)
 
-  const prefix = options.eci === undefined ? [] : encodeECI(options.eci)
+  const prefix = [...sequence, ...(options.eci === undefined ? [] : encodeECI(options.eci))]
 
-  // An ECI declaration goes in front of the message and takes symbol capacity
-  // from it, so the mode is asked what it would do with what is left
+  // What goes in front of the message takes symbol capacity from it, so the
+  // mode is asked what it would do with what is left
   const withPrefix =
     prefix.length === 0
       ? candidates

--- a/src/encoders/datamatrix/index.ts
+++ b/src/encoders/datamatrix/index.ts
@@ -44,10 +44,11 @@ export function encodeDataMatrix(
 
   // Steps 1 and 2: encode the text every way the standard allows and take the
   // one that reaches the smallest symbol
-  const chosen = smallestSymbol(encodeCandidates(text, { eci: options.eci }), options)
+  const encoding = { eci: options.eci, structuredAppend: options.structuredAppend }
+  const chosen = smallestSymbol(encodeCandidates(text, encoding), options)
   if (!chosen) {
     throw new CapacityError(
-      capacityMessage("Data Matrix", encodeAuto(text, { eci: options.eci }).length, options),
+      capacityMessage("Data Matrix", encodeAuto(text, encoding).length, options),
     )
   }
   const { codewords: dataCodewords, symbol } = chosen
@@ -162,4 +163,100 @@ function capacityMessage(label: string, needed: number, options: DataMatrixSizeO
   const shape = options.shape ?? "square"
   const limit = maxCapacity(options)
   return `Data too long for ${label}: ${needed} codewords needed, maximum is ${limit} for ${shape} symbols${options.dmre ? " (DMRE enabled)" : ""}`
+}
+
+export interface DataMatrixSequenceOptions
+  extends DataMatrixSizeOptions, Omit<DataMatrixEncodeOptions, "structuredAppend"> {
+  /**
+   * How many symbols to split the message into (2-16).
+   * Omit to use the fewest that hold the data.
+   */
+  symbols?: number
+  /**
+   * File identifier shared by the sequence, so a reader can tell one sequence
+   * from another. Two values of 1 to 254; defaults to `[1, 1]`.
+   */
+  fileId?: readonly [number, number]
+}
+
+/**
+ * Encode text as a Structured Append sequence: a set of Data Matrix symbols a
+ * reader reassembles into the original message.
+ *
+ * Each symbol opens with codeword 233, its position, the number of symbols and
+ * the shared file identifier — four codewords ISO/IEC 16022 5.6 takes out of
+ * every symbol's capacity, which is why a sequence holds less than the sum of
+ * its parts.
+ *
+ * @example
+ * ```ts
+ * const symbols = encodeDataMatrixSequence(longText, { symbols: 3 })
+ * // symbols[0], symbols[1], symbols[2] scan back as one message
+ * ```
+ */
+export function encodeDataMatrixSequence(
+  text: string,
+  options: DataMatrixSequenceOptions = {},
+): boolean[][][] {
+  if (text.length === 0) {
+    throw new InvalidInputError("Data Matrix input must not be empty")
+  }
+  const { symbols: requested, fileId, ...symbolOptions } = options
+  if (requested !== undefined && (requested < 2 || requested > 16)) {
+    throw new InvalidInputError(
+      `A Data Matrix Structured Append sequence holds 2 to 16 symbols, got ${requested}`,
+    )
+  }
+
+  const chars = [...text]
+  for (let total = requested ?? 2; total <= (requested ?? 16); total++) {
+    const chunks = splitEvenly(chars, total)
+    if (chunks.length !== total) continue
+
+    const sequence = trySequence(chunks, total, fileId, symbolOptions)
+    if (sequence) return sequence
+    if (requested !== undefined) {
+      throw new CapacityError(
+        `Data does not fit in ${total} Data Matrix symbol${total === 1 ? "" : "s"}`,
+      )
+    }
+  }
+
+  throw new CapacityError(
+    "Data does not fit in a Structured Append sequence of 16 Data Matrix symbols",
+  )
+}
+
+/** Encode every chunk, or return undefined if any of them overflows. */
+function trySequence(
+  chunks: string[],
+  total: number,
+  fileId: readonly [number, number] | undefined,
+  options: DataMatrixSizeOptions & DataMatrixEncodeOptions,
+): boolean[][][] | undefined {
+  const symbols: boolean[][][] = []
+  for (const [index, chunk] of chunks.entries()) {
+    try {
+      symbols.push(
+        encodeDataMatrix(chunk, {
+          ...options,
+          structuredAppend: { index: index + 1, total, fileId },
+        }),
+      )
+    } catch (error) {
+      if (error instanceof CapacityError) return undefined
+      throw error
+    }
+  }
+  return symbols
+}
+
+/** Split code points into `count` chunks of as equal a size as possible. */
+function splitEvenly(chars: string[], count: number): string[] {
+  const chunks: string[] = []
+  const size = Math.ceil(chars.length / count)
+  for (let i = 0; i < chars.length; i += size) {
+    chunks.push(chars.slice(i, i + size).join(""))
+  }
+  return chunks
 }

--- a/src/encoders/maxicode.ts
+++ b/src/encoders/maxicode.ts
@@ -658,15 +658,51 @@ const FINDER_DARK: number[] = [
 // Public API
 // ---------------------------------------------------------------------------
 
+/**
+ * One symbol's place in a Structured Append sequence.
+ *
+ * ISO/IEC 16023 5.5 splits a message across up to eight symbols, each opening
+ * with a pad codeword and one that holds the position and the count.
+ */
+export interface MaxiCodeStructuredAppend {
+  /** Position of this symbol, from 1. */
+  index: number
+  /** Symbols in the sequence, 2 to 8. */
+  total: number
+}
+
 export interface MaxiCodeOptions {
   /** Encoding mode: 2 (US structured), 3 (intl structured), 4 (standard), 5 (full ECC), 6 (reader programming) */
   mode?: 2 | 3 | 4 | 5 | 6
+  /** Place of this symbol in a Structured Append sequence. */
+  structuredAppend?: MaxiCodeStructuredAppend
   /** Postal code (modes 2/3) */
   postalCode?: string
   /** ISO country code number (modes 2/3) */
   countryCode?: number
   /** Service class (modes 2/3, e.g. 840 for UPS) */
   serviceClass?: number
+}
+
+/**
+ * The two codewords that open a symbol belonging to a sequence.
+ *
+ * A pad, then one codeword holding the position in its high three bits and the
+ * count in its low three, both counting from zero (ISO/IEC 16023 5.5).
+ */
+function structuredAppendCodewords(header: MaxiCodeStructuredAppend): number[] {
+  const { index, total } = header
+  if (!Number.isInteger(total) || total < 2 || total > 8) {
+    throw new InvalidInputError(
+      `MaxiCode Structured Append holds 2 to 8 symbols, got ${String(total)}`,
+    )
+  }
+  if (!Number.isInteger(index) || index < 1 || index > total) {
+    throw new InvalidInputError(
+      `MaxiCode Structured Append symbol ${String(index)} is outside a sequence of ${total}`,
+    )
+  }
+  return [symbolOf(SET_A, PAD), (index - 1) * 8 + (total - 1)]
 }
 
 /**
@@ -684,7 +720,9 @@ export function encodeMaxiCode(text: string, options: MaxiCodeOptions = {}): boo
   }
 
   const message = encodeMaxiCodeText(text)
-  let body = message.codewords
+  let body = options.structuredAppend
+    ? [...structuredAppendCodewords(options.structuredAppend), ...message.codewords]
+    : message.codewords
   let padValue = PAD_CODES[message.set]!
 
   // Secondary message length: 68 codewords for mode 5 (enhanced ECC), else 84
@@ -787,4 +825,72 @@ export function encodeMaxiCode(text: string, options: MaxiCodeOptions = {}): boo
   )
 
   return matrix
+}
+
+export interface MaxiCodeSequenceOptions extends Omit<MaxiCodeOptions, "structuredAppend"> {
+  /**
+   * How many symbols to split the message into (2-8).
+   * Omit to use the fewest that hold the data.
+   */
+  symbols?: number
+}
+
+/**
+ * Encode text as a Structured Append sequence: a set of MaxiCode symbols a
+ * reader reassembles into the original message.
+ *
+ * Every symbol is the same fixed size whatever it holds, so a message longer
+ * than one takes has nowhere else to go. Each opens with a pad codeword and one
+ * that holds its position and the count, two codewords ISO/IEC 16023 5.5 takes
+ * out of every symbol.
+ *
+ * @example
+ * ```ts
+ * const symbols = encodeMaxiCodeSequence(longText, { symbols: 3 })
+ * ```
+ */
+export function encodeMaxiCodeSequence(
+  text: string,
+  options: MaxiCodeSequenceOptions = {},
+): boolean[][][] {
+  if (text.length === 0) {
+    throw new InvalidInputError("MaxiCode input must not be empty")
+  }
+  const { symbols: requested, ...symbolOptions } = options
+  if (requested !== undefined && (requested < 2 || requested > 8)) {
+    throw new InvalidInputError(
+      `A MaxiCode Structured Append sequence holds 2 to 8 symbols, got ${requested}`,
+    )
+  }
+
+  const chars = [...text]
+  for (let total = requested ?? 2; total <= (requested ?? 8); total++) {
+    const size = Math.ceil(chars.length / total)
+    const chunks: string[] = []
+    for (let i = 0; i < chars.length; i += size) chunks.push(chars.slice(i, i + size).join(""))
+    if (chunks.length !== total) continue
+
+    const symbols: boolean[][][] = []
+    let overflowed = false
+    for (const [index, chunk] of chunks.entries()) {
+      try {
+        symbols.push(
+          encodeMaxiCode(chunk, {
+            ...symbolOptions,
+            structuredAppend: { index: index + 1, total },
+          }),
+        )
+      } catch (error) {
+        if (!(error instanceof CapacityError)) throw error
+        overflowed = true
+        break
+      }
+    }
+    if (!overflowed) return symbols
+    if (requested !== undefined) {
+      throw new CapacityError(`Data does not fit in ${total} MaxiCode symbols`)
+    }
+  }
+
+  throw new CapacityError("Data does not fit in a Structured Append sequence of 8 MaxiCode symbols")
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,8 +132,12 @@ export type { FourState } from "./encoders/fourstate"
 export { encodeIMb } from "./encoders/imb"
 export { encodeCodablockF } from "./encoders/codablock-f"
 export { encodeCode16K } from "./encoders/code16k"
-export { encodeMaxiCode } from "./encoders/maxicode"
-export type { MaxiCodeOptions } from "./encoders/maxicode"
+export { encodeMaxiCode, encodeMaxiCodeSequence } from "./encoders/maxicode"
+export type {
+  MaxiCodeOptions,
+  MaxiCodeSequenceOptions,
+  MaxiCodeStructuredAppend,
+} from "./encoders/maxicode"
 export { encodeRMQR } from "./encoders/rmqr"
 export type { RMQROptions } from "./encoders/rmqr"
 export { encodeDotCode } from "./encoders/dotcode"
@@ -142,7 +146,16 @@ export { encodeHanXin } from "./encoders/hanxin"
 export type { HanXinOptions } from "./encoders/hanxin"
 export { encodeJABCode, JAB_COLORS_4, JAB_COLORS_8 } from "./encoders/jabcode"
 export type { JABCodeOptions, JABCodeResult } from "./encoders/jabcode"
-export { encodeDataMatrix, encodeGS1DataMatrix } from "./encoders/datamatrix/index"
+export {
+  encodeDataMatrix,
+  encodeDataMatrixSequence,
+  encodeGS1DataMatrix,
+} from "./encoders/datamatrix/index"
+export type { DataMatrixSequenceOptions } from "./encoders/datamatrix/index"
+export type {
+  DataMatrixEncodeOptions,
+  DataMatrixStructuredAppend,
+} from "./encoders/datamatrix/encoder"
 export type {
   DataMatrixShape,
   DataMatrixSizeOptions,

--- a/test/encoders-structured-append.test.ts
+++ b/test/encoders-structured-append.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Structured Append for Data Matrix and MaxiCode.
+ *
+ * QR and PDF417 could already split a message across symbols a reader puts
+ * back together; Data Matrix and MaxiCode define the same thing and etiket did
+ * not offer it.
+ *
+ * Data Matrix opens each symbol with codeword 233, then its position in the
+ * high nibble of the next codeword and the number of symbols in the low one —
+ * counting *down*, so a sequence of two is 15 and one of sixteen is 1 — then
+ * two file identifier codewords (ISO/IEC 16022 5.6). zxing reports all three
+ * back, so it verifies itself.
+ *
+ * MaxiCode opens with a pad codeword and one holding the position in its top
+ * three bits and the count in its bottom three (ISO/IEC 16023 5.5). No decoder
+ * reports that, so BWIPP is the oracle: it takes the same thing through its
+ * `sam` option.
+ */
+
+import { describe, expect, it } from "vitest"
+import { readBarcodes } from "zxing-wasm/reader"
+import {
+  encodeDataMatrix,
+  encodeDataMatrixSequence,
+  encodeMaxiCode,
+  encodeMaxiCodeSequence,
+  CapacityError,
+  InvalidInputError,
+} from "../src/index"
+import { bwipMaxiCode } from "./_bwip"
+
+/** BWIPP draws the MaxiCode bullseye as rings rather than hexagons. */
+const BULLSEYE = new Set([
+  343, 344, 372, 376, 400, 403, 404, 407, 430, 432, 436, 438, 461, 463, 464, 466, 490, 493, 495,
+  498, 521, 523, 524, 526, 550, 552, 556, 558, 580, 583, 584, 587, 612, 616, 643, 644,
+])
+
+function differences(mine: boolean[][], theirs: boolean[][]): string[] {
+  const out: string[] = []
+  for (let r = 0; r < 33; r++) {
+    for (let c = 0; c < 30; c++) {
+      if (BULLSEYE.has(r * 30 + c)) continue
+      if (mine[r]![c] !== theirs[r]![c]) out.push(`${r},${c}`)
+    }
+  }
+  return out
+}
+
+interface Read {
+  text?: string
+  sequenceIndex?: number
+  sequenceSize?: number
+  sequenceId?: string
+}
+
+async function read(matrix: boolean[][]): Promise<Read | undefined> {
+  const scale = 6
+  const margin = 5
+  const rows = matrix.length
+  const cols = matrix[0]!.length
+  const width = (cols + margin * 2) * scale
+  const height = (rows + margin * 2) * scale
+  const data = new Uint8ClampedArray(width * height * 4)
+  data.fill(255)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const r = Math.floor(y / scale) - margin
+      const c = Math.floor(x / scale) - margin
+      if (r >= 0 && r < rows && c >= 0 && c < cols && matrix[r]![c]) {
+        const i = (y * width + x) * 4
+        data[i] = 0
+        data[i + 1] = 0
+        data[i + 2] = 0
+      }
+    }
+  }
+  const results = await readBarcodes({ data, width, height } as ImageData, {
+    tryHarder: true,
+    formats: ["DataMatrix"],
+  })
+  return results[0] as Read | undefined
+}
+
+describe("Data Matrix Structured Append", () => {
+  it.each([2, 3, 4, 8, 16])("splits a message across %i symbols", async (total) => {
+    const text = "ABCDEFGHIJ0123456789".repeat(4)
+    const symbols = encodeDataMatrixSequence(text, { symbols: total })
+    expect(symbols).toHaveLength(total)
+
+    let rebuilt = ""
+    for (const [index, matrix] of symbols.entries()) {
+      const result = await read(matrix)
+      expect(result?.sequenceIndex, `symbol ${index}`).toBe(index)
+      expect(result?.sequenceSize, `symbol ${index}`).toBe(total)
+      expect(result?.sequenceId, `symbol ${index}`).toBe("257")
+      rebuilt += result?.text ?? ""
+    }
+    expect(rebuilt).toBe(text)
+  })
+
+  it("gives every symbol of a sequence the same file identifier", async () => {
+    const symbols = encodeDataMatrixSequence("HELLO WORLD AND EVERYONE", {
+      symbols: 2,
+      fileId: [17, 42],
+    })
+    for (const matrix of symbols) {
+      // The identifier is reported as the two bytes read as one number
+      expect((await read(matrix))?.sequenceId).toBe(String(17 * 256 + 42))
+    }
+  })
+
+  it("takes the fewest symbols that hold the message when none is asked for", () => {
+    expect(encodeDataMatrixSequence("SHORT")).toHaveLength(2)
+    expect(encodeDataMatrixSequence("A".repeat(8000)).length).toBeGreaterThan(2)
+  })
+
+  it("costs four codewords a symbol, which the size shows", () => {
+    const text = "0123456789012345678901234567890123456789"
+    const alone = encodeDataMatrix(text)
+    const [first] = encodeDataMatrixSequence(text, { symbols: 2 })
+    // Half the message plus a four codeword header is not half the symbol
+    expect(first!.length).toBeGreaterThan(alone.length / 2)
+  })
+
+  it("refuses a sequence it cannot make", () => {
+    expect(() => encodeDataMatrixSequence("", { symbols: 2 })).toThrow(InvalidInputError)
+    expect(() => encodeDataMatrixSequence("A", { symbols: 1 })).toThrow(/2 to 16/)
+    expect(() => encodeDataMatrixSequence("A", { symbols: 17 })).toThrow(/2 to 16/)
+    expect(() =>
+      encodeDataMatrixSequence("A".repeat(400), { symbols: 2, symbolSize: "16x16" }),
+    ).toThrow(CapacityError)
+  })
+
+  it("refuses a header that is not a place in a sequence", () => {
+    expect(() => encodeDataMatrix("A", { structuredAppend: { index: 1, total: 1 } })).toThrow(
+      /2 to 16/,
+    )
+    expect(() => encodeDataMatrix("A", { structuredAppend: { index: 3, total: 2 } })).toThrow(
+      /outside a sequence/,
+    )
+    expect(() =>
+      encodeDataMatrix("A", { structuredAppend: { index: 1, total: 2, fileId: [0, 1] } }),
+    ).toThrow(/1 to 254/)
+    expect(() =>
+      encodeDataMatrix("A", { structuredAppend: { index: 1, total: 2, fileId: [1, 255] } }),
+    ).toThrow(/1 to 254/)
+  })
+})
+
+describe("MaxiCode Structured Append", () => {
+  it.each([
+    [1, 2],
+    [2, 2],
+    [1, 3],
+    [3, 3],
+    [4, 6],
+    [1, 8],
+    [8, 8],
+  ])("matches BWIPP for symbol %i of %i", (index, total) => {
+    for (const text of ["TEST", "HELLO WORLD", "abc123"]) {
+      const mine = encodeMaxiCode(text, { mode: 4, structuredAppend: { index, total } })
+      const theirs = bwipMaxiCode(text, { mode: 4, sam: `${index}${total}` })
+      expect(differences(mine, theirs), `${index} of ${total} ${text}`).toEqual([])
+    }
+  })
+
+  it("splits a message across symbols", () => {
+    const text = "ABCDEFGHIJ".repeat(20)
+    const symbols = encodeMaxiCodeSequence(text, { symbols: 3 })
+    expect(symbols).toHaveLength(3)
+    for (const matrix of symbols) expect(matrix).toHaveLength(33)
+  })
+
+  it("takes the fewest symbols that hold the message when none is asked for", () => {
+    expect(encodeMaxiCodeSequence("SHORT")).toHaveLength(2)
+    expect(encodeMaxiCodeSequence("A".repeat(200)).length).toBeGreaterThan(2)
+  })
+
+  it("refuses a sequence it cannot make", () => {
+    expect(() => encodeMaxiCodeSequence("", { symbols: 2 })).toThrow(InvalidInputError)
+    expect(() => encodeMaxiCodeSequence("A", { symbols: 1 })).toThrow(/2 to 8/)
+    expect(() => encodeMaxiCodeSequence("A", { symbols: 9 })).toThrow(/2 to 8/)
+    expect(() => encodeMaxiCodeSequence("A".repeat(2000))).toThrow(CapacityError)
+  })
+
+  it("refuses a header that is not a place in a sequence", () => {
+    expect(() => encodeMaxiCode("A", { structuredAppend: { index: 1, total: 1 } })).toThrow(
+      /2 to 8/,
+    )
+    expect(() => encodeMaxiCode("A", { structuredAppend: { index: 9, total: 8 } })).toThrow(
+      /outside a sequence/,
+    )
+  })
+})


### PR DESCRIPTION
QR and PDF417 could already split a message across symbols a reader puts back together. Data Matrix and MaxiCode define the same thing, and etiket did not offer it.

```ts
const symbols = encodeDataMatrixSequence(longText, { symbols: 3 })
const parts   = encodeMaxiCodeSequence(longText, { symbols: 3 })

// or place one symbol of a sequence by hand
encodeDataMatrix(part, { structuredAppend: { index: 2, total: 3, fileId: [17, 42] } })
encodeMaxiCode(part, { mode: 4, structuredAppend: { index: 2, total: 3 } })
```

## The headers

**Data Matrix** opens each symbol with codeword 233, then its position in the high nibble of the next codeword and the number of symbols in the low one — counting *down*, so a sequence of two is 15 and one of sixteen is 1 — then two file identifier codewords (ISO/IEC 16022 §5.6). Four codewords out of every symbol, which is why a sequence holds less than the sum of its parts.

**MaxiCode** opens with a pad codeword and one holding the position in its top three bits and the count in its bottom three (ISO/IEC 16023 §5.5). Every MaxiCode symbol is the same fixed size whatever it holds, so a message longer than one takes has nowhere else to go.

## Verification

Both against something that is not this encoder.

zxing reports the Data Matrix position, count and file identifier straight back, so the sequences check themselves — two through sixteen symbols, each reporting its own place and the parts reassembling into the message.

No decoder reports MaxiCode's, so BWIPP is the oracle: it takes the same header through its `sam` option and agrees module for module over seven positions and three payloads.

## Left out

Aztec's Structured Append. It is a text prefix rather than a codeword, BWIPP has no option for it, and zxing did not recognise the prefix on its own — nothing available can verify it, which is the bar this project holds encoders to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)