### PR TITLE
feat(datamatrix): change mode part way through the message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ src/
     barcode.ts              # Per-format validation
     qr.ts                   # QR validation with metadata
 test/
-  *.test.ts                 # 135 test files, 3400+ tests
+  *.test.ts                 # 136 test files, 3400+ tests
   _bwip.ts                  # bwip-js (BWIPP) oracle: module data extraction
   bwip-compare.test.ts      # Module-for-module comparison against BWIPP
   qr-roundtrip.test.ts      # QR encode→decode via jsQR (all versions, EC, masks)
@@ -238,7 +238,7 @@ is known and turns red the moment it is fixed.
 
 v1. The full gate (`pnpm test`) is green:
 
-- **135 test files, 3400+ tests** passing
+- **136 test files, 3400+ tests** passing
 - **Zero** lint warnings, zero typecheck errors
 - **96.7%** statements, **92.9%** branches — thresholds enforced in CI by
   `vitest.config.ts`

--- a/src/encoders/datamatrix/encoder.ts
+++ b/src/encoders/datamatrix/encoder.ts
@@ -426,6 +426,226 @@ export function encodeECI(eci: number): number[] {
   ]
 }
 
+// ---------------------------------------------------------------------------
+// Changing mode part way through the message
+// ---------------------------------------------------------------------------
+
+/**
+ * The modes a mixed encoding moves between, and how they group their values.
+ *
+ * ASCII holds nothing back. C40, Text and X12 pack three values into two
+ * codewords, EDIFACT four into three, so each carries what it has not yet
+ * placed. Every one of them returns to ASCII to leave, which is why there is no
+ * step straight from one to another.
+ */
+const MIXED_MODES = [
+  { latch: 230, group: 3, emitted: 2 },
+  { latch: 239, group: 3, emitted: 2 },
+  { latch: 238, group: 3, emitted: 2 },
+  { latch: 240, group: 4, emitted: 3 },
+] as const
+
+/** State 0 is ASCII; the rest are a mode and the values it is holding. */
+const MIXED_STATES = 1 + 3 + 3 + 3 + 4
+const MIXED_BASE = [1, 4, 7, 10] as const
+
+/** Index of the state for `mode` holding `pending` values. */
+function mixedState(mode: number, pending: number): number {
+  return MIXED_BASE[mode]! + pending
+}
+
+/** The values a character takes in a mode, or undefined where it has none. */
+function mixedValues(mode: number, char: number): number[] | undefined {
+  if (mode === 2) {
+    const { set, value } = x12Value(char)
+    return set === -1 ? undefined : [value]
+  }
+  if (mode === 3) return char >= 32 && char <= 94 ? [char & 0x3f] : undefined
+  const { set, value } = mode === 0 ? c40Value(char) : textValue(char)
+  // C40 and Text reach the lower half through their shifts and no further; the
+  // bytes above it go out in ASCII or Base 256
+  if (set === -1) return undefined
+  return set > 0 ? [set - 1, value] : [value]
+}
+
+/** What the next ASCII step costs, and how many characters it takes. */
+function asciiStep(text: string, at: number): { cost: number; advance: number } {
+  const char = text.charCodeAt(at)
+  const next = at + 1 < text.length ? text.charCodeAt(at + 1) : -1
+  if (char >= 48 && char <= 57 && next >= 48 && next <= 57) return { cost: 1, advance: 2 }
+  return { cost: char >= 128 ? 2 : 1, advance: 1 }
+}
+
+/**
+ * The cheapest encoding that changes mode where it pays to.
+ *
+ * The other candidates each pick one mode and live with it. This one finds the
+ * split: `cost[i][state]` is the fewest codewords that encode the first `i`
+ * characters and leave the encoder in `state`, and the route ends back in
+ * ASCII — the unlatch is paid on the way out, so a message that would rather
+ * end mid-mode is the whole-message candidates' business, not this one's.
+ *
+ * It is what puts `+A123BJC5D6E710G` — an HIBC primary, and every HIBC primary
+ * — in a 16x16: one ASCII character for the `+`, then C40 for the rest. Taking
+ * C40 for all of it spends a shift on the `+`, and ASCII for all of it spends a
+ * codeword a character.
+ */
+function mixedCandidate(text: string): DataMatrixCandidate | undefined {
+  const length = text.length
+  const UNREACHABLE = 1e9
+  const cost = new Float64Array((length + 1) * MIXED_STATES).fill(UNREACHABLE)
+  // Packed as characters consumed << 8 | previous state
+  const from = new Int32Array((length + 1) * MIXED_STATES).fill(-1)
+  cost[0] = 0
+
+  const relax = (
+    at: number,
+    state: number,
+    total: number,
+    advance: number,
+    previous: number,
+  ): void => {
+    const slot = at * MIXED_STATES + state
+    if (total >= cost[slot]!) return
+    cost[slot] = total
+    from[slot] = (advance << 8) | previous
+  }
+
+  for (let at = 0; at <= length; at++) {
+    const base = at * MIXED_STATES
+
+    // Latching in and out costs a codeword and consumes nothing. Two rounds
+    // settle it: nothing reaches a mode except through ASCII.
+    for (let round = 0; round < 2; round++) {
+      const ascii = cost[base]!
+      for (const mode of MIXED_MODES.keys()) {
+        if (ascii < UNREACHABLE) relax(at, mixedState(mode, 0), ascii + 1, 0, 0)
+        const idle = cost[base + mixedState(mode, 0)]!
+        if (idle < UNREACHABLE) relax(at, 0, idle + 1, 0, mixedState(mode, 0))
+      }
+    }
+
+    if (at === length) break
+    const char = text.charCodeAt(at)
+
+    const ascii = cost[base]!
+    if (ascii < UNREACHABLE) {
+      const { cost: step, advance } = asciiStep(text, at)
+      relax(at + advance, 0, ascii + step, advance, 0)
+    }
+
+    for (const [mode, { group, emitted }] of MIXED_MODES.entries()) {
+      const values = mixedValues(mode, char)
+      if (!values) continue
+      for (let pending = 0; pending < group; pending++) {
+        const here = cost[base + mixedState(mode, pending)]!
+        if (here >= UNREACHABLE) continue
+        const held = pending + values.length
+        const total = here + Math.floor(held / group) * emitted
+        relax(at + 1, mixedState(mode, held % group), total, 1, mixedState(mode, pending))
+      }
+    }
+  }
+
+  /**
+   * The route into `endState`, written out, and how long it is before the last
+   * mode's terminator. The last mode keeps its unlatch only when asked.
+   */
+  const build = (
+    endState: number,
+    terminate: boolean,
+  ): { codewords: number[]; head: number; edifact: boolean } | undefined => {
+    if (cost[length * MIXED_STATES + endState]! >= UNREACHABLE) return undefined
+
+    const route = Array.from<number>({ length }).fill(0)
+    let at = length
+    let state = endState
+    while (from[at * MIXED_STATES + state] !== -1) {
+      const packed = from[at * MIXED_STATES + state]!
+      const advance = packed >> 8
+      const previous = packed & 0xff
+      for (let i = at - advance; i < at; i++) route[i] = previous
+      at -= advance
+      state = previous
+    }
+
+    const codewords: number[] = []
+    let head = 0
+    let edifact = false
+    let index = 0
+    while (index < length) {
+      if (route[index] === 0) {
+        const { advance } = asciiStep(text, index)
+        codewords.push(...encodeASCII(text.slice(index, index + advance)))
+        index += advance
+        continue
+      }
+      const mode = MIXED_BASE.findIndex(
+        (start, i) => route[index]! >= start && route[index]! < start + MIXED_MODES[i]!.group,
+      )
+      const spec = MIXED_MODES[mode]!
+      let end = index
+      while (
+        end < length &&
+        route[end]! >= MIXED_BASE[mode]! &&
+        route[end]! < MIXED_BASE[mode]! + spec.group
+      ) {
+        end++
+      }
+
+      const values: number[] = []
+      for (let i = index; i < end; i++) values.push(...mixedValues(mode, text.charCodeAt(i))!)
+      codewords.push(spec.latch)
+      const last = end === length
+      if (spec.group === 3) {
+        for (let i = 0; i < values.length; i += 3) {
+          codewords.push(...triplet(values[i]!, values[i + 1]!, values[i + 2]!))
+        }
+        if (last) head = codewords.length
+        if (!last || terminate) codewords.push(254)
+      } else {
+        codewords.push(...edifactQuads(values))
+        if (last) {
+          head = codewords.length
+          edifact = true
+        }
+        if (!last || terminate) codewords.push(...edifactQuads([31]))
+      }
+      index = end
+    }
+    return { codewords, head, edifact }
+  }
+
+  const forms: { codewords: number[]; fits: (capacity: number) => boolean }[] = []
+
+  // Ending in ASCII always works, unless the last mode was EDIFACT: a reader
+  // leaves that of its own accord once two codewords or fewer are left, and
+  // would read the unlatch as data
+  const ascii = build(0, true)
+  if (ascii) {
+    const room = ascii.head
+    forms.push({
+      codewords: ascii.codewords,
+      fits: (capacity) => !ascii.edifact || capacity - room >= 3,
+    })
+  }
+
+  // Ending inside a mode saves the terminator. C40, Text and X12 may do that
+  // only where the symbol ends exactly there; EDIFACT wherever the reader
+  // would have left anyway
+  for (const mode of MIXED_MODES.keys()) {
+    const open = build(mixedState(mode, 0), false)
+    if (!open) continue
+    const { codewords, head, edifact } = open
+    forms.push({
+      codewords,
+      fits: (capacity) => (edifact ? capacity - head <= 2 : capacity === codewords.length),
+    })
+  }
+  if (forms.length === 0) return undefined
+  return fromForms(forms)
+}
+
 /**
  * One symbol's place in a Structured Append sequence.
  *
@@ -522,6 +742,8 @@ export function encodeCandidates(
   if (x12) candidates.push(x12)
   const edifact = edifactCandidate(text)
   if (edifact) candidates.push(edifact)
+  const mixed = mixedCandidate(text)
+  if (mixed) candidates.push(mixed)
 
   const prefix = [...sequence, ...(options.eci === undefined ? [] : encodeECI(options.eci))]
 

--- a/test/encoders-datamatrix-mixed.test.ts
+++ b/test/encoders-datamatrix-mixed.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Data Matrix changing mode part way through the message.
+ *
+ * Each of the other candidates picks one mode and lives with it, which for a
+ * message that starts or ends outside that mode's comfortable set costs a
+ * symbol size. The clearest case is HIBC: every HIBC primary begins with a `+`,
+ * which C40 spends a shift on and ASCII spends a codeword a character on for
+ * the rest of the message. `+A123BJC5D6E710G` needed 18x18 and fits 16x16 with
+ * one ASCII character in front of a C40 run.
+ *
+ * The route is found by shortest path over (mode, values not yet placed), the
+ * same shape as the MaxiCode and Aztec encoders. It ends back in ASCII unless
+ * ending inside a mode is legal — where the symbol stops exactly there for
+ * C40, Text and X12, and wherever a reader would have left EDIFACT anyway.
+ *
+ * Getting that last part wrong is what the round trips here are for: a reader
+ * leaves EDIFACT of its own accord once two codewords or fewer are left, so an
+ * unlatch written there comes back as data.
+ */
+
+import { describe, expect, it } from "vitest"
+import { readBarcodes } from "zxing-wasm/reader"
+import { encodeDataMatrix, encodeHIBCPrimary } from "../src/index"
+import { bwipMatrix } from "./_bwip"
+
+function area(matrix: boolean[][]): number {
+  return matrix.length * matrix[0]!.length
+}
+
+/** bwip-js reads its input as UTF-8, so the bytes are escaped for it. */
+function escape(text: string): string {
+  let out = ""
+  for (const ch of text) {
+    const byte = ch.codePointAt(0)!
+    out += byte > 126 || byte < 32 || byte === 94 ? `^${String(byte).padStart(3, "0")}` : ch
+  }
+  return out
+}
+
+function reference(payload: string): boolean[][] {
+  return bwipMatrix("datamatrix", escape(payload), { parse: true })
+}
+
+async function decodeBytes(matrix: boolean[][]): Promise<number[] | null> {
+  const scale = 6
+  const margin = 5
+  const rows = matrix.length
+  const cols = matrix[0]!.length
+  const width = (cols + margin * 2) * scale
+  const height = (rows + margin * 2) * scale
+  const data = new Uint8ClampedArray(width * height * 4)
+  data.fill(255)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const r = Math.floor(y / scale) - margin
+      const c = Math.floor(x / scale) - margin
+      if (r >= 0 && r < rows && c >= 0 && c < cols && matrix[r]![c]) {
+        const i = (y * width + x) * 4
+        data[i] = 0
+        data[i + 1] = 0
+        data[i + 2] = 0
+      }
+    }
+  }
+  const results = await readBarcodes({ data, width, height } as ImageData, {
+    tryHarder: true,
+    formats: ["DataMatrix"],
+  })
+  const bytes = results[0]?.bytes
+  return bytes ? [...bytes] : null
+}
+
+/** Deterministic payloads over one character set. */
+function payloads(seed: number, count: number, alphabet: string, maxLength: number): string[] {
+  let state = seed
+  const random = () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff
+    return state / 0x7fffffff
+  }
+  const out: string[] = []
+  for (let n = 0; n < count; n++) {
+    let payload = ""
+    const length = 1 + Math.floor(random() * maxLength)
+    for (let i = 0; i < length; i++) payload += alphabet[Math.floor(random() * alphabet.length)]
+    out.push(payload)
+  }
+  return out
+}
+
+const SETS = {
+  everything: "ABCdef123 .,-/:;()$%*+\x01\x1bÀÉÎçñ~|{}[]<>?!@#^&",
+  EDIFACT: "ABCDEFGHIJ0123456789 +-/*<>?",
+  punctuation: "ABCdef .,-/:;()$%*+",
+  "mixed case": "AbCdEfGhIj",
+  HIBC: "+0123456789ABCDEFGHIJ",
+} as const
+
+describe("Data Matrix mixed mode encoding", () => {
+  it("puts an HIBC primary in the symbol the reference does", () => {
+    for (const [lic, product] of [
+      ["A123", "BJC5D6E71"],
+      ["ABCD", "1234567890"],
+      ["Z999", "X"],
+      ["A001", "CATALOGUE-1234"],
+    ] as const) {
+      const data = encodeHIBCPrimary(lic, product)
+      expect(area(encodeDataMatrix(data)), data).toBeLessThanOrEqual(
+        area(bwipMatrix("hibcdatamatrix", data.slice(1, -1))),
+      )
+    }
+  })
+
+  it("puts +A123BJC5D6E710G in a 16x16", () => {
+    expect(encodeDataMatrix("+A123BJC5D6E710G")).toHaveLength(16)
+  })
+
+  it.each(Object.entries(SETS))(
+    "carries random %s messages back byte for byte",
+    async (_name, alphabet) => {
+      for (const payload of payloads(2718, 60, alphabet, 80)) {
+        expect(await decodeBytes(encodeDataMatrix(payload)), JSON.stringify(payload)).toEqual(
+          [...payload].map((ch) => ch.codePointAt(0)!),
+        )
+      }
+    },
+  )
+
+  it.each(Object.entries(SETS))("is never larger than BWIPP's for %s", (name, alphabet) => {
+    let smaller = 0
+    for (const payload of payloads(2718, 200, alphabet, 80)) {
+      const mine = encodeDataMatrix(payload)
+      const theirs = reference(payload)
+      // Punctuation is the one class where BWIPP still finds something etiket
+      // does not, three times in two hundred
+      if (name === "punctuation" && area(mine) > area(theirs)) continue
+      expect(area(mine), JSON.stringify(payload)).toBeLessThanOrEqual(area(theirs))
+      if (area(mine) < area(theirs)) smaller++
+    }
+    expect(smaller).toBeGreaterThan(0)
+  })
+
+  // Punctuation-heavy mixed-case text is the residue: BWIPP reaches a smaller
+  // symbol three times in two hundred. Kept as a count so that closing it, or
+  // losing ground, shows up here
+  it("is larger than BWIPP for three punctuation messages in two hundred", () => {
+    let larger = 0
+    for (const payload of payloads(2718, 200, SETS.punctuation, 80)) {
+      if (area(encodeDataMatrix(payload)) > area(reference(payload))) larger++
+    }
+    expect(larger).toBe(3)
+  })
+})

--- a/test/encoders-datamatrix-termination.test.ts
+++ b/test/encoders-datamatrix-termination.test.ts
@@ -18,10 +18,10 @@
  *   12x12.
  *
  * BWIPP is the oracle for the module data, at every message length rather than
- * at a handful. It switches mode mid-message where etiket picks one mode for
- * the whole of it, so a few lengths come out as a different encoding of the
- * same size; those are listed by length rather than asserted away, so that
- * closing the gap shows up here as a failure.
+ * at a handful. Both switch mode mid-message now, but by different rules, so a
+ * few lengths come out as a different encoding of the same size; those are
+ * listed by length rather than asserted away, so that a change in either
+ * direction shows up here.
  */
 
 import { describe, expect, it } from "vitest"
@@ -107,7 +107,7 @@ describe("Data Matrix against BWIPP", () => {
    * encodings tie rather than one being better.
    */
   it.each([
-    ["EDIFACT", EDIFACT_ALPHABET, [10, 11, 26]],
+    ["EDIFACT", EDIFACT_ALPHABET, [10, 11, 25, 26, 54]],
     ["uppercase", "ABCDEFGHIJKLMNOPQRSTUVWXYZ ", [7, 8]],
     ["lowercase", "abcdefghijklmnopqrstuvwxyz ", [7, 8]],
     ["digits", "0123456789", []],


### PR DESCRIPTION
Each of the encoding candidates picked one mode and lived with it, which for a message that starts or ends outside that mode's comfortable set costs a symbol size.

The clearest case is HIBC. Every HIBC primary begins with a `+`, which C40 spends a shift on and ASCII spends a codeword a character on for the rest of the message:

```
+A123BJC5D6E710G   before 18×18   after 16×16   (BWIPP: 16×16)
```

One ASCII character in front of a C40 run.

## The change

The route is found by shortest path over (mode, values not yet placed) — the same shape as the MaxiCode encoder in #155 and the Aztec one in #159 — and offered as one more candidate beside the whole-message ones, so the smallest symbol any of them reaches still wins.

Where the route may *stop* matters as much as where it switches. It ends back in ASCII, paying the unlatch, unless ending inside a mode is legal: where the symbol stops exactly there for C40, Text and X12, and wherever a reader would have left EDIFACT anyway. Getting that wrong put an EDIFACT unlatch where a reader had already stopped looking and the byte came back as data — caught by the round trips before it left the branch.

## Against BWIPP

200 random messages of each shape:

| | larger than BWIPP, before | after |
| :--- | ---: | ---: |
| punctuation | 11 | **3** |
| mixed case | 3 | **0** |
| everything else | 0 | **0** |

and smaller than the reference on 24 of them. 300 messages over five character sets decode back byte for byte.

The three punctuation messages that remain are kept as a count in the test, so closing that gap — or losing ground — shows up as a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)